### PR TITLE
fix: binary response routing for repeater status and telemetry

### DIFF
--- a/PocketMesh/ContentView.swift
+++ b/PocketMesh/ContentView.swift
@@ -67,6 +67,11 @@ struct MainTabView: View {
                 SettingsView()
             }
         }
+        .onChange(of: appState.connectionState) { oldState, newState in
+            if newState == .ready && oldState != .ready {
+                appState.triggerInitialSync()
+            }
+        }
 
             if appState.shouldShowSyncingPill {
                 SyncingPillView()

--- a/PocketMesh/Services/MessageEventBroadcaster.swift
+++ b/PocketMesh/Services/MessageEventBroadcaster.swift
@@ -34,6 +34,13 @@ public final class MessageEventBroadcaster {
     /// Count of new messages (triggers view updates)
     var newMessageCount: Int = 0
 
+    /// Triggers conversation list refresh (increment to force reload)
+    /// Use this for state changes like mark-as-read, not for new messages
+    var conversationRefreshTrigger: Int = 0
+
+    /// Trigger for contact list refresh (increment to force refresh)
+    var contactsRefreshTrigger: Int = 0
+
     /// Reference to notification service for posting notifications
     var notificationService: NotificationService?
 
@@ -150,6 +157,11 @@ public final class MessageEventBroadcaster {
     /// Handle error notification
     func handleError(_ message: String) {
         self.latestEvent = .error(message)
+    }
+
+    /// Handles contact update notification from AdvertisementService
+    func handleContactsUpdated() {
+        contactsRefreshTrigger += 1
     }
 
     // MARK: - Status Response Handling

--- a/PocketMesh/Views/Chats/ChatViewModel.swift
+++ b/PocketMesh/Views/Chats/ChatViewModel.swift
@@ -63,23 +63,29 @@ final class ChatViewModel {
 
     // MARK: - Dependencies
 
-    /// Weak reference to AppState for service access
-    private weak var appState: AppState?
-
-    /// Services accessed lazily to ensure they're always current
-    private var dataStore: DataStore? { appState?.services?.dataStore }
-    private var messageService: MessageService? { appState?.services?.messageService }
-    private var notificationService: NotificationService? { appState?.services?.notificationService }
-    private var channelService: ChannelService? { appState?.services?.channelService }
-    private var roomServerService: RoomServerService? { appState?.services?.roomServerService }
+    private var dataStore: DataStore?
+    private var messageService: MessageService?
+    private var notificationService: NotificationService?
+    private var channelService: ChannelService?
+    private var roomServerService: RoomServerService?
 
     // MARK: - Initialization
 
     init() {}
 
-    /// Configure with AppState reference
+    /// Configure with services from AppState
     func configure(appState: AppState) {
-        self.appState = appState
+        self.dataStore = appState.services?.dataStore
+        self.messageService = appState.services?.messageService
+        self.notificationService = appState.services?.notificationService
+        self.channelService = appState.services?.channelService
+        self.roomServerService = appState.services?.roomServerService
+    }
+
+    /// Configure with services (for testing)
+    func configure(dataStore: DataStore, messageService: MessageService) {
+        self.dataStore = dataStore
+        self.messageService = messageService
     }
 
     // MARK: - Conversation List

--- a/PocketMesh/Views/Contacts/ContactsListView.swift
+++ b/PocketMesh/Views/Contacts/ContactsListView.swift
@@ -15,8 +15,6 @@ struct ContactsListView: View {
     }
 
     var body: some View {
-        let _ = appState.contactsRefreshTrigger  // Force @Observable tracking
-
         NavigationStack {
             Group {
                 if viewModel.isLoading && viewModel.contacts.isEmpty {
@@ -76,7 +74,7 @@ struct ContactsListView: View {
                 viewModel.configure(appState: appState)
                 await loadContacts()
             }
-            .onChange(of: appState.contactsRefreshTrigger) { _, _ in
+            .onChange(of: appState.messageEventBroadcaster.contactsRefreshTrigger) { _, _ in
                 Task {
                     await loadContacts()
                 }

--- a/PocketMesh/Views/Contacts/ContactsViewModel.swift
+++ b/PocketMesh/Views/Contacts/ContactsViewModel.swift
@@ -25,20 +25,23 @@ final class ContactsViewModel {
 
     // MARK: - Dependencies
 
-    /// Weak reference to AppState for service access
-    private weak var appState: AppState?
-
-    /// Services accessed lazily to ensure they're always current
-    private var dataStore: DataStore? { appState?.services?.dataStore }
-    private var contactService: ContactService? { appState?.services?.contactService }
+    private var dataStore: DataStore?
+    private var contactService: ContactService?
 
     // MARK: - Initialization
 
     init() {}
 
-    /// Configure with AppState reference
+    /// Configure with services from AppState
     func configure(appState: AppState) {
-        self.appState = appState
+        self.dataStore = appState.services?.dataStore
+        self.contactService = appState.services?.contactService
+    }
+
+    /// Configure with services (for testing)
+    func configure(dataStore: DataStore, contactService: ContactService) {
+        self.dataStore = dataStore
+        self.contactService = contactService
     }
 
     // MARK: - Load Contacts

--- a/PocketMesh/Views/Contacts/DiscoveryView.swift
+++ b/PocketMesh/Views/Contacts/DiscoveryView.swift
@@ -10,8 +10,6 @@ struct DiscoveryView: View {
     @State private var errorMessage: String?
 
     var body: some View {
-        let _ = appState.contactsRefreshTrigger  // Force @Observable tracking
-
         Group {
             if isLoading && discoveredContacts.isEmpty {
                 ProgressView()
@@ -26,7 +24,7 @@ struct DiscoveryView: View {
         .task {
             await loadDiscoveredContacts()
         }
-        .onChange(of: appState.contactsRefreshTrigger) { _, _ in
+        .onChange(of: appState.messageEventBroadcaster.contactsRefreshTrigger) { _, _ in
             Task {
                 await loadDiscoveredContacts()
             }

--- a/PocketMesh/Views/Map/MapViewModel.swift
+++ b/PocketMesh/Views/Map/MapViewModel.swift
@@ -26,20 +26,23 @@ final class MapViewModel {
 
     // MARK: - Dependencies
 
-    /// Weak reference to AppState for service access
-    private weak var appState: AppState?
-
-    /// Services accessed lazily to ensure they're always current
-    private var dataStore: PersistenceStore? { appState?.services?.dataStore }
-    private var deviceID: UUID? { appState?.connectedDevice?.id }
+    private var dataStore: PersistenceStore?
+    private var deviceID: UUID?
 
     // MARK: - Initialization
 
     init() {}
 
-    /// Configure with AppState reference
+    /// Configure with services from AppState
     func configure(appState: AppState) {
-        self.appState = appState
+        self.dataStore = appState.services?.dataStore
+        self.deviceID = appState.connectedDevice?.id
+    }
+
+    /// Configure with services (for testing)
+    func configure(dataStore: PersistenceStore, deviceID: UUID?) {
+        self.dataStore = dataStore
+        self.deviceID = deviceID
     }
 
     // MARK: - Load Contacts

--- a/PocketMesh/Views/RemoteNodes/RepeaterStatusViewModel.swift
+++ b/PocketMesh/Views/RemoteNodes/RepeaterStatusViewModel.swift
@@ -112,15 +112,13 @@ final class RepeaterStatusViewModel {
         }
 
         do {
-            _ = try await repeaterAdminService.requestStatus(sessionID: session.id)
-            // Status response arrives via push notification
-            // The handler will set isLoadingStatus = false when response arrives
+            let response = try await repeaterAdminService.requestStatus(sessionID: session.id)
+            handleStatusResponse(response)
         } catch {
             errorMessage = error.localizedDescription
-            isLoadingStatus = false  // Only clear on error
+            isLoadingStatus = false
             statusTimeoutTask?.cancel()
         }
-        // Note: Don't clear isLoadingStatus here - it's cleared by handleStatusResponse
     }
 
     /// Request neighbors from the repeater
@@ -200,8 +198,8 @@ final class RepeaterStatusViewModel {
         }
 
         do {
-            try await repeaterAdminService.requestTelemetry(sessionID: session.id)
-            // Response arrives via push notification - handler will set isLoadingTelemetry = false
+            let response = try await repeaterAdminService.requestTelemetry(sessionID: session.id)
+            handleTelemetryResponse(response)
         } catch {
             errorMessage = error.localizedDescription
             isLoadingTelemetry = false

--- a/PocketMeshServices/Sources/PocketMeshServices/ConnectionManager.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/ConnectionManager.swift
@@ -50,17 +50,7 @@ public final class ConnectionManager {
     // MARK: - Observable State
 
     /// Current connection state
-    public private(set) var connectionState: ConnectionState = .disconnected {
-        didSet {
-            if connectionState == .ready && oldValue != .ready {
-                onBecameReady?()
-            }
-        }
-    }
-
-    /// Callback fired when connection transitions to .ready state.
-    /// Callers should use `[weak self]` to avoid retain cycles.
-    public var onBecameReady: (@Sendable () -> Void)?
+    public private(set) var connectionState: ConnectionState = .disconnected
 
     /// Connected device info (nil when disconnected)
     public private(set) var connectedDevice: DeviceDTO?


### PR DESCRIPTION
## Summary

- Add `parseFromBinaryResponse` methods for `StatusResponse` and `TelemetryResponse` to handle Format 2 binary payloads (no pubkey header)
- Route `.status` and `.telemetry` request types in `routeGenericBinaryResponse`
- Fix binary response parser to skip request type byte (extract tag from bytes 1-4, not 0-3)
- Use `expectedAck` tag from `messageSent` events for response correlation instead of pubkey prefix
- Serialize binary requests with `BinaryRequestSerializer` to prevent `messageSent` race conditions when multiple requests are in flight
- Simplify view model to handle responses directly instead of via push notification handlers

## Test plan

- [x] Unit tests added for `parseFromBinaryResponse` methods
- [ ] Verify repeater status requests return correct data
- [ ] Verify repeater telemetry requests return correct data
- [ ] Test concurrent status/telemetry requests don't interfere with each other