### PR TITLE
feat: preserve contacts locally when device auto-deletes due to capacity

### DIFF
--- a/MeshCore/Sources/MeshCore/Protocols/MeshCoreSessionProtocol.swift
+++ b/MeshCore/Sources/MeshCore/Protocols/MeshCoreSessionProtocol.swift
@@ -89,6 +89,25 @@ public protocol MeshCoreSessionProtocol: Actor {
     /// - Throws: `MeshCoreError` if the discovery request fails.
     func sendPathDiscovery(to destination: Data) async throws -> MessageSentInfo
 
+    /// Shares a contact via zero-hop broadcast.
+    ///
+    /// - Parameter publicKey: The contact's 32-byte public key to share.
+    /// - Throws: `MeshCoreError` if the share fails.
+    func shareContact(publicKey: Data) async throws
+
+    /// Exports a contact to a shareable URI.
+    ///
+    /// - Parameter publicKey: The contact's 32-byte public key (nil for self).
+    /// - Returns: Contact URI string.
+    /// - Throws: `MeshCoreError` if export fails.
+    func exportContact(publicKey: Data?) async throws -> String
+
+    /// Imports a contact from card data.
+    ///
+    /// - Parameter cardData: The contact card data.
+    /// - Throws: `MeshCoreError` if import fails.
+    func importContact(cardData: Data) async throws
+
     // MARK: - Channel Operations (used by ChannelService)
 
     /// Retrieves information about a channel.

--- a/PocketMesh/Views/Chats/ChatsListView.swift
+++ b/PocketMesh/Views/Chats/ChatsListView.swift
@@ -348,7 +348,15 @@ struct ConversationRow: View {
     var body: some View {
         HStack(spacing: 12) {
             // Avatar
-            ContactAvatar(contact: contact, size: 44)
+            if contact.isArchived {
+                Image(systemName: "archivebox.fill")
+                    .font(.title2)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 44, height: 44)
+                    .accessibilityLabel("\(contact.displayName), archived")
+            } else {
+                ContactAvatar(contact: contact, size: 44)
+            }
 
             // Content
             VStack(alignment: .leading, spacing: 4) {

--- a/PocketMesh/Views/Contacts/ContactDetailView.swift
+++ b/PocketMesh/Views/Contacts/ContactDetailView.swift
@@ -270,7 +270,14 @@ struct ContactDetailView: View {
     private var profileSection: some View {
         Section {
             VStack(spacing: 16) {
-                ContactAvatar(contact: currentContact, size: 100)
+                if currentContact.isArchived {
+                    Image(systemName: "archivebox.fill")
+                        .font(.largeTitle)
+                        .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
+                } else {
+                    ContactAvatar(contact: currentContact, size: 100)
+                }
 
                 VStack(spacing: 4) {
                     Text(currentContact.displayName)
@@ -280,6 +287,12 @@ struct ContactDetailView: View {
                     Text(contactTypeLabel)
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
+
+                    if currentContact.isArchived {
+                        Text("Archived")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
 
                     // Status indicators
                     HStack(spacing: 12) {
@@ -312,6 +325,17 @@ struct ContactDetailView: View {
 
     private var actionsSection: some View {
         Section {
+            // Restore button for archived contacts
+            if currentContact.isArchived {
+                Button("Restore to Device", systemImage: "arrow.uturn.up") {
+                    Task {
+                        try? await appState.services?.contactService.restoreContact(contactID: currentContact.id)
+                        await refreshContact()
+                    }
+                }
+                .accessibilityHint("Returns this contact to your mesh device so you can send messages")
+            }
+
             // Role-specific actions based on contact type
             switch currentContact.type {
             case .room:

--- a/PocketMeshServices/Sources/PocketMeshServices/Models/Contact.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Models/Contact.swift
@@ -61,6 +61,9 @@ public final class Contact {
     /// Contacts from NEW_ADVERT push have this set to true until explicitly added
     public var isDiscovered: Bool
 
+    /// Whether this contact has been removed from the device but preserved locally
+    public var isArchived: Bool
+
     /// Selected OCV preset name (nil = liIon default)
     public var ocvPreset: String?
 
@@ -86,6 +89,7 @@ public final class Contact {
         lastMessageDate: Date? = nil,
         unreadCount: Int = 0,
         isDiscovered: Bool = false,
+        isArchived: Bool = false,
         ocvPreset: String? = nil,
         customOCVArrayString: String? = nil
     ) {
@@ -107,6 +111,7 @@ public final class Contact {
         self.lastMessageDate = lastMessageDate
         self.unreadCount = unreadCount
         self.isDiscovered = isDiscovered
+        self.isArchived = isArchived
         self.ocvPreset = ocvPreset
         self.customOCVArrayString = customOCVArrayString
     }
@@ -219,6 +224,7 @@ public struct ContactDTO: Sendable, Equatable, Identifiable, Hashable {
     public let lastMessageDate: Date?
     public let unreadCount: Int
     public let isDiscovered: Bool
+    public let isArchived: Bool
     public let ocvPreset: String?
     public let customOCVArrayString: String?
 
@@ -241,6 +247,7 @@ public struct ContactDTO: Sendable, Equatable, Identifiable, Hashable {
         self.lastMessageDate = contact.lastMessageDate
         self.unreadCount = contact.unreadCount
         self.isDiscovered = contact.isDiscovered
+        self.isArchived = contact.isArchived
         self.ocvPreset = contact.ocvPreset
         self.customOCVArrayString = contact.customOCVArrayString
     }
@@ -263,6 +270,7 @@ public struct ContactDTO: Sendable, Equatable, Identifiable, Hashable {
         isBlocked: Bool,
         isFavorite: Bool,
         isDiscovered: Bool,
+        isArchived: Bool,
         lastMessageDate: Date?,
         unreadCount: Int,
         ocvPreset: String? = nil,
@@ -284,6 +292,7 @@ public struct ContactDTO: Sendable, Equatable, Identifiable, Hashable {
         self.isBlocked = isBlocked
         self.isFavorite = isFavorite
         self.isDiscovered = isDiscovered
+        self.isArchived = isArchived
         self.lastMessageDate = lastMessageDate
         self.unreadCount = unreadCount
         self.ocvPreset = ocvPreset
@@ -348,5 +357,10 @@ public struct ContactDTO: Sendable, Equatable, Identifiable, Hashable {
             longitude: longitude,
             lastModified: lastModified
         )
+    }
+
+    /// Converts to MeshContact for session operations
+    public func toMeshContact() -> MeshContact {
+        toContactFrame().toMeshContact()
     }
 }

--- a/PocketMeshServices/Sources/PocketMeshServices/Services/PersistenceStore.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Services/PersistenceStore.swift
@@ -333,6 +333,8 @@ public actor PersistenceStore: PersistenceStoreProtocol {
             existing.isFavorite = dto.isFavorite
             existing.lastMessageDate = dto.lastMessageDate
             existing.unreadCount = dto.unreadCount
+            existing.isDiscovered = dto.isDiscovered
+            existing.isArchived = dto.isArchived
             existing.ocvPreset = dto.ocvPreset
             existing.customOCVArrayString = dto.customOCVArrayString
         } else {
@@ -354,6 +356,8 @@ public actor PersistenceStore: PersistenceStoreProtocol {
                 isFavorite: dto.isFavorite,
                 lastMessageDate: dto.lastMessageDate,
                 unreadCount: dto.unreadCount,
+                isDiscovered: dto.isDiscovered,
+                isArchived: dto.isArchived,
                 ocvPreset: dto.ocvPreset,
                 customOCVArrayString: dto.customOCVArrayString
             )

--- a/PocketMeshServices/Sources/PocketMeshServices/Simulator/MockDataProvider.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Simulator/MockDataProvider.swift
@@ -87,6 +87,7 @@ public enum MockDataProvider {
                 isBlocked: false,
                 isFavorite: false,
                 isDiscovered: false,
+                isArchived: false,
                 lastMessageDate: now.addingTimeInterval(-1800),  // 30 min ago
                 unreadCount: 3
             ),
@@ -109,6 +110,7 @@ public enum MockDataProvider {
                 isBlocked: false,
                 isFavorite: true,
                 isDiscovered: false,
+                isArchived: false,
                 lastMessageDate: now.addingTimeInterval(-900),  // 15 min ago
                 unreadCount: 0
             ),
@@ -131,6 +133,7 @@ public enum MockDataProvider {
                 isBlocked: false,
                 isFavorite: false,
                 isDiscovered: false,
+                isArchived: false,
                 lastMessageDate: nil,
                 unreadCount: 0
             ),
@@ -153,11 +156,12 @@ public enum MockDataProvider {
                 isBlocked: false,
                 isFavorite: false,
                 isDiscovered: false,
+                isArchived: false,
                 lastMessageDate: nil,
                 unreadCount: 0
             ),
 
-            // Eve Thompson - chat, blocked, 4 hops
+            // Eve Thompson - chat, blocked, archived, 4 hops
             ContactDTO(
                 id: eveThompsonID,
                 deviceID: simulatorDeviceID,
@@ -175,7 +179,8 @@ public enum MockDataProvider {
                 isBlocked: true,
                 isFavorite: false,
                 isDiscovered: false,
-                lastMessageDate: nil,
+                isArchived: true,
+                lastMessageDate: now.addingTimeInterval(-604600),  // 1 week ago
                 unreadCount: 0
             ),
 
@@ -197,6 +202,7 @@ public enum MockDataProvider {
                 isBlocked: false,
                 isFavorite: false,
                 isDiscovered: false,
+                isArchived: false,
                 lastMessageDate: now.addingTimeInterval(-7200),  // 2 hours ago
                 unreadCount: 0
             ),
@@ -219,6 +225,7 @@ public enum MockDataProvider {
                 isBlocked: false,
                 isFavorite: false,
                 isDiscovered: false,
+                isArchived: false,
                 lastMessageDate: nil,
                 unreadCount: 0
             ),
@@ -241,6 +248,7 @@ public enum MockDataProvider {
                 isBlocked: false,
                 isFavorite: false,
                 isDiscovered: true,  // Just discovered
+                isArchived: false,
                 lastMessageDate: nil,
                 unreadCount: 0
             )
@@ -642,8 +650,82 @@ public enum MockDataProvider {
                 )
             ]
 
+        case eveThompsonID:
+            // Eve: archived contact with message history
+            return [
+                MessageDTO(
+                    id: UUID(uuidString: "50000000-0000-0000-0000-000000000001")!,
+                    deviceID: deviceID,
+                    contactID: contactID,
+                    channelIndex: nil,
+                    text: "Hey, can you pick up some groceries?",
+                    timestamp: UInt32(now.addingTimeInterval(-604800).timeIntervalSince1970),  // 1 week ago
+                    createdAt: now.addingTimeInterval(-604800),
+                    direction: .outgoing,
+                    status: .delivered,
+                    textType: .plain,
+                    ackCode: 54321,
+                    pathLength: 4,
+                    snr: nil,
+                    senderKeyPrefix: nil,
+                    senderNodeName: nil,
+                    isRead: true,
+                    replyToID: nil,
+                    roundTripTime: 4500,
+                    heardRepeats: 0,
+                    retryAttempt: 0,
+                    maxRetryAttempts: 3
+                ),
+                MessageDTO(
+                    id: UUID(uuidString: "50000000-0000-0000-0000-000000000002")!,
+                    deviceID: deviceID,
+                    contactID: contactID,
+                    channelIndex: nil,
+                    text: "Sure, what do you need?",
+                    timestamp: UInt32(now.addingTimeInterval(-604700).timeIntervalSince1970),
+                    createdAt: now.addingTimeInterval(-604700),
+                    direction: .incoming,
+                    status: .delivered,
+                    textType: .plain,
+                    ackCode: nil,
+                    pathLength: 4,
+                    snr: 3.2,
+                    senderKeyPrefix: mockPublicKey(seed: 50).prefix(6),
+                    senderNodeName: nil,
+                    isRead: true,
+                    replyToID: nil,
+                    roundTripTime: nil,
+                    heardRepeats: 0,
+                    retryAttempt: 0,
+                    maxRetryAttempts: 0
+                ),
+                MessageDTO(
+                    id: UUID(uuidString: "50000000-0000-0000-0000-000000000003")!,
+                    deviceID: deviceID,
+                    contactID: contactID,
+                    channelIndex: nil,
+                    text: "Milk and bread. Thanks!",
+                    timestamp: UInt32(now.addingTimeInterval(-604600).timeIntervalSince1970),
+                    createdAt: now.addingTimeInterval(-604600),
+                    direction: .outgoing,
+                    status: .delivered,
+                    textType: .plain,
+                    ackCode: 54322,
+                    pathLength: 4,
+                    snr: nil,
+                    senderKeyPrefix: nil,
+                    senderNodeName: nil,
+                    isRead: true,
+                    replyToID: nil,
+                    roundTripTime: 4200,
+                    heardRepeats: 0,
+                    retryAttempt: 0,
+                    maxRetryAttempts: 3
+                )
+            ]
+
         default:
-            // No messages for other contacts (Charlie, Diana, Eve, Ghost, Hannah)
+            // No messages for other contacts (Charlie, Diana, Ghost, Hannah)
             return []
         }
     }

--- a/PocketMeshServices/Sources/PocketMeshServices/Simulator/SimulatorMeshSession.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Simulator/SimulatorMeshSession.swift
@@ -1,0 +1,100 @@
+#if targetEnvironment(simulator)
+import Foundation
+import MeshCore
+
+/// Mock session for simulator that allows runtime manipulation of contacts.
+/// Used to test archiving behavior when device capacity is reached.
+public actor SimulatorMeshSession: MeshCoreSessionProtocol {
+
+    // MARK: - Mutable State
+
+    /// Current contacts on the simulated device
+    private var _contacts: [MeshContact] = []
+
+    /// Maximum contacts before oldest gets removed
+    private var _maxContacts: Int = 100
+
+    // MARK: - Configuration
+
+    /// Set the contacts list
+    public func setContacts(_ contacts: [MeshContact]) {
+        _contacts = contacts
+    }
+
+    /// Get current contacts
+    public func currentContacts() -> [MeshContact] {
+        _contacts
+    }
+
+    /// Set maximum contact capacity
+    public func setMaxContacts(_ max: Int) {
+        _maxContacts = max
+    }
+
+    /// Get maximum contact capacity
+    public func maxContacts() -> Int {
+        _maxContacts
+    }
+
+    // MARK: - MeshCoreSessionProtocol
+
+    public var connectionState: AsyncStream<MeshCore.ConnectionState> {
+        AsyncStream { continuation in
+            continuation.yield(.connected)
+            continuation.finish()
+        }
+    }
+
+    public func getContacts(since lastModified: Date?) async throws -> [MeshContact] {
+        _contacts
+    }
+
+    public func addContact(_ contact: MeshContact) async throws {
+        // Simulate device capacity behavior - remove oldest when at limit
+        if _contacts.count >= _maxContacts {
+            _contacts.removeFirst()
+        }
+        _contacts.append(contact)
+    }
+
+    public func removeContact(publicKey: Data) async throws {
+        _contacts.removeAll { $0.publicKey == publicKey }
+    }
+
+    public func sendMessage(to destination: Data, text: String, timestamp: Date) async throws -> MessageSentInfo {
+        MessageSentInfo(type: 0, expectedAck: Data([0x01, 0x02, 0x03, 0x04]), suggestedTimeoutMs: 5000)
+    }
+
+    public func sendChannelMessage(channel: UInt8, text: String, timestamp: Date) async throws {
+        // No-op for simulator
+    }
+
+    public func resetPath(publicKey: Data) async throws {
+        // No-op for simulator
+    }
+
+    public func sendPathDiscovery(to destination: Data) async throws -> MessageSentInfo {
+        MessageSentInfo(type: 0, expectedAck: Data([0x01, 0x02, 0x03, 0x04]), suggestedTimeoutMs: 5000)
+    }
+
+    public func shareContact(publicKey: Data) async throws {
+        // No-op for simulator
+    }
+
+    public func exportContact(publicKey: Data?) async throws -> String {
+        "meshcore://contact/simulator"
+    }
+
+    public func importContact(cardData: Data) async throws {
+        // No-op for simulator
+    }
+
+    public func getChannel(index: UInt8) async throws -> ChannelInfo {
+        ChannelInfo(index: index, name: "", secret: Data(repeating: 0, count: 16))
+    }
+
+    public func setChannel(index: UInt8, name: String, secret: Data) async throws {
+        // No-op for simulator
+    }
+}
+#endif

--- a/PocketMeshServices/Tests/PocketMeshServicesTests/Mocks/MockMeshCoreSession.swift
+++ b/PocketMeshServices/Tests/PocketMeshServicesTests/Mocks/MockMeshCoreSession.swift
@@ -173,7 +173,24 @@ public actor MockMeshCoreSession: MeshCoreSessionProtocol {
         }
     }
 
+    public func shareContact(publicKey: Data) async throws {
+        // No-op for mock
+    }
+
+    public func exportContact(publicKey: Data?) async throws -> String {
+        "meshcore://contact/mock"
+    }
+
+    public func importContact(cardData: Data) async throws {
+        // No-op for mock
+    }
+
     // MARK: - Test Helpers
+
+    /// Set the stubbed contacts (for actor-safe mutation from tests)
+    public func setStubbedContacts(_ contacts: [MeshContact]) {
+        stubbedContacts = contacts
+    }
 
     /// Resets all recorded invocations
     public func reset() {

--- a/PocketMeshServices/Tests/PocketMeshServicesTests/Mocks/MockPersistenceStore.swift
+++ b/PocketMeshServices/Tests/PocketMeshServicesTests/Mocks/MockPersistenceStore.swift
@@ -281,6 +281,7 @@ public actor MockPersistenceStore: PersistenceStoreProtocol {
             isBlocked: false,
             isFavorite: false,
             isDiscovered: false,
+            isArchived: false,
             lastMessageDate: nil,
             unreadCount: 0
         )
@@ -306,7 +307,7 @@ public actor MockPersistenceStore: PersistenceStoreProtocol {
     }
 
     public func updateContactLastMessage(contactID: UUID, date: Date?) async throws {
-        if var contact = contacts[contactID] {
+        if let contact = contacts[contactID] {
             contacts[contactID] = ContactDTO(
                 id: contact.id,
                 deviceID: contact.deviceID,
@@ -324,6 +325,7 @@ public actor MockPersistenceStore: PersistenceStoreProtocol {
                 isBlocked: contact.isBlocked,
                 isFavorite: contact.isFavorite,
                 isDiscovered: contact.isDiscovered,
+                isArchived: contact.isArchived,
                 lastMessageDate: date,
                 unreadCount: contact.unreadCount
             )
@@ -331,7 +333,7 @@ public actor MockPersistenceStore: PersistenceStoreProtocol {
     }
 
     public func incrementUnreadCount(contactID: UUID) async throws {
-        if var contact = contacts[contactID] {
+        if let contact = contacts[contactID] {
             contacts[contactID] = ContactDTO(
                 id: contact.id,
                 deviceID: contact.deviceID,
@@ -349,6 +351,7 @@ public actor MockPersistenceStore: PersistenceStoreProtocol {
                 isBlocked: contact.isBlocked,
                 isFavorite: contact.isFavorite,
                 isDiscovered: contact.isDiscovered,
+                isArchived: contact.isArchived,
                 lastMessageDate: contact.lastMessageDate,
                 unreadCount: contact.unreadCount + 1
             )
@@ -356,7 +359,7 @@ public actor MockPersistenceStore: PersistenceStoreProtocol {
     }
 
     public func clearUnreadCount(contactID: UUID) async throws {
-        if var contact = contacts[contactID] {
+        if let contact = contacts[contactID] {
             contacts[contactID] = ContactDTO(
                 id: contact.id,
                 deviceID: contact.deviceID,
@@ -374,6 +377,7 @@ public actor MockPersistenceStore: PersistenceStoreProtocol {
                 isBlocked: contact.isBlocked,
                 isFavorite: contact.isFavorite,
                 isDiscovered: contact.isDiscovered,
+                isArchived: contact.isArchived,
                 lastMessageDate: contact.lastMessageDate,
                 unreadCount: 0
             )
@@ -388,7 +392,7 @@ public actor MockPersistenceStore: PersistenceStoreProtocol {
     }
 
     public func confirmContact(id: UUID) async throws {
-        if var contact = contacts[id] {
+        if let contact = contacts[id] {
             contacts[id] = ContactDTO(
                 id: contact.id,
                 deviceID: contact.deviceID,
@@ -406,6 +410,7 @@ public actor MockPersistenceStore: PersistenceStoreProtocol {
                 isBlocked: contact.isBlocked,
                 isFavorite: contact.isFavorite,
                 isDiscovered: false,
+                isArchived: contact.isArchived,
                 lastMessageDate: contact.lastMessageDate,
                 unreadCount: contact.unreadCount
             )

--- a/PocketMeshServices/Tests/PocketMeshServicesTests/Services/ContactArchivingIntegrationTests.swift
+++ b/PocketMeshServices/Tests/PocketMeshServicesTests/Services/ContactArchivingIntegrationTests.swift
@@ -1,0 +1,266 @@
+import Testing
+import Foundation
+@testable import PocketMeshServices
+@testable import MeshCore
+
+@Suite("Contact Archiving Integration Tests")
+struct ContactArchivingIntegrationTests {
+
+    /// Test device ID (same as MockDataProvider.simulatorDeviceID)
+    private let deviceID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+
+    // MARK: - Helper Methods
+
+    private func makeContact(name: String, seed: UInt8, isArchived: Bool = false) -> ContactDTO {
+        let publicKey = Data((0..<32).map { UInt8($0) &+ seed })
+        return ContactDTO(
+            id: UUID(),
+            deviceID: deviceID,
+            publicKey: publicKey,
+            name: name,
+            typeRawValue: ContactType.chat.rawValue,
+            flags: 0,
+            outPathLength: 1,
+            outPath: Data([seed]),
+            lastAdvertTimestamp: UInt32(Date().timeIntervalSince1970),
+            latitude: 0,
+            longitude: 0,
+            lastModified: UInt32(Date().timeIntervalSince1970),
+            nickname: nil,
+            isBlocked: false,
+            isFavorite: false,
+            isDiscovered: false,
+            isArchived: isArchived,
+            lastMessageDate: nil,
+            unreadCount: 0
+        )
+    }
+
+    private func makeMeshContact(from dto: ContactDTO) -> MeshContact {
+        MeshContact(
+            id: dto.publicKey.hexString(),
+            publicKey: dto.publicKey,
+            type: dto.typeRawValue,
+            flags: dto.flags,
+            outPathLength: dto.outPathLength,
+            outPath: dto.outPath,
+            advertisedName: dto.name,
+            lastAdvertisement: Date(timeIntervalSince1970: TimeInterval(dto.lastAdvertTimestamp)),
+            latitude: dto.latitude,
+            longitude: dto.longitude,
+            lastModified: Date(timeIntervalSince1970: TimeInterval(dto.lastModified))
+        )
+    }
+
+    // MARK: - Tests
+
+    @Test("Sync archives contacts removed from device")
+    func syncArchivesRemovedContacts() async throws {
+        // Given: 3 contacts in local store
+        let mockSession = MockMeshCoreSession()
+        let store = MockPersistenceStore()
+        let service = ContactService(session: mockSession, dataStore: store)
+
+        let alice = makeContact(name: "Alice", seed: 1)
+        let bob = makeContact(name: "Bob", seed: 2)
+        let charlie = makeContact(name: "Charlie", seed: 3)
+
+        try await store.saveContact(alice)
+        try await store.saveContact(bob)
+        try await store.saveContact(charlie)
+
+        // When: Device only returns Bob and Charlie (Alice removed)
+        await mockSession.setStubbedContacts([makeMeshContact(from: bob), makeMeshContact(from: charlie)])
+        _ = try await service.syncContacts(deviceID: deviceID)
+
+        // Then: Alice should be archived
+        let fetchedAlice = try await store.fetchContact(id: alice.id)
+        #expect(fetchedAlice?.isArchived == true, "Alice should be archived")
+
+        let fetchedBob = try await store.fetchContact(id: bob.id)
+        #expect(fetchedBob?.isArchived == false, "Bob should not be archived")
+    }
+
+    @Test("Sync unarchives restored contacts")
+    func syncUnarchivesRestoredContacts() async throws {
+        // Given: An archived contact
+        let mockSession = MockMeshCoreSession()
+        let store = MockPersistenceStore()
+        let service = ContactService(session: mockSession, dataStore: store)
+
+        let alice = makeContact(name: "Alice", seed: 1, isArchived: true)
+        try await store.saveContact(alice)
+
+        // When: Device returns Alice (she's back)
+        await mockSession.setStubbedContacts([makeMeshContact(from: alice)])
+        _ = try await service.syncContacts(deviceID: deviceID)
+
+        // Then: Alice should be unarchived
+        let fetchedAlice = try await store.fetchContact(id: alice.id)
+        #expect(fetchedAlice?.isArchived == false, "Alice should be unarchived")
+    }
+
+    // MARK: - SimulatorMeshSession Tests (Xcode only)
+
+    #if targetEnvironment(simulator)
+    @Test("SimulatorMeshSession removes oldest contact when at capacity")
+    func simulatorSessionRemovesOldestAtCapacity() async throws {
+        // Given: A SimulatorMeshSession at capacity
+        let session = SimulatorMeshSession()
+        await session.setMaxContacts(3)
+
+        let alice = makeContact(name: "Alice", seed: 1)
+        let bob = makeContact(name: "Bob", seed: 2)
+        let charlie = makeContact(name: "Charlie", seed: 3)
+
+        try await session.addContact(makeMeshContact(from: alice))
+        try await session.addContact(makeMeshContact(from: bob))
+        try await session.addContact(makeMeshContact(from: charlie))
+
+        // When: Adding a fourth contact
+        let dave = makeContact(name: "Dave", seed: 4)
+        try await session.addContact(makeMeshContact(from: dave))
+
+        // Then: Alice (oldest) should be removed, others remain
+        let contacts = await session.currentContacts()
+        #expect(contacts.count == 3, "Should have 3 contacts")
+        let publicKeys = contacts.map { $0.publicKey }
+        #expect(!publicKeys.contains(alice.publicKey), "Alice should be removed")
+        #expect(publicKeys.contains(bob.publicKey), "Bob should remain")
+        #expect(publicKeys.contains(charlie.publicKey), "Charlie should remain")
+        #expect(publicKeys.contains(dave.publicKey), "Dave should be added")
+    }
+
+    @Test("Full archiving flow with SimulatorMeshSession")
+    func fullArchivingFlowWithSimulator() async throws {
+        // Given: ContactService with SimulatorMeshSession at capacity
+        let session = SimulatorMeshSession()
+        let store = MockPersistenceStore()
+        let service = ContactService(session: session, dataStore: store)
+
+        await session.setMaxContacts(2)
+
+        // Add 2 contacts to both session and store
+        let alice = makeContact(name: "Alice", seed: 1)
+        let bob = makeContact(name: "Bob", seed: 2)
+
+        try await session.addContact(makeMeshContact(from: alice))
+        try await session.addContact(makeMeshContact(from: bob))
+        try await store.saveContact(alice)
+        try await store.saveContact(bob)
+
+        // When: Adding a third contact pushes Alice out
+        let charlie = makeContact(name: "Charlie", seed: 3)
+        try await session.addContact(makeMeshContact(from: charlie))
+        try await store.saveContact(charlie)
+
+        // Sync detects Alice is missing
+        _ = try await service.syncContacts(deviceID: deviceID)
+
+        // Then: Alice should be archived
+        let fetchedAlice = try await store.fetchContact(id: alice.id)
+        #expect(fetchedAlice?.isArchived == true, "Alice should be archived after being pushed out")
+
+        // Bob and Charlie should not be archived
+        let fetchedBob = try await store.fetchContact(id: bob.id)
+        let fetchedCharlie = try await store.fetchContact(id: charlie.id)
+        #expect(fetchedBob?.isArchived == false, "Bob should not be archived")
+        #expect(fetchedCharlie?.isArchived == false, "Charlie should not be archived")
+    }
+
+    @Test("Restore archived contact adds it back to device")
+    func restoreArchivedContactWithSimulator() async throws {
+        // Given: An archived contact that was pushed out
+        let session = SimulatorMeshSession()
+        let store = MockPersistenceStore()
+        let service = ContactService(session: session, dataStore: store)
+
+        await session.setMaxContacts(2)
+
+        let alice = makeContact(name: "Alice", seed: 1, isArchived: true)
+        let bob = makeContact(name: "Bob", seed: 2)
+        let charlie = makeContact(name: "Charlie", seed: 3)
+
+        // Only Bob and Charlie are on device, Alice is archived locally
+        try await session.addContact(makeMeshContact(from: bob))
+        try await session.addContact(makeMeshContact(from: charlie))
+        try await store.saveContact(alice)
+        try await store.saveContact(bob)
+        try await store.saveContact(charlie)
+
+        // When: Restoring Alice
+        try await service.restoreContact(contactID: alice.id)
+
+        // Then: Alice should be on device (and Bob pushed out due to capacity)
+        let contacts = await session.currentContacts()
+        let publicKeys = contacts.map { $0.publicKey }
+        #expect(publicKeys.contains(alice.publicKey), "Alice should be on device after restore")
+
+        // And: Alice should be unarchived locally
+        let fetchedAlice = try await store.fetchContact(id: alice.id)
+        #expect(fetchedAlice?.isArchived == false, "Alice should be unarchived")
+    }
+    #endif
+
+    @Test("Discovered contacts are not archived when missing from device")
+    func discoveredContactsNotArchived() async throws {
+        // Given: A discovered contact (from NEW_ADVERT, not yet confirmed on device)
+        let mockSession = MockMeshCoreSession()
+        let store = MockPersistenceStore()
+        let service = ContactService(session: mockSession, dataStore: store)
+
+        let discovered = ContactDTO(
+            id: UUID(),
+            deviceID: deviceID,
+            publicKey: Data((0..<32).map { UInt8($0) }),
+            name: "Discovered",
+            typeRawValue: ContactType.chat.rawValue,
+            flags: 0,
+            outPathLength: -1,
+            outPath: Data(),
+            lastAdvertTimestamp: UInt32(Date().timeIntervalSince1970),
+            latitude: 0,
+            longitude: 0,
+            lastModified: UInt32(Date().timeIntervalSince1970),
+            nickname: nil,
+            isBlocked: false,
+            isFavorite: false,
+            isDiscovered: true,
+            isArchived: false,
+            lastMessageDate: nil,
+            unreadCount: 0
+        )
+        try await store.saveContact(discovered)
+
+        // When: Device returns no contacts
+        await mockSession.setStubbedContacts([])
+        _ = try await service.syncContacts(deviceID: deviceID)
+
+        // Then: Discovered contact should NOT be archived (it was never on device)
+        let fetched = try await store.fetchContact(id: discovered.id)
+        #expect(fetched?.isArchived == false, "Discovered contacts should not be archived")
+    }
+
+    @Test("Restore contact sends to device and marks unarchived")
+    func restoreContactSendsToDevice() async throws {
+        // Given: An archived contact
+        let mockSession = MockMeshCoreSession()
+        let store = MockPersistenceStore()
+        let service = ContactService(session: mockSession, dataStore: store)
+
+        let archived = makeContact(name: "Archived", seed: 42, isArchived: true)
+        try await store.saveContact(archived)
+
+        // When: Restore is called
+        try await service.restoreContact(contactID: archived.id)
+
+        // Then: Contact should be sent to device
+        let addInvocations = await mockSession.addContactInvocations
+        #expect(addInvocations.count == 1, "Should have called addContact once")
+        #expect(addInvocations.first?.contact.publicKey == archived.publicKey, "Should send correct contact")
+
+        // And: Contact should be marked unarchived locally
+        let fetched = try await store.fetchContact(id: archived.id)
+        #expect(fetched?.isArchived == false, "Contact should be unarchived after restore")
+    }
+}

--- a/PocketMeshTests/Models/ConversationFilteringTests.swift
+++ b/PocketMeshTests/Models/ConversationFilteringTests.swift
@@ -28,6 +28,7 @@ final class ConversationFilteringTests: XCTestCase {
             isBlocked: false,
             isFavorite: isFavorite,
             isDiscovered: false,
+            isArchived: false,
             lastMessageDate: Date(),
             unreadCount: unreadCount
         )

--- a/PocketMeshTests/Services/ContactArchiveTests.swift
+++ b/PocketMeshTests/Services/ContactArchiveTests.swift
@@ -1,0 +1,88 @@
+import Testing
+import Foundation
+@testable import PocketMeshServices
+
+@Suite("Contact Archive Tests")
+struct ContactArchiveTests {
+
+    @Test("Sync marks removed contacts as archived")
+    func syncArchivesRemovedContact() async throws {
+        // Given: A contact exists locally
+        let deviceID = UUID()
+        let publicKey = Data(repeating: 0x01, count: 32)
+        let contact = Contact(
+            deviceID: deviceID,
+            publicKey: publicKey,
+            name: "Test Contact"
+        )
+
+        // When: Device returns empty contact list (contact was removed)
+        // Then: Contact should be marked as archived
+        #expect(contact.isArchived == false, "Contact should start not archived")
+
+        // Simulate archive
+        contact.isArchived = true
+        #expect(contact.isArchived == true, "Contact should be archived after removal")
+    }
+
+    @Test("Sync unarchives restored contacts")
+    func syncUnarchivesRestoredContact() async throws {
+        // Given: An archived contact
+        let deviceID = UUID()
+        let publicKey = Data(repeating: 0x02, count: 32)
+        let contact = Contact(
+            deviceID: deviceID,
+            publicKey: publicKey,
+            name: "Archived Contact",
+            isArchived: true
+        )
+
+        #expect(contact.isArchived == true, "Contact should start archived")
+
+        // When: Contact is found on device again
+        // Then: Should be unarchived
+        contact.isArchived = false
+        #expect(contact.isArchived == false, "Contact should be unarchived")
+    }
+
+    @Test("Archived contacts preserve message history association")
+    func archivedContactPreservesMessageAssociation() async throws {
+        // Given: A contact with an associated message ID
+        let deviceID = UUID()
+        let contactID = UUID()
+        let publicKey = Data(repeating: 0x03, count: 32)
+        let contact = Contact(
+            id: contactID,
+            deviceID: deviceID,
+            publicKey: publicKey,
+            name: "Contact With Messages"
+        )
+
+        // When: Contact is archived
+        contact.isArchived = true
+
+        // Then: Contact ID remains stable for message association
+        #expect(contact.id == contactID, "Contact ID should remain stable")
+        #expect(contact.isArchived == true)
+    }
+
+    @Test("Restore contact creates valid contact frame")
+    func restoreContactCreatesValidFrame() async throws {
+        // Given: An archived contact
+        let deviceID = UUID()
+        let publicKey = Data(repeating: 0x04, count: 32)
+        let contact = Contact(
+            deviceID: deviceID,
+            publicKey: publicKey,
+            name: "Archived Contact",
+            isArchived: true
+        )
+
+        // When: Converting to frame for restore
+        let frame = contact.toContactFrame()
+
+        // Then: Frame should have correct public key
+        #expect(frame.publicKey == publicKey)
+        #expect(frame.name == "Archived Contact")
+    }
+}


### PR DESCRIPTION
## Summary

Closes #37

When the MeshCore device reaches its `maxContacts` capacity, it automatically removes the oldest contact to make room for new ones. Previously, this caused unexpected data loss in PocketMesh.

This PR preserves all contacts and message history locally. When a contact is removed from the device, it's marked as "archived" rather than deleted. Archived contacts remain visible with their full message history but cannot receive new messages until restored.

### Changes

- **Model**: Add `isArchived` property to Contact and ContactDTO
- **Sync Logic**: Detect removed contacts and mark as archived; auto-unarchive when contact returns
- **Restore Flow**: Add `restoreContact()` method to re-add archived contacts to device
- **UI**: 
  - Archivebox icon replaces avatar for archived contacts in chat list
  - Archived state and restore button in contact detail view
  - Restore footer with iOS 26 liquid glass (+ fallback) replaces compose area

### Design Decisions

| Aspect | Decision |
|--------|----------|
| Message history | Preserved locally forever |
| Auto-unarchive | Yes, when contact re-added (matched by publicKey) |
| Archived contacts | Read-only - must restore to send messages |
| UI indicator | Archivebox icon replaces avatar |
| Capacity warnings | None - silent archiving |

## Test Plan

- [x] Unit tests for archive detection and restore logic
- [ ] Manual: Verify archived contacts show archivebox icon in chat list
- [ ] Manual: Verify contact detail shows "Archived" label and restore button
- [ ] Manual: Verify conversation view hides compose, shows restore footer
- [ ] Manual: Verify restore button re-adds contact to device