### PR TITLE
feat: add sheet detents and drag indicators

### DIFF
--- a/PocketMesh/Views/Chats/ChannelChatView.swift
+++ b/PocketMesh/Views/Chats/ChannelChatView.swift
@@ -45,6 +45,8 @@ struct ChannelChatView: View {
                 // Dismiss the chat view when channel is deleted
                 dismiss()
             }
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
         }
         .task {
             viewModel.configure(appState: appState)

--- a/PocketMesh/Views/Chats/ChatsListView.swift
+++ b/PocketMesh/Views/Chats/ChatsListView.swift
@@ -125,6 +125,8 @@ struct ChatsListView: View {
                     roomToAuthenticate = nil
                     navigationPath.append(authenticatedSession)
                 }
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
             }
             .alert("Leave Room", isPresented: $showRoomDeleteAlert) {
                 Button("Cancel", role: .cancel) {

--- a/PocketMesh/Views/Contacts/ContactDetailView.swift
+++ b/PocketMesh/Views/Contacts/ContactDetailView.swift
@@ -147,6 +147,8 @@ struct ContactDetailView: View {
                     // Navigate to Chats tab with the room conversation
                     appState.navigateToRoom(with: session)
                 }
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
             }
         }
         .sheet(item: $activeSheet, onDismiss: presentPendingSheet) { sheet in
@@ -161,6 +163,8 @@ struct ContactDetailView: View {
                         pendingSheet = .repeaterStatus(session)
                         activeSheet = nil  // Triggers dismissal, then onDismiss fires
                     }
+                    .presentationDetents([.medium, .large])
+                    .presentationDragIndicator(.visible)
                 }
             case .repeaterStatus(let session):
                 RepeaterStatusView(session: session)
@@ -183,6 +187,8 @@ struct ContactDetailView: View {
                     showRepeaterAdminAuth = false
                     // Navigation triggers in onDismiss above
                 }
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
             }
         }
         .sheet(isPresented: $showQRShareSheet) {
@@ -191,6 +197,8 @@ struct ContactDetailView: View {
                 publicKey: currentContact.publicKey,
                 contactType: currentContact.type
             )
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
         }
         .navigationDestination(isPresented: $navigateToSettings) {
             if let session = adminSession {

--- a/PocketMesh/Views/Map/MapView.swift
+++ b/PocketMesh/Views/Map/MapView.swift
@@ -38,6 +38,8 @@ struct MapView: View {
                     contact: contact,
                     onMessage: { navigateToChat(with: contact) }
                 )
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
             }
         }
     }
@@ -261,7 +263,6 @@ private struct ContactDetailSheet: View {
                 }
             }
         }
-        .presentationDetents([.medium, .large])
     }
 
     // MARK: - Computed Properties


### PR DESCRIPTION
Closes #31

## Summary

- Add `.presentationDetents([.medium, .large])` and `.presentationDragIndicator(.visible)` to medium-height sheets
- Sheets updated: ContactDetailSheet (map), QR share, auth sheets (room join, telemetry, admin), ChannelInfoSheet, RoomAuthenticationSheet
- Remove duplicate internal detents from ContactDetailSheet for consistency

## Test Plan

- [ ] Open map, tap contact annotation, verify sheet has drag indicator and can expand
- [ ] Open contact detail, tap "Share Contact", verify QR sheet has drag indicator
- [ ] Open contact detail for room/repeater, tap auth actions, verify sheets have drag indicator
- [ ] Open channel chat, tap info button, verify sheet has drag indicator
- [ ] From chats list, tap disconnected room, verify auth sheet has drag indicator