### PR TITLE
feat: add OCV battery curve feature for accurate percentage calculation

### DIFF
--- a/PocketMesh/Extensions/BatteryInfo+Display.swift
+++ b/PocketMesh/Extensions/BatteryInfo+Display.swift
@@ -16,6 +16,37 @@ extension BatteryInfo {
         return Int(min(100, max(0, percent)))
     }
 
+    /// Calculate percentage using OCV array lookup with linear interpolation.
+    /// The OCV array should have 11 values mapping to 100%, 90%, 80%... 0%.
+    func percentage(using ocvArray: [Int]) -> Int {
+        guard ocvArray.count == 11 else { return percentage }  // Fallback to linear
+
+        let mV = level
+
+        // Above max voltage = 100%
+        if mV >= ocvArray[0] {
+            return 100
+        }
+
+        // Below min voltage = 0%
+        if mV <= ocvArray[10] {
+            return 0
+        }
+
+        // Find segment and interpolate
+        for i in 0..<10 {
+            let upperV = ocvArray[i]
+            let lowerV = ocvArray[i + 1]
+            if mV >= lowerV {
+                let segmentPercent = Double(mV - lowerV) / Double(upperV - lowerV)
+                let basePercent = (10 - i - 1) * 10  // 90, 80, 70, ...
+                return basePercent + Int((segmentPercent * 10).rounded())
+            }
+        }
+
+        return 0
+    }
+
     /// SF Symbol name for battery level
     var iconName: String {
         switch percentage {
@@ -27,9 +58,29 @@ extension BatteryInfo {
         }
     }
 
+    /// SF Symbol name for battery level using OCV array
+    func iconName(using ocvArray: [Int]) -> String {
+        switch percentage(using: ocvArray) {
+        case 88...100: "battery.100"
+        case 63..<88: "battery.75"
+        case 38..<63: "battery.50"
+        case 13..<38: "battery.25"
+        default: "battery.0"
+        }
+    }
+
     /// Color for battery display based on level
     var levelColor: Color {
         switch percentage {
+        case 20...100: .primary
+        case 10..<20: .orange
+        default: .red
+        }
+    }
+
+    /// Color for battery display based on OCV level
+    func levelColor(using ocvArray: [Int]) -> Color {
+        switch percentage(using: ocvArray) {
         case 20...100: .primary
         case 10..<20: .orange
         default: .red

--- a/PocketMesh/Views/Components/BLEStatusIndicatorView.swift
+++ b/PocketMesh/Views/Components/BLEStatusIndicatorView.swift
@@ -59,8 +59,8 @@ struct BLEStatusIndicatorView: View {
                         Label(device.nodeName, systemImage: "antenna.radiowaves.left.and.right")
                         if let battery = appState.deviceBattery {
                             Label(
-                                "\(battery.percentage)% (\(battery.voltage, format: .number.precision(.fractionLength(2)))v)",
-                                systemImage: battery.iconName
+                                "\(battery.percentage(using: appState.activeBatteryOCVArray))% (\(battery.voltage, format: .number.precision(.fractionLength(2)))v)",
+                                systemImage: battery.iconName(using: appState.activeBatteryOCVArray)
                             )
                             .font(.caption)
                             .foregroundStyle(.secondary)

--- a/PocketMesh/Views/Settings/AdvancedSettingsView.swift
+++ b/PocketMesh/Views/Settings/AdvancedSettingsView.swift
@@ -18,6 +18,9 @@ struct AdvancedSettingsView: View {
                 // Telemetry Settings
                 TelemetrySettingsSection()
 
+                // Battery Curve
+                BatteryCurveSection()
+
                 // Danger Zone
                 DangerZoneSection()
             }

--- a/PocketMesh/Views/Settings/Components/BatteryCurveChart.swift
+++ b/PocketMesh/Views/Settings/Components/BatteryCurveChart.swift
@@ -1,0 +1,74 @@
+import Charts
+import SwiftUI
+
+/// Visual representation of an OCV discharge curve
+struct BatteryCurveChart: View {
+    let ocvArray: [Int]
+
+    private var dataPoints: [DataPoint] {
+        ocvArray.enumerated().map { index, voltage in
+            DataPoint(
+                voltage: Double(voltage) / 1000.0,  // Convert to volts
+                percent: (10 - index) * 10  // 100, 90, 80, ... 0
+            )
+        }
+    }
+
+    /// Y axis lower bound: min voltage - 100mV, rounded down to nearest 0.1V
+    private var yAxisMin: Double {
+        guard let minMV = ocvArray.min() else { return 1.0 }
+        return (Double(minMV - 100) / 1000.0).rounded(.down, precision: 1)
+    }
+
+    /// Y axis upper bound: max voltage + 100mV, rounded up to nearest 0.1V
+    private var yAxisMax: Double {
+        guard let maxMV = ocvArray.max() else { return 4.5 }
+        return (Double(maxMV + 100) / 1000.0).rounded(.up, precision: 1)
+    }
+
+    var body: some View {
+        Chart(dataPoints) { point in
+            AreaMark(
+                x: .value("Percent", point.percent),
+                yStart: .value("Baseline", yAxisMin),
+                yEnd: .value("Voltage", point.voltage)
+            )
+            .foregroundStyle(.blue.opacity(0.2))
+            .interpolationMethod(.monotone)
+
+            LineMark(
+                x: .value("Percent", point.percent),
+                y: .value("Voltage", point.voltage)
+            )
+            .foregroundStyle(.blue)
+            .interpolationMethod(.monotone)
+        }
+        .chartXScale(domain: 0...100)
+        .chartXAxis {
+            AxisMarks(values: [0, 25, 50, 75, 100])
+        }
+        .chartYScale(domain: yAxisMin...yAxisMax)
+        .chartXAxisLabel("Percent")
+        .chartYAxisLabel("Voltage (V)")
+        .accessibilityLabel("Battery discharge curve showing voltage at each percentage level")
+        .frame(height: 150)
+    }
+}
+
+private struct DataPoint: Identifiable {
+    var id: Int { percent }
+    let voltage: Double
+    let percent: Int
+}
+
+private extension Double {
+    func rounded(_ rule: FloatingPointRoundingRule, precision: Int) -> Double {
+        let multiplier = pow(10.0, Double(precision))
+        return (self * multiplier).rounded(rule) / multiplier
+    }
+}
+
+#Preview {
+    BatteryCurveChart(ocvArray: [4190, 4050, 3990, 3890, 3800, 3720, 3630, 3530, 3420, 3300, 3100])
+        .padding()
+}

--- a/PocketMesh/Views/Settings/DeviceInfoView.swift
+++ b/PocketMesh/Views/Settings/DeviceInfoView.swift
@@ -45,11 +45,11 @@ struct DeviceInfoView: View {
                 Section {
                     if let battery = appState.deviceBattery {
                         HStack {
-                            Label("Battery", systemImage: battery.iconName)
+                            Label("Battery", systemImage: battery.iconName(using: appState.activeBatteryOCVArray))
                                 .symbolRenderingMode(.multicolor)
                             Spacer()
-                            Text("\(battery.percentage)%")
-                                .foregroundStyle(battery.levelColor)
+                            Text("\(battery.percentage(using: appState.activeBatteryOCVArray))%")
+                                .foregroundStyle(battery.levelColor(using: appState.activeBatteryOCVArray))
                             Text("(\(battery.voltage, format: .number.precision(.fractionLength(2)))V)")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)

--- a/PocketMesh/Views/Settings/Sections/BatteryCurveSection.swift
+++ b/PocketMesh/Views/Settings/Sections/BatteryCurveSection.swift
@@ -1,0 +1,222 @@
+import SwiftUI
+import PocketMeshServices
+
+/// Battery curve configuration section for Advanced Settings
+struct BatteryCurveSection: View {
+    @Environment(AppState.self) private var appState
+
+    @State private var selectedPreset: OCVPreset = .liIon
+    @State private var voltageValues: [Int] = OCVPreset.liIon.ocvArray
+    @State private var isEditingValues = false
+    @State private var validationError: String?
+    /// Tracks whether voltageValues change is from preset selection (not user edit)
+    @State private var isUpdatingFromPreset = false
+
+    var body: some View {
+        Section {
+            // Preset picker
+            Picker("Preset", selection: $selectedPreset) {
+                ForEach(OCVPreset.selectablePresets, id: \.self) { preset in
+                    Text(preset.displayName).tag(preset)
+                }
+                if selectedPreset == .custom {
+                    Text("Custom").tag(OCVPreset.custom)
+                }
+            }
+            .onChange(of: selectedPreset) { _, newValue in
+                if newValue != .custom {
+                    isUpdatingFromPreset = true
+                    voltageValues = newValue.ocvArray
+                    isUpdatingFromPreset = false
+                    saveToDevice()
+                }
+            }
+
+            // Chart
+            BatteryCurveChart(ocvArray: voltageValues)
+
+            // Edit values disclosure
+            DisclosureGroup("Edit Values", isExpanded: $isEditingValues) {
+                VoltageFieldsGrid(
+                    voltageValues: $voltageValues,
+                    validationError: $validationError,
+                    onValueChanged: handleValueChanged
+                )
+            }
+
+            // Validation error
+            if let error = validationError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        } header: {
+            Text("Battery Curve")
+        } footer: {
+            Text("Configure the voltage-to-percentage curve for your device's battery.")
+        }
+        .task(id: appState.connectedDevice?.id) {
+            loadFromDevice()
+        }
+    }
+
+    private func loadFromDevice() {
+        guard let device = appState.connectedDevice else { return }
+
+        isUpdatingFromPreset = true
+        defer { isUpdatingFromPreset = false }
+
+        if let presetName = device.ocvPreset {
+            if presetName == OCVPreset.custom.rawValue, let customString = device.customOCVArrayString {
+                let parsed = customString.split(separator: ",")
+                    .compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+                if parsed.count == 11 {
+                    voltageValues = parsed
+                    selectedPreset = .custom
+                    return
+                }
+            }
+            if let preset = OCVPreset(rawValue: presetName) {
+                selectedPreset = preset
+                voltageValues = preset.ocvArray
+                return
+            }
+        }
+
+        // Default
+        selectedPreset = .liIon
+        voltageValues = OCVPreset.liIon.ocvArray
+    }
+
+    private func handleValueChanged() {
+        // Ignore if this change came from preset selection
+        guard !isUpdatingFromPreset else { return }
+
+        // Validate
+        if let error = validateVoltageValues() {
+            validationError = error
+            return
+        }
+        validationError = nil
+
+        // Mark as custom (user manually edited a value)
+        selectedPreset = .custom
+        saveToDevice()
+    }
+
+    private func validateVoltageValues() -> String? {
+        // Check all values in valid range
+        for (index, value) in voltageValues.enumerated() {
+            if value < 1000 || value > 5000 {
+                return "Value at \((10 - index) * 10)% must be 1000-5000 mV"
+            }
+        }
+
+        // Check descending order
+        for i in 0..<(voltageValues.count - 1) {
+            if voltageValues[i] <= voltageValues[i + 1] {
+                return "Values must be in descending order"
+            }
+        }
+
+        return nil
+    }
+
+    private func saveToDevice() {
+        Task {
+            guard let deviceService = appState.services?.deviceService,
+                  let deviceID = appState.connectedDevice?.id else { return }
+
+            if selectedPreset == .custom {
+                let customString = voltageValues.map(String.init).joined(separator: ",")
+                try? await deviceService.updateOCVSettings(
+                    deviceID: deviceID,
+                    preset: OCVPreset.custom.rawValue,
+                    customArray: customString
+                )
+            } else {
+                try? await deviceService.updateOCVSettings(
+                    deviceID: deviceID,
+                    preset: selectedPreset.rawValue,
+                    customArray: nil
+                )
+            }
+        }
+    }
+}
+
+/// Two-column grid of voltage input fields
+private struct VoltageFieldsGrid: View {
+    @Binding var voltageValues: [Int]
+    @Binding var validationError: String?
+    let onValueChanged: () -> Void
+
+    private let columns = [
+        GridItem(.flexible()),
+        GridItem(.flexible())
+    ]
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 12) {
+            ForEach(0..<11, id: \.self) { index in
+                VoltageField(
+                    percent: (10 - index) * 10,
+                    value: $voltageValues[index],
+                    hasError: fieldHasError(at: index),
+                    onValueChanged: onValueChanged
+                )
+            }
+        }
+        .padding(.vertical, 8)
+    }
+
+    private func fieldHasError(at index: Int) -> Bool {
+        let value = voltageValues[index]
+        if value < 1000 || value > 5000 { return true }
+        if index > 0 && voltageValues[index - 1] <= value { return true }
+        if index < 10 && value <= voltageValues[index + 1] { return true }
+        return false
+    }
+}
+
+/// Individual voltage input field
+private struct VoltageField: View {
+    let percent: Int
+    @Binding var value: Int
+    let hasError: Bool
+    let onValueChanged: () -> Void
+
+    var body: some View {
+        HStack {
+            Text("\(percent)%")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 40, alignment: .trailing)
+
+            TextField("", value: $value, format: .number)
+                .keyboardType(.numberPad)
+                .textFieldStyle(.roundedBorder)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(hasError ? .red : .clear, lineWidth: 1)
+                )
+                .onChange(of: value) { _, _ in
+                    onValueChanged()
+                }
+                .accessibilityLabel("Voltage at \(percent) percent")
+
+            Text("mV")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        List {
+            BatteryCurveSection()
+        }
+    }
+    .environment(AppState())
+}

--- a/PocketMeshServices/Sources/PocketMeshServices/Models/OCVPreset.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Models/OCVPreset.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Battery OCV (Open Circuit Voltage) presets for accurate percentage calculation.
+/// Each preset contains 11 millivolt values mapping to 100%, 90%, 80%... 0%.
+///
+/// Reference: https://github.com/meshtastic/firmware
+public enum OCVPreset: String, CaseIterable, Codable, Sendable {
+    case liIon
+    case liFePO4
+    case leadAcid
+    case alkaline
+    case niMH
+    case lto
+    case trackerT1000E
+    case heltecPocket5000
+    case heltecPocket10000
+    case seeedWioTracker
+    case seeedSolarNode
+    case r1Neo
+    case wisMeshTag
+    case custom
+
+    /// The 11-point OCV array in millivolts (100% to 0% in 10% steps)
+    public var ocvArray: [Int] {
+        switch self {
+        case .liIon:
+            [4190, 4050, 3990, 3890, 3800, 3720, 3630, 3530, 3420, 3300, 3100]
+        case .liFePO4:
+            [3400, 3350, 3320, 3290, 3270, 3260, 3250, 3230, 3200, 3120, 3000]
+        case .leadAcid:
+            [2120, 2090, 2070, 2050, 2030, 2010, 1990, 1980, 1970, 1960, 1950]
+        case .alkaline:
+            [1580, 1400, 1350, 1300, 1280, 1250, 1230, 1190, 1150, 1100, 1000]
+        case .niMH:
+            [1400, 1300, 1280, 1270, 1260, 1250, 1240, 1230, 1210, 1150, 1000]
+        case .lto:
+            [2700, 2560, 2540, 2520, 2500, 2460, 2420, 2400, 2380, 2320, 1500]
+        case .trackerT1000E:
+            [4190, 4042, 3957, 3885, 3820, 3776, 3746, 3725, 3696, 3644, 3100]
+        case .heltecPocket5000:
+            [4300, 4240, 4120, 4000, 3888, 3800, 3740, 3698, 3655, 3580, 3400]
+        case .heltecPocket10000:
+            [4100, 4060, 3960, 3840, 3729, 3625, 3550, 3500, 3420, 3345, 3100]
+        case .seeedWioTracker:
+            [4200, 3876, 3826, 3763, 3713, 3660, 3573, 3485, 3422, 3359, 3300]
+        case .seeedSolarNode:
+            [4200, 3986, 3922, 3812, 3734, 3645, 3527, 3420, 3281, 3087, 2786]
+        case .r1Neo:
+            [4330, 4292, 4254, 4216, 4178, 4140, 4102, 4064, 4026, 3988, 3950]
+        case .wisMeshTag:
+            [4240, 4112, 4029, 3970, 3906, 3846, 3824, 3802, 3776, 3650, 3072]
+        case .custom:
+            OCVPreset.liIon.ocvArray  // Fallback, actual custom values stored separately
+        }
+    }
+
+    /// Human-readable display name
+    public var displayName: String {
+        switch self {
+        case .liIon: "Li-Ion (Default)"
+        case .liFePO4: "LiFePO4"
+        case .leadAcid: "Lead Acid"
+        case .alkaline: "Alkaline"
+        case .niMH: "NiMH"
+        case .lto: "LTO"
+        case .trackerT1000E: "Tracker T1000-E"
+        case .heltecPocket5000: "Heltec Pocket 5000"
+        case .heltecPocket10000: "Heltec Pocket 10000"
+        case .seeedWioTracker: "Seeed WIO Tracker"
+        case .seeedSolarNode: "Seeed Solar Node"
+        case .r1Neo: "R1 Neo"
+        case .wisMeshTag: "WisMesh Tag"
+        case .custom: "Custom"
+        }
+    }
+
+    /// All presets except custom (for picker display)
+    public static var selectablePresets: [OCVPreset] {
+        allCases.filter { $0 != .custom }
+    }
+}

--- a/PocketMeshServices/Sources/PocketMeshServices/ServiceContainer.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/ServiceContainer.swift
@@ -65,6 +65,9 @@ public final class ServiceContainer {
     /// Service for device settings management
     public let settingsService: SettingsService
 
+    /// Service for device data persistence
+    public let deviceService: DeviceService
+
     /// Service for advertisements and path discovery
     public let advertisementService: AdvertisementService
 
@@ -118,6 +121,7 @@ public final class ServiceContainer {
         self.messageService = MessageService(session: session, dataStore: dataStore)
         self.channelService = ChannelService(session: session, dataStore: dataStore)
         self.settingsService = SettingsService(session: session)
+        self.deviceService = DeviceService(dataStore: dataStore)
         self.advertisementService = AdvertisementService(session: session, dataStore: dataStore)
         self.messagePollingService = MessagePollingService(session: session, dataStore: dataStore)
         self.binaryProtocolService = BinaryProtocolService(session: session, dataStore: dataStore)

--- a/PocketMeshServices/Sources/PocketMeshServices/Services/DeviceService.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Services/DeviceService.swift
@@ -1,0 +1,111 @@
+import Foundation
+import MeshCore
+import OSLog
+
+// MARK: - Device Service Errors
+
+public enum DeviceServiceError: Error, LocalizedError, Sendable {
+    case deviceNotFound
+    case persistenceFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .deviceNotFound:
+            return "Device not found"
+        case .persistenceFailed(let reason):
+            return "Failed to save device settings: \(reason)"
+        }
+    }
+}
+
+// MARK: - Device Service
+
+/// Service for managing device-level data and settings persistence.
+/// Handles local device configuration that doesn't require MeshCore communication.
+public actor DeviceService {
+    private let dataStore: PersistenceStore
+    private let logger = Logger(subsystem: "com.pocketmesh.services", category: "DeviceService")
+
+    /// Callback invoked when device data is successfully updated.
+    /// Used to refresh ConnectionManager.connectedDevice for UI updates.
+    private var onDeviceUpdated: (@Sendable (DeviceDTO) async -> Void)?
+
+    public init(dataStore: PersistenceStore) {
+        self.dataStore = dataStore
+    }
+
+    /// Sets the callback for device updates.
+    public func setDeviceUpdateCallback(
+        _ callback: @escaping @Sendable (DeviceDTO) async -> Void
+    ) {
+        onDeviceUpdated = callback
+    }
+
+    // MARK: - OCV Settings
+
+    /// Update OCV settings for the connected device.
+    ///
+    /// - Parameters:
+    ///   - deviceID: The UUID of the device to update
+    ///   - preset: The OCV preset name (e.g., "liIon", "liPo", "custom")
+    ///   - customArray: Custom OCV array as comma-separated string (required if preset is "custom")
+    /// - Throws: DeviceServiceError if device not found or persistence fails
+    public func updateOCVSettings(
+        deviceID: UUID,
+        preset: String,
+        customArray: String?
+    ) async throws {
+        logger.info("Updating OCV settings for device \(deviceID): preset=\(preset)")
+
+        // Fetch current device
+        guard var device = try await dataStore.fetchDevice(id: deviceID) else {
+            logger.error("Device not found: \(deviceID)")
+            throw DeviceServiceError.deviceNotFound
+        }
+
+        // Update OCV fields
+        device = DeviceDTO(
+            id: device.id,
+            publicKey: device.publicKey,
+            nodeName: device.nodeName,
+            firmwareVersion: device.firmwareVersion,
+            firmwareVersionString: device.firmwareVersionString,
+            manufacturerName: device.manufacturerName,
+            buildDate: device.buildDate,
+            maxContacts: device.maxContacts,
+            maxChannels: device.maxChannels,
+            frequency: device.frequency,
+            bandwidth: device.bandwidth,
+            spreadingFactor: device.spreadingFactor,
+            codingRate: device.codingRate,
+            txPower: device.txPower,
+            maxTxPower: device.maxTxPower,
+            latitude: device.latitude,
+            longitude: device.longitude,
+            blePin: device.blePin,
+            manualAddContacts: device.manualAddContacts,
+            multiAcks: device.multiAcks,
+            telemetryModeBase: device.telemetryModeBase,
+            telemetryModeLoc: device.telemetryModeLoc,
+            telemetryModeEnv: device.telemetryModeEnv,
+            advertLocationPolicy: device.advertLocationPolicy,
+            lastConnected: device.lastConnected,
+            lastContactSync: device.lastContactSync,
+            isActive: device.isActive,
+            ocvPreset: preset,
+            customOCVArrayString: customArray
+        )
+
+        // Save to persistence
+        do {
+            try await dataStore.saveDevice(device)
+            logger.info("OCV settings saved successfully")
+        } catch {
+            logger.error("Failed to save OCV settings: \(error.localizedDescription)")
+            throw DeviceServiceError.persistenceFailed(error.localizedDescription)
+        }
+
+        // Notify callback for UI refresh
+        await onDeviceUpdated?(device)
+    }
+}

--- a/PocketMeshServices/Sources/PocketMeshServices/Services/PersistenceStore.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Services/PersistenceStore.swift
@@ -116,6 +116,8 @@ public actor PersistenceStore: PersistenceStoreProtocol {
             existing.lastConnected = dto.lastConnected
             existing.lastContactSync = dto.lastContactSync
             existing.isActive = dto.isActive
+            existing.ocvPreset = dto.ocvPreset
+            existing.customOCVArrayString = dto.customOCVArrayString
         } else {
             // Create new
             let device = Device(
@@ -145,7 +147,9 @@ public actor PersistenceStore: PersistenceStoreProtocol {
                 advertLocationPolicy: dto.advertLocationPolicy,
                 lastConnected: dto.lastConnected,
                 lastContactSync: dto.lastContactSync,
-                isActive: dto.isActive
+                isActive: dto.isActive,
+                ocvPreset: dto.ocvPreset,
+                customOCVArrayString: dto.customOCVArrayString
             )
             modelContext.insert(device)
         }

--- a/PocketMeshTests/Extensions/BatteryPercentageCalculationTests.swift
+++ b/PocketMeshTests/Extensions/BatteryPercentageCalculationTests.swift
@@ -1,0 +1,49 @@
+import Testing
+import MeshCore
+@testable import PocketMesh
+
+@Suite("Battery Percentage Calculation Tests")
+struct BatteryPercentageCalculationTests {
+
+    // Li-Ion array for testing: [4190, 4050, 3990, 3890, 3800, 3720, 3630, 3530, 3420, 3300, 3100]
+    let liIonArray = [4190, 4050, 3990, 3890, 3800, 3720, 3630, 3530, 3420, 3300, 3100]
+
+    @Test("Voltage at 100% point returns 100")
+    func voltageAt100Percent() {
+        let battery = BatteryInfo(level: 4190)
+        #expect(battery.percentage(using: liIonArray) == 100)
+    }
+
+    @Test("Voltage at 0% point returns 0")
+    func voltageAt0Percent() {
+        let battery = BatteryInfo(level: 3100)
+        #expect(battery.percentage(using: liIonArray) == 0)
+    }
+
+    @Test("Voltage above max returns 100")
+    func voltageAboveMax() {
+        let battery = BatteryInfo(level: 4500)
+        #expect(battery.percentage(using: liIonArray) == 100)
+    }
+
+    @Test("Voltage below min returns 0")
+    func voltageBelowMin() {
+        let battery = BatteryInfo(level: 2800)
+        #expect(battery.percentage(using: liIonArray) == 0)
+    }
+
+    @Test("Voltage at 50% point returns 50")
+    func voltageAt50Percent() {
+        // 50% is at index 5 = 3720mV
+        let battery = BatteryInfo(level: 3720)
+        #expect(battery.percentage(using: liIonArray) == 50)
+    }
+
+    @Test("Voltage interpolates between points")
+    func voltageInterpolates() {
+        // Midpoint between 4190 (100%) and 4050 (90%) = 4120 should be ~95%
+        let battery = BatteryInfo(level: 4120)
+        let percent = battery.percentage(using: liIonArray)
+        #expect(percent >= 94 && percent <= 96, "Expected ~95%, got \(percent)")
+    }
+}

--- a/PocketMeshTests/Models/OCVPresetTests.swift
+++ b/PocketMeshTests/Models/OCVPresetTests.swift
@@ -1,0 +1,48 @@
+import Testing
+@testable import PocketMeshServices
+
+@Suite("OCVPreset Tests")
+struct OCVPresetTests {
+
+    @Test("All presets have exactly 11 values")
+    func presetsHaveCorrectLength() {
+        for preset in OCVPreset.allCases where preset != .custom {
+            #expect(preset.ocvArray.count == 11, "Preset \(preset) should have 11 values")
+        }
+    }
+
+    @Test("All preset arrays are descending")
+    func presetsAreDescending() {
+        for preset in OCVPreset.allCases where preset != .custom {
+            let array = preset.ocvArray
+            for i in 0..<(array.count - 1) {
+                #expect(array[i] > array[i + 1], "Preset \(preset) should be descending at index \(i)")
+            }
+        }
+    }
+
+    @Test("All presets have display names")
+    func presetsHaveDisplayNames() {
+        for preset in OCVPreset.allCases {
+            #expect(!preset.displayName.isEmpty, "Preset \(preset) should have a display name")
+        }
+    }
+
+    @Test("Selectable presets excludes custom")
+    func selectablePresetsExcludesCustom() {
+        #expect(!OCVPreset.selectablePresets.contains(.custom))
+        #expect(OCVPreset.selectablePresets.count == OCVPreset.allCases.count - 1)
+    }
+
+    @Test("Li-Ion preset has expected values")
+    func liIonPresetValues() {
+        let expected = [4190, 4050, 3990, 3890, 3800, 3720, 3630, 3530, 3420, 3300, 3100]
+        #expect(OCVPreset.liIon.ocvArray == expected)
+    }
+
+    @Test("WisMesh Tag preset has expected values")
+    func wisMeshTagPresetValues() {
+        let expected = [4240, 4112, 4029, 3970, 3906, 3846, 3824, 3802, 3776, 3650, 3072]
+        #expect(OCVPreset.wisMeshTag.ocvArray == expected)
+    }
+}


### PR DESCRIPTION
## Summary

Replace linear battery percentage calculation with OCV (Open Circuit Voltage) array lookup. Ships 13 presets for common battery chemistries and allows per-device customization in Advanced Settings.

- Add `OCVPreset` enum with 13 presets (Li-Ion, LiFePO4, Lead Acid, Alkaline, NiMH, LTO, Tracker T1000-E, Heltec Pocket 5000/10000, Seeed WIO Tracker, Seeed Solar Node, R1 Neo, WisMesh Tag)
- Add `BatteryCurveSection` with preset picker and editable voltage values
- Add `BatteryCurveChart` component with Swift Charts (dynamic Y axis bounds)
- Persist OCV settings per device (survives reconnect/device switching)
- Add `percentage(using:)` method for interpolated OCV calculation
- Add `DeviceService` with `updateOCVSettings` method

## Test Plan

- [ ] Select different presets and verify chart updates
- [ ] Edit voltage values manually and verify validation
- [ ] Switch devices and verify OCV settings persist per device
- [ ] Verify battery percentage display uses OCV calculation
- [ ] Run unit tests: `OCVPresetTests`, `BatteryPercentageCalculationTests`

Closes #27