### PR TITLE
feat(ChatsListView): add chat filtering with toolbar menu and search scopes

### DIFF
--- a/PocketMesh/Models/ChatFilter.swift
+++ b/PocketMesh/Models/ChatFilter.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Filter options for the Chats list view
+enum ChatFilter: String, CaseIterable, Identifiable {
+    case unread = "Unread"
+    case directMessages = "DMs"
+    case channels = "Channels"
+    case favorites = "Favorites"
+
+    var id: String { rawValue }
+
+    var systemImage: String {
+        switch self {
+        case .unread: return "message.badge"
+        case .directMessages: return "person"
+        case .channels: return "number"
+        case .favorites: return "star"
+        }
+    }
+}

--- a/PocketMesh/Models/Conversation+Filtering.swift
+++ b/PocketMesh/Models/Conversation+Filtering.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+extension Array where Element == Conversation {
+    /// Filters conversations by category and search text
+    /// - Parameters:
+    ///   - filter: Optional filter category (nil = show all)
+    ///   - searchText: Search string to match against display names
+    /// - Returns: Filtered array of conversations
+    func filtered(by filter: ChatFilter?, searchText: String) -> [Conversation] {
+        let categoryFiltered: [Conversation]
+        switch filter {
+        case .none:
+            categoryFiltered = self
+        case .unread:
+            categoryFiltered = self.filter { $0.unreadCount > 0 }
+        case .directMessages:
+            categoryFiltered = self.filter {
+                if case .direct = $0 { return true }
+                return false
+            }
+        case .channels:
+            categoryFiltered = self.filter {
+                if case .channel = $0 { return true }
+                if case .room = $0 { return true }
+                return false
+            }
+        case .favorites:
+            categoryFiltered = self.filter {
+                if case .direct(let contact) = $0 {
+                    return contact.isFavorite
+                }
+                return false
+            }
+        }
+
+        if searchText.isEmpty {
+            return categoryFiltered
+        }
+        return categoryFiltered.filter { conversation in
+            conversation.displayName.localizedStandardContains(searchText)
+        }
+    }
+}

--- a/PocketMeshTests/Models/ConversationFilteringTests.swift
+++ b/PocketMeshTests/Models/ConversationFilteringTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+@testable import PocketMesh
+@testable import PocketMeshServices
+
+final class ConversationFilteringTests: XCTestCase {
+
+    // MARK: - Test Data
+
+    private func makeContact(
+        name: String,
+        isFavorite: Bool = false,
+        unreadCount: Int = 0
+    ) -> ContactDTO {
+        ContactDTO(
+            id: UUID(),
+            deviceID: UUID(),
+            publicKey: Data(repeating: 0, count: 32),
+            name: name,
+            typeRawValue: ContactType.chat.rawValue,
+            flags: 0,
+            outPathLength: 0,
+            outPath: Data(),
+            lastAdvertTimestamp: 0,
+            latitude: 0,
+            longitude: 0,
+            lastModified: 0,
+            nickname: nil,
+            isBlocked: false,
+            isFavorite: isFavorite,
+            isDiscovered: false,
+            lastMessageDate: Date(),
+            unreadCount: unreadCount
+        )
+    }
+
+    private func makeChannel(
+        name: String,
+        unreadCount: Int = 0
+    ) -> ChannelDTO {
+        ChannelDTO(
+            id: UUID(),
+            deviceID: UUID(),
+            index: 1,
+            name: name,
+            secret: Data(repeating: 0, count: 16),
+            isEnabled: true,
+            lastMessageDate: Date(),
+            unreadCount: unreadCount
+        )
+    }
+
+    private func makeRoom(
+        name: String,
+        unreadCount: Int = 0
+    ) -> RemoteNodeSessionDTO {
+        RemoteNodeSessionDTO(
+            id: UUID(),
+            deviceID: UUID(),
+            publicKey: Data(repeating: 0, count: 32),
+            name: name,
+            role: .roomServer,
+            isConnected: true,
+            lastConnectedDate: Date(),
+            unreadCount: unreadCount
+        )
+    }
+
+    // MARK: - Filter Tests
+
+    func testNilFilterShowsAll() {
+        let conversations: [Conversation] = [
+            .direct(makeContact(name: "Alice")),
+            .channel(makeChannel(name: "General")),
+            .room(makeRoom(name: "Room1"))
+        ]
+
+        let result = conversations.filtered(by: nil, searchText: "")
+
+        XCTAssertEqual(result.count, 3)
+    }
+
+    func testFilterByUnread() {
+        let conversations: [Conversation] = [
+            .direct(makeContact(name: "Alice", unreadCount: 5)),
+            .direct(makeContact(name: "Bob", unreadCount: 0)),
+            .channel(makeChannel(name: "General", unreadCount: 2))
+        ]
+
+        let result = conversations.filtered(by: .unread, searchText: "")
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertTrue(result.allSatisfy { $0.unreadCount > 0 })
+    }
+
+    func testFilterByDirectMessages() {
+        let conversations: [Conversation] = [
+            .direct(makeContact(name: "Alice")),
+            .direct(makeContact(name: "Bob")),
+            .channel(makeChannel(name: "General")),
+            .room(makeRoom(name: "Room1"))
+        ]
+
+        let result = conversations.filtered(by: .directMessages, searchText: "")
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertTrue(result.allSatisfy {
+            if case .direct = $0 { return true }
+            return false
+        })
+    }
+
+    func testFilterByChannelsIncludesRooms() {
+        let conversations: [Conversation] = [
+            .direct(makeContact(name: "Alice")),
+            .channel(makeChannel(name: "General")),
+            .room(makeRoom(name: "Room1"))
+        ]
+
+        let result = conversations.filtered(by: .channels, searchText: "")
+
+        XCTAssertEqual(result.count, 2)
+        XCTAssertTrue(result.allSatisfy {
+            if case .channel = $0 { return true }
+            if case .room = $0 { return true }
+            return false
+        })
+    }
+
+    func testFilterByFavorites() {
+        let conversations: [Conversation] = [
+            .direct(makeContact(name: "Alice", isFavorite: true)),
+            .direct(makeContact(name: "Bob", isFavorite: false)),
+            .channel(makeChannel(name: "General"))
+        ]
+
+        let result = conversations.filtered(by: .favorites, searchText: "")
+
+        XCTAssertEqual(result.count, 1)
+        if case .direct(let contact) = result.first {
+            XCTAssertEqual(contact.displayName, "Alice")
+            XCTAssertTrue(contact.isFavorite)
+        } else {
+            XCTFail("Expected direct conversation")
+        }
+    }
+
+    func testSearchWithinFilter() {
+        let conversations: [Conversation] = [
+            .direct(makeContact(name: "Alice", unreadCount: 1)),
+            .direct(makeContact(name: "Bob", unreadCount: 1)),
+            .direct(makeContact(name: "Charlie", unreadCount: 0))
+        ]
+
+        let result = conversations.filtered(by: .unread, searchText: "Ali")
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.displayName, "Alice")
+    }
+
+    func testSearchOnlyWithoutFilter() {
+        let conversations: [Conversation] = [
+            .direct(makeContact(name: "Alice")),
+            .direct(makeContact(name: "Bob")),
+            .channel(makeChannel(name: "Alpha"))
+        ]
+
+        let result = conversations.filtered(by: nil, searchText: "Al")
+
+        XCTAssertEqual(result.count, 2)
+    }
+
+    func testEmptyResultsWhenNoMatch() {
+        let conversations: [Conversation] = [
+            .direct(makeContact(name: "Alice")),
+            .direct(makeContact(name: "Bob"))
+        ]
+
+        let result = conversations.filtered(by: nil, searchText: "Zzzz")
+
+        XCTAssertTrue(result.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- Add toolbar filter menu with Picker for selecting filter type (Unread, DMs, Channels, Favorites)
- Add search scopes that appear as segmented control when search field is focused
- Add dynamic empty states with contextual messages and Clear Filter action
- Add 8 unit tests for filtering logic

## Test Plan

- [x] Toolbar filter menu shows all options with checkmarks
- [x] Filter icon changes from outline to filled when active
- [x] Search scopes appear on search focus and sync with toolbar menu
- [x] Each filter correctly filters conversations
- [x] Empty states show filter-specific messages
- [x] Clear Filter button resets to show all conversations
- [x] All 101 tests pass

Closes #11