### PR TITLE
feat(contacts): Add contact QR code sharing

### DIFF
--- a/PocketMesh/AppState.swift
+++ b/PocketMesh/AppState.swift
@@ -26,15 +26,11 @@ public final class AppState {
     public var connectedDevice: DeviceDTO? { connectionManager.connectedDevice }
     public var services: ServiceContainer? { connectionManager.services }
 
-    /// The sync coordinator for data synchronization
+    /// The sync coordinator for data synchronization (stored for direct observation)
     public private(set) var syncCoordinator: SyncCoordinator?
 
     /// Incremented when services change (device switch, reconnect). Views observe this to reload.
     public private(set) var servicesVersion: Int = 0
-
-    /// Incremented when conversations data changes. Views observe this to reload.
-    /// Lives on AppState (not SyncCoordinator) because SwiftUI can only observe @Observable classes.
-    public private(set) var conversationsVersion: Int = 0
 
     // MARK: - UI State for Connection
 
@@ -151,12 +147,6 @@ public final class AppState {
                 self?.syncActivityCount -= 1
             }
         )
-
-        // Wire conversations changed callback for UI observation
-        // This lives on AppState because SwiftUI can only observe @Observable classes, not actors
-        await services.syncCoordinator.setConversationsChangedCallback { @MainActor [weak self] in
-            self?.conversationsVersion += 1
-        }
 
         // Increment version to trigger UI refresh in views observing this
         servicesVersion += 1

--- a/PocketMesh/Views/Chats/ChatViewModel.swift
+++ b/PocketMesh/Views/Chats/ChatViewModel.swift
@@ -68,7 +68,6 @@ final class ChatViewModel {
     private var notificationService: NotificationService?
     private var channelService: ChannelService?
     private var roomServerService: RoomServerService?
-    private weak var appState: AppState?
 
     // MARK: - Initialization
 
@@ -81,7 +80,6 @@ final class ChatViewModel {
         self.notificationService = appState.services?.notificationService
         self.channelService = appState.services?.channelService
         self.roomServerService = appState.services?.roomServerService
-        self.appState = appState
     }
 
     /// Configure with services (for testing)
@@ -212,7 +210,6 @@ final class ChatViewModel {
 
             // Update conversations list to reflect new message
             await loadConversations(deviceID: contact.deviceID)
-            await appState?.syncCoordinator?.notifyConversationsChanged()
         } catch {
             errorMessage = error.localizedDescription
             // Note: composingText already cleared - failed message can be retried from bubble
@@ -282,7 +279,6 @@ final class ChatViewModel {
 
             // Reload channels to update conversation list
             await loadChannels(deviceID: channel.deviceID)
-            await appState?.syncCoordinator?.notifyConversationsChanged()
         } catch {
             errorMessage = error.localizedDescription
             // Restore the text so user can retry

--- a/PocketMesh/Views/Chats/ChatsListView.swift
+++ b/PocketMesh/Views/Chats/ChatsListView.swift
@@ -82,6 +82,8 @@ struct ChatsListView: View {
             }
             .task {
                 viewModel.configure(appState: appState)
+                await loadConversations()
+                // Handle pending navigation from other tabs (e.g., Map)
                 handlePendingNavigation()
             }
             .navigationDestination(for: ContactDTO.self) { contact in
@@ -99,9 +101,16 @@ struct ChatsListView: View {
             .onChange(of: appState.pendingChatContact) { _, _ in
                 handlePendingNavigation()
             }
-            // Runs on initial appearance AND when conversationsVersion changes
-            .task(id: appState.conversationsVersion) {
-                await loadConversations()
+            .onChange(of: appState.servicesVersion) { _, _ in
+                // Services changed (device switch, reconnect) - reload conversations
+                Task {
+                    await loadConversations()
+                }
+            }
+            .onChange(of: appState.syncCoordinator?.conversationsVersion) { _, _ in
+                Task {
+                    await loadConversations()
+                }
             }
             .onChange(of: appState.pendingRoomSession) { _, _ in
                 handlePendingRoomNavigation()

--- a/PocketMesh/Views/Contacts/AddContactSheet.swift
+++ b/PocketMesh/Views/Contacts/AddContactSheet.swift
@@ -1,0 +1,261 @@
+import SwiftUI
+import PocketMeshServices
+import os
+
+/// Sheet for manually adding a contact or scanning a QR code
+struct AddContactSheet: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var selectedType: ContactType = .chat
+    @State private var contactName = ""
+    @State private var publicKeyHex = ""
+    @State private var showScanner = false
+    @State private var isSubmitting = false
+    @State private var errorMessage: String?
+
+    private let logger = Logger(subsystem: "com.pocketmesh", category: "AddContactSheet")
+
+    // MARK: - Validation
+
+    private var normalizedPublicKeyHex: String {
+        publicKeyHex.filter { $0.isHexDigit }.lowercased()
+    }
+
+    private var isValidPublicKey: Bool {
+        normalizedPublicKeyHex.count == Constants.publicKeyHexLength
+    }
+
+    private var canAdd: Bool {
+        !contactName.isEmpty && isValidPublicKey && !isSubmitting
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                ScannerSection(showScanner: $showScanner)
+
+                TypePickerSection(selectedType: $selectedType)
+
+                NameInputSection(contactName: $contactName)
+
+                PublicKeyInputSection(
+                    publicKeyHex: $publicKeyHex,
+                    normalizedCount: normalizedPublicKeyHex.count,
+                    isValid: isValidPublicKey
+                )
+
+                if let errorMessage {
+                    ErrorSection(message: errorMessage)
+                }
+            }
+            .navigationTitle("Add Contact")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Add") {
+                        Task {
+                            await handleAdd()
+                        }
+                    }
+                    .disabled(!canAdd)
+                }
+            }
+            .navigationDestination(isPresented: $showScanner) {
+                ScanContactQRView { _, _ in
+                    // Scanner handles import automatically
+                    // Dismiss both sheets on success
+                    showScanner = false
+                    dismiss()
+                }
+            }
+            .disabled(isSubmitting)
+        }
+    }
+
+    // MARK: - Actions
+
+    @MainActor
+    private func handleAdd() async {
+        guard let services = appState.services,
+              let deviceID = appState.connectedDevice?.id else {
+            logger.error("Services or device not available")
+            errorMessage = "Not connected to device"
+            return
+        }
+
+        guard let publicKeyData = Data(hexString: normalizedPublicKeyHex) else {
+            logger.error("Failed to convert hex string to data: \(normalizedPublicKeyHex)")
+            errorMessage = "Invalid public key format"
+            return
+        }
+
+        guard publicKeyData.count == ProtocolLimits.publicKeySize else {
+            logger.error("Public key is not \(ProtocolLimits.publicKeySize) bytes: \(publicKeyData.count)")
+            errorMessage = "Public key must be \(ProtocolLimits.publicKeySize) bytes (\(Constants.publicKeyHexLength) hex characters)"
+            return
+        }
+
+        isSubmitting = true
+        errorMessage = nil
+
+        do {
+            let currentTimestamp = UInt32(Date().timeIntervalSince1970)
+
+            let contactFrame = ContactFrame(
+                publicKey: publicKeyData,
+                type: selectedType,
+                flags: 0,
+                outPathLength: -1,  // Flood routing
+                outPath: Data(),
+                name: contactName,
+                lastAdvertTimestamp: 0,  // Never advertised
+                latitude: 0,
+                longitude: 0,
+                lastModified: currentTimestamp
+            )
+
+            logger.info("Adding contact: \(contactName) (\(publicKeyData.hex))")
+            try await services.contactService.addOrUpdateContact(deviceID: deviceID, contact: contactFrame)
+            logger.info("Contact added successfully")
+
+            dismiss()
+        } catch ContactServiceError.contactTableFull {
+            logger.error("Contact table is full")
+            errorMessage = "Contact table is full (max \(ProtocolLimits.maxContacts) contacts)"
+            isSubmitting = false
+        } catch {
+            logger.error("Failed to add contact: \(error.localizedDescription)")
+            errorMessage = "Failed to add contact: \(error.localizedDescription)"
+            isSubmitting = false
+        }
+    }
+}
+
+// MARK: - Constants
+
+private enum Constants {
+    static let publicKeyHexLength = ProtocolLimits.publicKeySize * 2
+}
+
+// MARK: - Scanner Section
+
+private struct ScannerSection: View {
+    @Binding var showScanner: Bool
+
+    var body: some View {
+        Section {
+            Button {
+                showScanner = true
+            } label: {
+                Label("Scan QR Code", systemImage: "camera")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+}
+
+// MARK: - Type Picker Section
+
+private struct TypePickerSection: View {
+    @Binding var selectedType: ContactType
+
+    var body: some View {
+        Section {
+            Picker("Type", selection: $selectedType) {
+                Text("Chat").tag(ContactType.chat)
+                Text("Repeater").tag(ContactType.repeater)
+                Text("Room").tag(ContactType.room)
+            }
+            .pickerStyle(.segmented)
+        } header: {
+            Text("Type")
+        }
+    }
+}
+
+// MARK: - Name Input Section
+
+private struct NameInputSection: View {
+    @Binding var contactName: String
+
+    var body: some View {
+        Section {
+            TextField("Contact Name", text: $contactName)
+                .textInputAutocapitalization(.words)
+                .autocorrectionDisabled()
+        } header: {
+            Text("Name")
+        }
+    }
+}
+
+// MARK: - Public Key Input Section
+
+private struct PublicKeyInputSection: View {
+    @Binding var publicKeyHex: String
+    let normalizedCount: Int
+    let isValid: Bool
+
+    var body: some View {
+        Section {
+            TextField("\(Constants.publicKeyHexLength) hex characters", text: $publicKeyHex)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.asciiCapable)
+                .font(.system(.body, design: .monospaced))
+                .onChange(of: publicKeyHex) { _, newValue in
+                    // Filter to hex chars only and lowercase
+                    let filtered = newValue.filter { $0.isHexDigit }.lowercased()
+                    if filtered != newValue {
+                        publicKeyHex = filtered
+                    }
+                }
+
+            if !publicKeyHex.isEmpty {
+                HStack {
+                    if isValid {
+                        Label("Valid", systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    } else {
+                        Label("\(normalizedCount)/\(Constants.publicKeyHexLength) characters", systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                    }
+                }
+                .font(.caption)
+            }
+        } header: {
+            Text("Public Key")
+        } footer: {
+            Text("Enter the \(Constants.publicKeyHexLength)-character hexadecimal public key of the contact")
+        }
+    }
+}
+
+// MARK: - Error Section
+
+private struct ErrorSection: View {
+    let message: String
+
+    var body: some View {
+        Section {
+            Text(message)
+                .foregroundStyle(.red)
+                .font(.caption)
+        }
+    }
+}
+
+#Preview {
+    AddContactSheet()
+        .environment(AppState())
+}

--- a/PocketMesh/Views/Contacts/ContactDetailView.swift
+++ b/PocketMesh/Views/Contacts/ContactDetailView.swift
@@ -42,6 +42,8 @@ struct ContactDetailView: View {
     @State private var showRepeaterAdminAuth = false
     @State private var adminSession: RemoteNodeSessionDTO?
     @State private var navigateToSettings = false
+    // QR sharing state
+    @State private var showQRShareSheet = false
 
     init(contact: ContactDTO, showFromDirectChat: Bool = false) {
         self.contact = contact
@@ -182,6 +184,13 @@ struct ContactDetailView: View {
                     // Navigation triggers in onDismiss above
                 }
             }
+        }
+        .sheet(isPresented: $showQRShareSheet) {
+            ContactQRShareSheet(
+                contactName: currentContact.name,
+                publicKey: currentContact.publicKey,
+                contactType: currentContact.type
+            )
         }
         .navigationDestination(isPresented: $navigateToSettings) {
             if let session = adminSession {
@@ -347,13 +356,20 @@ struct ContactDetailView: View {
                 )
             }
 
-            // Share contact (for all contact types)
+            // Share Contact via QR
+            Button {
+                showQRShareSheet = true
+            } label: {
+                Label("Share Contact", systemImage: "square.and.arrow.up")
+            }
+
+            // Share Contact via Advert
             Button {
                 Task {
                     await shareContact()
                 }
             } label: {
-                Label("Share Contact", systemImage: "square.and.arrow.up")
+                Label("Share Contact via Advert", systemImage: "antenna.radiowaves.left.and.right")
             }
         }
     }

--- a/PocketMesh/Views/Contacts/ContactsListView.swift
+++ b/PocketMesh/Views/Contacts/ContactsListView.swift
@@ -9,6 +9,8 @@ struct ContactsListView: View {
     @State private var showFavoritesOnly = false
     @State private var showDiscovery = false
     @State private var syncSuccessTrigger = false
+    @State private var showShareMyContact = false
+    @State private var showAddContact = false
 
     private var filteredContacts: [ContactDTO] {
         viewModel.filteredContacts(searchText: searchText, showFavoritesOnly: showFavoritesOnly)
@@ -41,6 +43,20 @@ struct ContactsListView: View {
                                 showFavoritesOnly ? "Show All" : "Show Favorites",
                                 systemImage: showFavoritesOnly ? "star.slash" : "star.fill"
                             )
+                        }
+
+                        Divider()
+
+                        Button {
+                            showShareMyContact = true
+                        } label: {
+                            Label("Share My Contact", systemImage: "square.and.arrow.up")
+                        }
+
+                        Button {
+                            showAddContact = true
+                        } label: {
+                            Label("Add Contact", systemImage: "plus")
                         }
 
                         Divider()
@@ -93,6 +109,18 @@ struct ContactsListView: View {
             }
             .navigationDestination(isPresented: $showDiscovery) {
                 DiscoveryView()
+            }
+            .sheet(isPresented: $showShareMyContact) {
+                if let device = appState.connectedDevice {
+                    ContactQRShareSheet(
+                        contactName: device.nodeName,
+                        publicKey: device.publicKey,
+                        contactType: .chat
+                    )
+                }
+            }
+            .sheet(isPresented: $showAddContact) {
+                AddContactSheet()
             }
         }
     }

--- a/PocketMesh/Views/Contacts/ScanContactQRView.swift
+++ b/PocketMesh/Views/Contacts/ScanContactQRView.swift
@@ -1,0 +1,243 @@
+import SwiftUI
+import VisionKit
+import PocketMeshServices
+import os
+
+/// View for scanning a contact QR code to import
+struct ScanContactQRView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.openURL) private var openURL
+    @Environment(\.dismiss) private var dismiss
+
+    let onScan: (String, Data) -> Void
+
+    @State private var isImporting = false
+    @State private var errorMessage: String?
+    @State private var cameraPermissionDenied = false
+    @State private var scanSuccessTrigger = false
+
+    private let logger = Logger(subsystem: "com.pocketmesh", category: "ScanContactQRView")
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let scanFrameSize: CGFloat = 250
+        static let overlayOpacity: CGFloat = 0.6
+        static let errorOpacity: CGFloat = 0.8
+        static let bottomPadding: CGFloat = 50
+    }
+
+    var body: some View {
+        Group {
+            if cameraPermissionDenied {
+                cameraPermissionDeniedView
+            } else {
+                scannerView
+            }
+        }
+        .navigationTitle("Scan QR Code")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - Scanner View
+
+    private var scannerView: some View {
+        ZStack {
+            if QRDataScannerView.isSupported && QRDataScannerView.isAvailable {
+                QRDataScannerView { result in
+                    handleScanResult(result)
+                } onPermissionDenied: {
+                    cameraPermissionDenied = true
+                }
+            } else {
+                // Fallback for unsupported devices
+                ContentUnavailableView(
+                    "Scanner Not Available",
+                    systemImage: "qrcode.viewfinder",
+                    description: Text("QR scanning is not supported on this device")
+                )
+            }
+
+            // Overlay with scan frame
+            VStack {
+                Spacer()
+
+                RoundedRectangle(cornerRadius: 20)
+                    .stroke(.white, lineWidth: 3)
+                    .frame(width: Constants.scanFrameSize, height: Constants.scanFrameSize)
+
+                Spacer()
+
+                if isImporting {
+                    VStack(spacing: 12) {
+                        ProgressView()
+                        Text("Importing contact...")
+                    }
+                    .font(.subheadline)
+                    .foregroundStyle(.white)
+                    .padding()
+                    .background(.black.opacity(Constants.overlayOpacity), in: .capsule)
+                    .padding(.bottom, Constants.bottomPadding)
+                } else if let errorMessage {
+                    Button {
+                        self.errorMessage = nil
+                    } label: {
+                        Text(errorMessage)
+                            .font(.subheadline)
+                            .foregroundStyle(.white)
+                            .padding()
+                            .background(.red.opacity(Constants.errorOpacity), in: .capsule)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.bottom, Constants.bottomPadding)
+                } else {
+                    Text("Point your camera at a contact QR code")
+                        .font(.subheadline)
+                        .foregroundStyle(.white)
+                        .padding()
+                        .background(.black.opacity(Constants.overlayOpacity), in: .capsule)
+                        .padding(.bottom, Constants.bottomPadding)
+                }
+            }
+        }
+        .sensoryFeedback(.success, trigger: scanSuccessTrigger)
+        .ignoresSafeArea()
+    }
+
+    // MARK: - Permission Denied View
+
+    private var cameraPermissionDeniedView: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "camera.fill")
+                .font(.system(size: 60))
+                .foregroundStyle(.secondary)
+
+            Text("Camera Access Required")
+                .font(.title2)
+                .bold()
+
+            Text("Please enable camera access in Settings to scan QR codes.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            Button("Open Settings") {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    openURL(url)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+
+    // MARK: - Parsed Contact
+
+    private struct ParsedContact {
+        let name: String
+        let publicKey: Data
+        let type: ContactType
+    }
+
+    // MARK: - Private Methods
+
+    private func handleScanResult(_ result: String) {
+        guard !isImporting else { return }
+
+        // Parse URL: meshcore://contact/add?name=<name>&public_key=<hex>&type=<1|2|3>
+        guard let url = URL(string: result),
+              url.scheme == "meshcore",
+              url.host == "contact",
+              url.path == "/add",
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let queryItems = components.queryItems else {
+            logger.error("Invalid QR code format: \(result)")
+            errorMessage = "Invalid QR code format"
+            return
+        }
+
+        // Extract parameters
+        // Note: URLQueryItem decodes %20 but not + (form-urlencoded space)
+        guard let rawName = queryItems.first(where: { $0.name == "name" })?.value,
+              !rawName.isEmpty else {
+            logger.error("Missing or empty name parameter")
+            errorMessage = "Invalid QR code: missing name"
+            return
+        }
+        let name = rawName.replacing("+", with: " ")
+
+        guard let publicKeyHex = queryItems.first(where: { $0.name == "public_key" })?.value,
+              let publicKey = Data(hexString: publicKeyHex),
+              publicKey.count == ProtocolLimits.publicKeySize else {
+            logger.error("Invalid or missing public_key parameter")
+            errorMessage = "Invalid QR code: invalid public key"
+            return
+        }
+
+        let typeValue = queryItems.first(where: { $0.name == "type" })?.value.flatMap { Int($0) } ?? 1
+        let contactType = ContactType(rawValue: UInt8(typeValue)) ?? .chat
+
+        let parsed = ParsedContact(name: name, publicKey: publicKey, type: contactType)
+
+        // Provide haptic feedback on successful QR scan
+        scanSuccessTrigger.toggle()
+
+        Task {
+            await importContact(parsed)
+        }
+    }
+
+    @MainActor
+    private func importContact(_ contact: ParsedContact) async {
+        guard let services = appState.services,
+              let deviceID = appState.connectedDevice?.id else {
+            logger.error("Services or device not available")
+            errorMessage = "Not connected to device"
+            return
+        }
+
+        isImporting = true
+        errorMessage = nil
+
+        do {
+            let currentTimestamp = UInt32(Date().timeIntervalSince1970)
+
+            let contactFrame = ContactFrame(
+                publicKey: contact.publicKey,
+                type: contact.type,
+                flags: 0,
+                outPathLength: -1,  // Flood routing
+                outPath: Data(),
+                name: contact.name,
+                lastAdvertTimestamp: 0,
+                latitude: 0,
+                longitude: 0,
+                lastModified: currentTimestamp
+            )
+
+            logger.info("Importing contact: \(contact.name) (\(contact.publicKey.hexString()))")
+            try await services.contactService.addOrUpdateContact(deviceID: deviceID, contact: contactFrame)
+            logger.info("Contact imported successfully")
+
+            // Reset state and dismiss before calling completion handler
+            isImporting = false
+            dismiss()
+
+            onScan(contact.name, contact.publicKey)
+        } catch {
+            logger.error("Failed to import contact: \(error.localizedDescription)")
+            errorMessage = "Failed to import contact: \(error.localizedDescription)"
+            isImporting = false
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ScanContactQRView { name, data in
+            print("Scanned: \(name), data: \(data.count) bytes")
+        }
+    }
+    .environment(AppState())
+}

--- a/PocketMesh/Views/RemoteNodes/RoomConversationViewModel.swift
+++ b/PocketMesh/Views/RemoteNodes/RoomConversationViewModel.swift
@@ -30,7 +30,6 @@ final class RoomConversationViewModel {
 
     private var roomServerService: RoomServerService?
     private var dataStore: DataStore?
-    private weak var appState: AppState?
 
     // MARK: - Initialization
 
@@ -40,7 +39,6 @@ final class RoomConversationViewModel {
     func configure(appState: AppState) {
         self.roomServerService = appState.services?.roomServerService
         self.dataStore = appState.services?.dataStore
-        self.appState = appState
     }
 
     // MARK: - Messages
@@ -83,7 +81,6 @@ final class RoomConversationViewModel {
 
             // Add to local array
             messages.append(message)
-            await appState?.syncCoordinator?.notifyConversationsChanged()
         } catch {
             errorMessage = error.localizedDescription
             // Restore the text so user can retry

--- a/PocketMesh/Views/Settings/DeviceInfoView.swift
+++ b/PocketMesh/Views/Settings/DeviceInfoView.swift
@@ -8,6 +8,7 @@ struct DeviceInfoView: View {
     @State private var batteryInfo: MeshCore.BatteryInfo?
     @State private var isLoadingBattery: Bool = false
     @State private var lastRefresh: Date?
+    @State private var showShareSheet = false
 
     var body: some View {
         List {
@@ -146,14 +147,25 @@ struct DeviceInfoView: View {
                         Text(device.blePin == 0 ? "Disabled" : "Enabled")
                             .foregroundStyle(.secondary)
                     }
+                } header: {
+                    Text("Security")
+                }
 
+                // Identity
+                Section {
                     NavigationLink {
                         PublicKeyView(publicKey: device.publicKey)
                     } label: {
                         Label("Public Key", systemImage: "key")
                     }
+
+                    Button {
+                        showShareSheet = true
+                    } label: {
+                        Label("Share My Contact", systemImage: "square.and.arrow.up")
+                    }
                 } header: {
-                    Text("Security")
+                    Text("Identity")
                 }
 
                 // Identifier
@@ -185,6 +197,15 @@ struct DeviceInfoView: View {
         }
         .onAppear {
             refreshBatteryInfo()
+        }
+        .sheet(isPresented: $showShareSheet) {
+            if let device = appState.connectedDevice {
+                ContactQRShareSheet(
+                    contactName: device.nodeName,
+                    publicKey: device.publicKey,
+                    contactType: .chat
+                )
+            }
         }
     }
 

--- a/PocketMeshServices/Sources/PocketMeshServices/Services/ContactService.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Services/ContactService.swift
@@ -272,15 +272,27 @@ public actor ContactService {
 
     // MARK: - Export/Import Contact
 
-    /// Export a contact to a shareable URI
+    /// Export a contact to a shareable URI (legacy firmware call)
     /// - Parameter publicKey: The contact's 32-byte public key (nil for self)
     /// - Returns: Contact URI string
+    @available(*, deprecated, message: "Use exportContactURI(name:publicKey:type:) instead")
     public func exportContact(publicKey: Data? = nil) async throws -> String {
         do {
             return try await session.exportContact(publicKey: publicKey)
         } catch let error as MeshCoreError {
             throw ContactServiceError.sessionError(error)
         }
+    }
+
+    /// Build a shareable contact URI from contact information
+    /// - Parameters:
+    ///   - name: The contact's advertised name
+    ///   - publicKey: The contact's 32-byte public key
+    ///   - type: The contact type (chat, repeater, room)
+    /// - Returns: Contact URI string in format: meshcore://contact/add?name=...&public_key=...&type=...
+    public static func exportContactURI(name: String, publicKey: Data, type: ContactType) -> String {
+        let encodedName = name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        return "meshcore://contact/add?name=\(encodedName)&public_key=\(publicKey.hexString())&type=\(type.rawValue)"
     }
 
     /// Import a contact from card data

--- a/PocketMeshServices/Tests/PocketMeshServicesTests/SyncCoordinatorTests.swift
+++ b/PocketMeshServices/Tests/PocketMeshServicesTests/SyncCoordinatorTests.swift
@@ -39,6 +39,7 @@ struct SyncCoordinatorTests {
         let coordinator = SyncCoordinator()
         #expect(coordinator.state == .idle)
         #expect(coordinator.contactsVersion == 0)
+        #expect(coordinator.conversationsVersion == 0)
         #expect(coordinator.lastSyncDate == nil)
     }
 
@@ -53,31 +54,28 @@ struct SyncCoordinatorTests {
         #expect(coordinator.contactsVersion == initialVersion + 1)
     }
 
-    @Test("notifyConversationsChanged calls callback")
+    @Test("notifyConversationsChanged increments conversationsVersion")
     @MainActor
-    func notifyConversationsChangedCallsCallback() async {
+    func notifyConversationsChangedIncrementsVersion() async {
         let coordinator = SyncCoordinator()
-        let tracker = CallbackTracker()
-
-        await coordinator.setConversationsChangedCallback {
-            await tracker.markStarted()
-        }
+        let initialVersion = coordinator.conversationsVersion
 
         await coordinator.notifyConversationsChanged()
 
-        let callbackCalled = await tracker.started
-        #expect(callbackCalled, "Callback should have been called")
+        #expect(coordinator.conversationsVersion == initialVersion + 1)
     }
 
-    @Test("Multiple contact notifications increment correctly")
+    @Test("Multiple notifications increment correctly")
     @MainActor
-    func multipleContactNotificationsIncrementCorrectly() async {
+    func multipleNotificationsIncrementCorrectly() async {
         let coordinator = SyncCoordinator()
 
         await coordinator.notifyContactsChanged()
         await coordinator.notifyContactsChanged()
+        await coordinator.notifyConversationsChanged()
 
         #expect(coordinator.contactsVersion == 2)
+        #expect(coordinator.conversationsVersion == 1)
     }
 
     @Test("Sync activity callbacks fire during full sync")


### PR DESCRIPTION
## Summary

- Add QR code generation and scanning for sharing contacts between PocketMesh and official MeshCore iOS app
- New `ContactQRShareSheet` for displaying shareable QR codes with contact info
- New `ScanContactQRView` for scanning and importing contacts via QR code
- New `AddContactSheet` for manual contact entry with QR scan option
- Share contact functionality from Device Info, Contacts List, and Contact Detail views

## Technical Details

- Uses standard MeshCore URI format: `meshcore://contact/add?name=<NAME>&public_key=<HEX>&type=<1|2|3>`
- Contact types: Chat (1), Repeater (2), Room (3)
- Client-side URI building via `ContactService.exportContactURI()` (no firmware call needed)
- Handles form-urlencoded spaces (`+` → space) for compatibility with official app
- Copy button copies lowercase public key without spaces
- QR codes generated using CoreImage CIFilter

## Test plan

- [x] Generate QR code from PocketMesh, scan with official MeshCore iOS app
- [x] Generate QR code from official MeshCore iOS app, scan with PocketMesh
- [x] Verify contact names with spaces import correctly (no `+` characters)
- [x] Verify contact type is preserved during import/export
- [x] Test manual contact entry with type picker
- [x] Verify copy button copies lowercase key without spaces
- [x] Verify share button includes name, key, and URI
- [x] Verify Done button is in top-right corner per iOS HIG

🤖 Generated with [Claude Code](https://claude.com/claude-code)