### PR TITLE
feat: revamp onboarding UX with haptics and TipKit guidance

### DIFF
--- a/PocketMesh/PocketMeshApp.swift
+++ b/PocketMesh/PocketMeshApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import TipKit
 import PocketMeshServices
 #if DEBUG
 import DataScoutCompanion
@@ -19,6 +20,9 @@ struct PocketMeshApp: App {
             ContentView()
                 .environment(appState)
                 .task {
+                    try? Tips.configure([
+                        .displayFrequency(.immediate)
+                    ])
                     await appState.initialize()
                     #if DEBUG
                     // ConnectionService.shared.startAdvertising(container: appState.modelContainer)

--- a/PocketMesh/Tips/SendFloodAdvertTip.swift
+++ b/PocketMesh/Tips/SendFloodAdvertTip.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import TipKit
+
+/// Tip shown after onboarding to guide users to send their first flood advert
+struct SendFloodAdvertTip: Tip {
+    static let hasCompletedOnboarding = Tips.Event(id: "hasCompletedOnboarding")
+
+    var title: Text {
+        Text("Announce yourself to the mesh")
+    }
+
+    var message: Text? {
+        Text("Tap here and send a Flood Advert to let nearby devices know you've joined.")
+    }
+
+    var image: Image? {
+        Image(systemName: "dot.radiowaves.left.and.right")
+    }
+
+    var rules: [Rule] {
+        #Rule(Self.hasCompletedOnboarding) { $0.donations.count >= 1 }
+    }
+}

--- a/PocketMesh/Views/Components/BLEStatusIndicatorView.swift
+++ b/PocketMesh/Views/Components/BLEStatusIndicatorView.swift
@@ -1,5 +1,6 @@
 import OSLog
 import SwiftUI
+import TipKit
 import PocketMeshServices
 
 private let logger = Logger(subsystem: "com.pocketmesh", category: "BLEStatus")
@@ -12,6 +13,8 @@ struct BLEStatusIndicatorView: View {
     @State private var isSendingAdvert = false
     @State private var successFeedbackTrigger = false
     @State private var errorFeedbackTrigger = false
+
+    private let floodAdvertTip = SendFloodAdvertTip()
 
     var body: some View {
         Group {
@@ -106,6 +109,7 @@ struct BLEStatusIndicatorView: View {
                 .foregroundStyle(iconColor)
                 .symbolEffect(.pulse, isActive: isAnimating)
         }
+        .popoverTip(floodAdvertTip, arrowEdge: .top)
         .sensoryFeedback(.success, trigger: successFeedbackTrigger)
         .sensoryFeedback(.error, trigger: errorFeedbackTrigger)
         .accessibilityLabel("Bluetooth connection status")
@@ -155,6 +159,7 @@ struct BLEStatusIndicatorView: View {
     // MARK: - Actions
 
     private func sendAdvert(flood: Bool) {
+        floodAdvertTip.invalidate(reason: .actionPerformed)
         guard !isSendingAdvert else { return }
         isSendingAdvert = true
 

--- a/PocketMesh/Views/Onboarding/DeviceScanView.swift
+++ b/PocketMesh/Views/Onboarding/DeviceScanView.swift
@@ -7,6 +7,7 @@ struct DeviceScanView: View {
     @State private var isPairing = false
     @State private var showTroubleshooting = false
     @State private var errorMessage: String?
+    @State private var pairingSuccessTrigger = false
 
     var body: some View {
         VStack(spacing: 24) {
@@ -100,6 +101,7 @@ struct DeviceScanView: View {
             .padding(.horizontal)
             .padding(.bottom)
         }
+        .sensoryFeedback(.success, trigger: pairingSuccessTrigger)
         .sheet(isPresented: $showTroubleshooting) {
             TroubleshootingSheet()
         }
@@ -128,6 +130,7 @@ struct DeviceScanView: View {
             do {
                 try await appState.connectionManager.pairNewDevice()
                 await appState.wireServicesIfConnected()
+                pairingSuccessTrigger.toggle()
                 appState.onboardingPath.append(.radioPreset)
             } catch AccessorySetupKitError.pickerDismissed {
                 // User cancelled - no error to show

--- a/PocketMesh/Views/Onboarding/PermissionsView.swift
+++ b/PocketMesh/Views/Onboarding/PermissionsView.swift
@@ -108,7 +108,6 @@ struct PermissionsView: View {
                     description: "Receive alerts for new messages",
                     isGranted: coordinator.notificationAuthorization == .authorized,
                     isDenied: coordinator.notificationAuthorization == .denied,
-                    isOptional: true,
                     action: coordinator.requestNotifications
                 )
 
@@ -118,7 +117,6 @@ struct PermissionsView: View {
                     description: "Share your location with mesh contacts",
                     isGranted: coordinator.locationAuthorization == .authorizedWhenInUse || coordinator.locationAuthorization == .authorizedAlways,
                     isDenied: coordinator.locationAuthorization == .denied,
-                    isOptional: true,
                     action: {
                         if coordinator.locationAuthorization == .denied {
                             showingLocationAlert = true


### PR DESCRIPTION
## Summary

- Remove "Optional" labels from permission cards (Skip button already communicates optionality)
- Add haptic feedback (`.sensoryFeedback(.success)`) on device pairing and preset apply
- Add TipKit tip that appears 2.5s after onboarding, guiding users to send their first flood advert
- Tip points to BLE status menu and dismisses when user sends any advert

## Test Plan

- [ ] Complete onboarding flow
- [ ] Verify no "Optional" labels appear on permissions screen
- [ ] Verify haptic feedback on successful device pairing
- [ ] Verify haptic feedback on successful preset apply
- [ ] Verify TipKit tip appears ~2.5s after entering main app
- [ ] Verify tip dismisses when opening radio menu and sending advert