### PR TITLE
feat: consolidate battery fetch logic

### DIFF
--- a/PocketMesh/AppState.swift
+++ b/PocketMesh/AppState.swift
@@ -49,8 +49,8 @@ public final class AppState {
     /// Device ID pending retry
     var pendingReconnectDeviceID: UUID?
 
-    /// Current device battery level in millivolts (nil if not fetched)
-    var deviceBatteryMillivolts: UInt16?
+    /// Current device battery info (nil if not fetched)
+    var deviceBattery: BatteryInfo?
 
     // MARK: - Onboarding State
 
@@ -270,11 +270,10 @@ public final class AppState {
         guard connectionState == .ready else { return }
 
         do {
-            let battery = try await services?.settingsService.getBattery()
-            deviceBatteryMillivolts = battery.map { UInt16(clamping: $0.level) }
+            deviceBattery = try await services?.settingsService.getBattery()
         } catch {
             // Silently fail - battery info is optional
-            deviceBatteryMillivolts = nil
+            deviceBattery = nil
         }
     }
 

--- a/PocketMesh/Extensions/BatteryInfo+Display.swift
+++ b/PocketMesh/Extensions/BatteryInfo+Display.swift
@@ -1,0 +1,38 @@
+import MeshCore
+import SwiftUI
+
+/// Display helpers for battery information.
+/// Consolidates LiPo voltage-to-percentage calculation previously duplicated in
+/// BLEStatusIndicatorView and DeviceInfoView.
+extension BatteryInfo {
+    /// Battery voltage in volts (converted from millivolts)
+    var voltage: Double {
+        Double(level) / 1000.0
+    }
+
+    /// Estimated percentage based on LiPo curve (4.2V = 100%, 3.0V = 0%)
+    var percentage: Int {
+        let percent = ((voltage - 3.0) / 1.2) * 100
+        return Int(min(100, max(0, percent)))
+    }
+
+    /// SF Symbol name for battery level
+    var iconName: String {
+        switch percentage {
+        case 88...100: "battery.100"
+        case 63..<88: "battery.75"
+        case 38..<63: "battery.50"
+        case 13..<38: "battery.25"
+        default: "battery.0"
+        }
+    }
+
+    /// Color for battery display based on level
+    var levelColor: Color {
+        switch percentage {
+        case 20...100: .primary
+        case 10..<20: .orange
+        default: .red
+        }
+    }
+}

--- a/PocketMesh/Views/Components/BLEStatusIndicatorView.swift
+++ b/PocketMesh/Views/Components/BLEStatusIndicatorView.swift
@@ -63,10 +63,10 @@ struct BLEStatusIndicatorView: View {
                 Section {
                     VStack(alignment: .leading) {
                         Label(device.nodeName, systemImage: "antenna.radiowaves.left.and.right")
-                        if let percent = batteryPercentage, let voltage = batteryVoltage {
+                        if let battery = appState.deviceBattery {
                             Label(
-                                "\(percent)% (\(voltage, format: .number.precision(.fractionLength(2)))v)",
-                                systemImage: batterySymbolName
+                                "\(battery.percentage)% (\(battery.voltage, format: .number.precision(.fractionLength(2)))v)",
+                                systemImage: battery.iconName
                             )
                             .font(.caption)
                             .foregroundStyle(.secondary)
@@ -158,36 +158,6 @@ struct BLEStatusIndicatorView: View {
             "Connected"
         case .ready:
             "Ready"
-        }
-    }
-
-    // MARK: - Battery Properties
-
-    /// Battery voltage calculated from millivolts
-    private var batteryVoltage: Double? {
-        guard let millivolts = appState.deviceBatteryMillivolts else { return nil }
-        return Double(millivolts) / 1000.0
-    }
-
-    /// Estimated battery percentage from millivolts (LiPo curve)
-    private var batteryPercentage: Int? {
-        guard let voltage = batteryVoltage else { return nil }
-        // LiPo voltage to percentage: 4.2V = 100%, 3.0V = 0%
-        let minV = 3.0
-        let maxV = 4.2
-        let percent = ((voltage - minV) / (maxV - minV)) * 100
-        return Int(min(100, max(0, percent)))
-    }
-
-    /// SF Symbol name for current battery level
-    private var batterySymbolName: String {
-        guard let percent = batteryPercentage else { return "battery.0" }
-        switch percent {
-        case 88...100: return "battery.100"
-        case 63..<88: return "battery.75"
-        case 38..<63: return "battery.50"
-        case 13..<38: return "battery.25"
-        default: return "battery.0"
         }
     }
 

--- a/PocketMeshTests/Extensions/BatteryInfoDisplayTests.swift
+++ b/PocketMeshTests/Extensions/BatteryInfoDisplayTests.swift
@@ -1,0 +1,89 @@
+import Testing
+@testable import PocketMesh
+import MeshCore
+
+struct BatteryInfoDisplayTests {
+
+    // MARK: - Voltage Tests
+
+    @Test func voltage_convertsMillivoltsCorrectly() {
+        let battery = BatteryInfo(level: 3700)
+        #expect(battery.voltage == 3.7)
+    }
+
+    @Test func voltage_zeroMillivolts() {
+        let battery = BatteryInfo(level: 0)
+        #expect(battery.voltage == 0.0)
+    }
+
+    // MARK: - Percentage Tests
+
+    @Test func percentage_fullBattery() {
+        let battery = BatteryInfo(level: 4200)
+        #expect(battery.percentage == 100)
+    }
+
+    @Test func percentage_emptyBattery() {
+        let battery = BatteryInfo(level: 3000)
+        #expect(battery.percentage == 0)
+    }
+
+    @Test func percentage_midRange() {
+        let battery = BatteryInfo(level: 3600)  // 50% point
+        #expect(battery.percentage == 50)
+    }
+
+    @Test func percentage_clampsAbove100() {
+        let battery = BatteryInfo(level: 4500)
+        #expect(battery.percentage == 100)
+    }
+
+    @Test func percentage_clampsBelow0() {
+        let battery = BatteryInfo(level: 2500)
+        #expect(battery.percentage == 0)
+    }
+
+    // MARK: - Icon Tests
+
+    @Test func iconName_fullBattery() {
+        let battery = BatteryInfo(level: 4200)
+        #expect(battery.iconName == "battery.100")
+    }
+
+    @Test func iconName_75percent() {
+        let battery = BatteryInfo(level: 3900)  // ~75%
+        #expect(battery.iconName == "battery.75")
+    }
+
+    @Test func iconName_50percent() {
+        let battery = BatteryInfo(level: 3600)  // ~50%
+        #expect(battery.iconName == "battery.50")
+    }
+
+    @Test func iconName_25percent() {
+        let battery = BatteryInfo(level: 3300)  // ~25%
+        #expect(battery.iconName == "battery.25")
+    }
+
+    @Test func iconName_lowBattery() {
+        let battery = BatteryInfo(level: 3100)  // ~8%
+        #expect(battery.iconName == "battery.0")
+    }
+
+    // MARK: - Color Tests
+
+    @Test func levelColor_normalLevel() {
+        let battery = BatteryInfo(level: 3600)  // 50%
+        #expect(battery.levelColor == .primary)
+    }
+
+    @Test func levelColor_warningLevel() {
+        let battery = BatteryInfo(level: 3180)  // ~15%
+        #expect(battery.levelColor == .orange)
+    }
+
+    @Test func levelColor_criticalLevel() {
+        let battery = BatteryInfo(level: 3060)  // ~5%
+        #expect(battery.levelColor == .red)
+    }
+}


### PR DESCRIPTION
## Summary
- Consolidate duplicated battery percentage calculation from 4 locations into single `BatteryInfo+Display` extension
- Update `AppState` to store full `BatteryInfo` instead of raw millivolts
- Single fetch path through `AppState.fetchDeviceBattery()` for both views

## Changes
| File | Change |
|------|--------|
| `PocketMesh/Extensions/BatteryInfo+Display.swift` | New extension with `voltage`, `percentage`, `iconName`, `levelColor` |
| `PocketMesh/AppState.swift` | Store `BatteryInfo?` instead of `UInt16?` |
| `PocketMesh/Views/Components/BLEStatusIndicatorView.swift` | Use extension, remove duplicate calculation |
| `PocketMesh/Views/Settings/DeviceInfoView.swift` | Use AppState, remove `BatteryRow` struct |
| `PocketMeshTests/Extensions/BatteryInfoDisplayTests.swift` | Unit tests for extension |

## Test plan
- [x] Build passes (0 errors)
- [x] Connect to device, verify battery shows in toolbar menu
- [x] Navigate to Device Info, verify battery displays correctly
- [x] Both views show same values (single source of truth)

Closes #26