### PR TITLE
feat: add battery curve configuration to repeater status

### DIFF
--- a/PocketMesh/Views/Settings/AdvancedSettingsView.swift
+++ b/PocketMesh/Views/Settings/AdvancedSettingsView.swift
@@ -6,6 +6,9 @@ struct AdvancedSettingsView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.dismiss) private var dismiss
 
+    @State private var selectedOCVPreset: OCVPreset = .liIon
+    @State private var ocvValues: [Int] = OCVPreset.liIon.ocvArray
+
     var body: some View {
         NavigationStack {
             List {
@@ -19,12 +22,19 @@ struct AdvancedSettingsView: View {
                 TelemetrySettingsSection()
 
                 // Battery Curve
-                BatteryCurveSection()
+                BatteryCurveSection(
+                    availablePresets: OCVPreset.selectablePresets,
+                    headerText: "Battery Curve",
+                    footerText: "Configure the voltage-to-percentage curve for your device's battery.",
+                    selectedPreset: $selectedOCVPreset,
+                    voltageValues: $ocvValues,
+                    onSave: saveOCVToDevice
+                )
 
                 // Danger Zone
                 DangerZoneSection()
             }
-            .scrollDismissesKeyboard(.immediately)
+            .scrollDismissesKeyboard(.interactively)
             .navigationTitle("Advanced Settings")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -47,11 +57,58 @@ struct AdvancedSettingsView: View {
         .task {
             await refreshDeviceSettings()
         }
+        .task(id: appState.connectedDevice?.id) {
+            loadOCVFromDevice()
+        }
     }
 
     /// Fetch fresh device settings to ensure cache is up-to-date
     private func refreshDeviceSettings() async {
         guard let settingsService = appState.services?.settingsService else { return }
         _ = try? await settingsService.getSelfInfo()
+    }
+
+    private func loadOCVFromDevice() {
+        guard let device = appState.connectedDevice else { return }
+
+        if let presetName = device.ocvPreset {
+            if presetName == OCVPreset.custom.rawValue, let customString = device.customOCVArrayString {
+                let parsed = customString.split(separator: ",")
+                    .compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+                if parsed.count == 11 {
+                    ocvValues = parsed
+                    selectedOCVPreset = .custom
+                    return
+                }
+            }
+            if let preset = OCVPreset(rawValue: presetName) {
+                selectedOCVPreset = preset
+                ocvValues = preset.ocvArray
+                return
+            }
+        }
+
+        selectedOCVPreset = .liIon
+        ocvValues = OCVPreset.liIon.ocvArray
+    }
+
+    private func saveOCVToDevice(preset: OCVPreset, values: [Int]) async {
+        guard let deviceService = appState.services?.deviceService,
+              let deviceID = appState.connectedDevice?.id else { return }
+
+        if preset == .custom {
+            let customString = values.map(String.init).joined(separator: ",")
+            try? await deviceService.updateOCVSettings(
+                deviceID: deviceID,
+                preset: OCVPreset.custom.rawValue,
+                customArray: customString
+            )
+        } else {
+            try? await deviceService.updateOCVSettings(
+                deviceID: deviceID,
+                preset: preset.rawValue,
+                customArray: nil
+            )
+        }
     }
 }

--- a/PocketMeshServices/Sources/PocketMeshServices/Models/OCVPreset.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Models/OCVPreset.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+/// Categories for OCV presets
+public enum OCVPresetCategory: Sendable {
+    /// Generic battery chemistry (Li-Ion, LiFePO4, etc.)
+    case batteryChemistry
+    /// Specific commercial device
+    case deviceSpecific
+}
+
 /// Battery OCV (Open Circuit Voltage) presets for accurate percentage calculation.
 /// Each preset contains 11 millivolt values mapping to 100%, 90%, 80%... 0%.
 ///
@@ -74,8 +82,24 @@ public enum OCVPreset: String, CaseIterable, Codable, Sendable {
         }
     }
 
+    /// The category of this preset
+    public var category: OCVPresetCategory {
+        switch self {
+        case .liIon, .liFePO4, .leadAcid, .alkaline, .niMH, .lto:
+            .batteryChemistry
+        case .trackerT1000E, .heltecPocket5000, .heltecPocket10000,
+             .seeedWioTracker, .seeedSolarNode, .r1Neo, .wisMeshTag, .custom:
+            .deviceSpecific
+        }
+    }
+
     /// All presets except custom (for picker display)
     public static var selectablePresets: [OCVPreset] {
         allCases.filter { $0 != .custom }
+    }
+
+    /// Battery chemistry presets only (excludes device-specific and custom)
+    public static var batteryChemistryPresets: [OCVPreset] {
+        allCases.filter { $0.category == .batteryChemistry }
     }
 }

--- a/PocketMeshServices/Sources/PocketMeshServices/Services/ContactService.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Services/ContactService.swift
@@ -362,6 +362,48 @@ public actor ContactService {
     public func confirmContact(id: UUID) async throws {
         try await dataStore.confirmContact(id: id)
     }
+
+    /// Updates OCV settings for a contact
+    /// - Parameters:
+    ///   - contactID: The contact's ID
+    ///   - preset: The OCV preset name
+    ///   - customArray: Custom OCV array string (for custom preset)
+    public func updateContactOCVSettings(
+        contactID: UUID,
+        preset: String,
+        customArray: String?
+    ) async throws {
+        guard let existing = try await dataStore.fetchContact(id: contactID) else {
+            throw ContactServiceError.contactNotFound
+        }
+
+        let updated = ContactDTO(
+            from: Contact(
+                id: existing.id,
+                deviceID: existing.deviceID,
+                publicKey: existing.publicKey,
+                name: existing.name,
+                typeRawValue: existing.typeRawValue,
+                flags: existing.flags,
+                outPathLength: existing.outPathLength,
+                outPath: existing.outPath,
+                lastAdvertTimestamp: existing.lastAdvertTimestamp,
+                latitude: existing.latitude,
+                longitude: existing.longitude,
+                lastModified: existing.lastModified,
+                nickname: existing.nickname,
+                isBlocked: existing.isBlocked,
+                isFavorite: existing.isFavorite,
+                lastMessageDate: existing.lastMessageDate,
+                unreadCount: existing.unreadCount,
+                isDiscovered: existing.isDiscovered,
+                ocvPreset: preset,
+                customOCVArrayString: customArray
+            )
+        )
+
+        try await dataStore.saveContact(updated)
+    }
 }
 
 // MARK: - ContactServiceProtocol Conformance

--- a/PocketMeshTests/Models/ContactOCVTests.swift
+++ b/PocketMeshTests/Models/ContactOCVTests.swift
@@ -1,0 +1,122 @@
+import Testing
+import Foundation
+@testable import PocketMeshServices
+
+@Suite("Contact OCV Tests")
+struct ContactOCVTests {
+
+    @Test("activeOCVArray returns Li-Ion by default")
+    func activeOCVArrayReturnsLiIonByDefault() {
+        let contact = ContactDTO(
+            id: UUID(),
+            deviceID: UUID(),
+            publicKey: Data(repeating: 0x42, count: 32),
+            name: "Test",
+            typeRawValue: ContactType.repeater.rawValue,
+            flags: 0,
+            outPathLength: -1,
+            outPath: Data(),
+            lastAdvertTimestamp: 0,
+            latitude: 0,
+            longitude: 0,
+            lastModified: 0,
+            nickname: nil,
+            isBlocked: false,
+            isFavorite: false,
+            isDiscovered: false,
+            lastMessageDate: nil,
+            unreadCount: 0,
+            ocvPreset: nil,
+            customOCVArrayString: nil
+        )
+
+        #expect(contact.activeOCVArray == OCVPreset.liIon.ocvArray)
+    }
+
+    @Test("activeOCVArray returns preset array when set")
+    func activeOCVArrayReturnsPresetWhenSet() {
+        let contact = ContactDTO(
+            id: UUID(),
+            deviceID: UUID(),
+            publicKey: Data(repeating: 0x42, count: 32),
+            name: "Test",
+            typeRawValue: ContactType.repeater.rawValue,
+            flags: 0,
+            outPathLength: -1,
+            outPath: Data(),
+            lastAdvertTimestamp: 0,
+            latitude: 0,
+            longitude: 0,
+            lastModified: 0,
+            nickname: nil,
+            isBlocked: false,
+            isFavorite: false,
+            isDiscovered: false,
+            lastMessageDate: nil,
+            unreadCount: 0,
+            ocvPreset: OCVPreset.liFePO4.rawValue,
+            customOCVArrayString: nil
+        )
+
+        #expect(contact.activeOCVArray == OCVPreset.liFePO4.ocvArray)
+    }
+
+    @Test("activeOCVArray returns custom array when valid")
+    func activeOCVArrayReturnsCustomWhenValid() {
+        let customArray = [4200, 4100, 4000, 3900, 3800, 3700, 3600, 3500, 3400, 3300, 3200]
+        let customString = customArray.map(String.init).joined(separator: ",")
+
+        let contact = ContactDTO(
+            id: UUID(),
+            deviceID: UUID(),
+            publicKey: Data(repeating: 0x42, count: 32),
+            name: "Test",
+            typeRawValue: ContactType.repeater.rawValue,
+            flags: 0,
+            outPathLength: -1,
+            outPath: Data(),
+            lastAdvertTimestamp: 0,
+            latitude: 0,
+            longitude: 0,
+            lastModified: 0,
+            nickname: nil,
+            isBlocked: false,
+            isFavorite: false,
+            isDiscovered: false,
+            lastMessageDate: nil,
+            unreadCount: 0,
+            ocvPreset: OCVPreset.custom.rawValue,
+            customOCVArrayString: customString
+        )
+
+        #expect(contact.activeOCVArray == customArray)
+    }
+
+    @Test("activeOCVArray falls back to Li-Ion for invalid custom array")
+    func activeOCVArrayFallsBackForInvalidCustom() {
+        let contact = ContactDTO(
+            id: UUID(),
+            deviceID: UUID(),
+            publicKey: Data(repeating: 0x42, count: 32),
+            name: "Test",
+            typeRawValue: ContactType.repeater.rawValue,
+            flags: 0,
+            outPathLength: -1,
+            outPath: Data(),
+            lastAdvertTimestamp: 0,
+            latitude: 0,
+            longitude: 0,
+            lastModified: 0,
+            nickname: nil,
+            isBlocked: false,
+            isFavorite: false,
+            isDiscovered: false,
+            lastMessageDate: nil,
+            unreadCount: 0,
+            ocvPreset: OCVPreset.custom.rawValue,
+            customOCVArrayString: "invalid"
+        )
+
+        #expect(contact.activeOCVArray == OCVPreset.liIon.ocvArray)
+    }
+}

--- a/PocketMeshTests/Models/OCVPresetTests.swift
+++ b/PocketMeshTests/Models/OCVPresetTests.swift
@@ -45,4 +45,43 @@ struct OCVPresetTests {
         let expected = [4240, 4112, 4029, 3970, 3906, 3846, 3824, 3802, 3776, 3650, 3072]
         #expect(OCVPreset.wisMeshTag.ocvArray == expected)
     }
+
+    // MARK: - Category Tests
+
+    @Test("Battery chemistry presets include only chemistry types")
+    func batteryChemistryPresetsIncludeOnlyChemistryTypes() {
+        let presets = OCVPreset.batteryChemistryPresets
+
+        #expect(presets.contains(.liIon))
+        #expect(presets.contains(.liFePO4))
+        #expect(presets.contains(.leadAcid))
+        #expect(presets.contains(.alkaline))
+        #expect(presets.contains(.niMH))
+        #expect(presets.contains(.lto))
+        #expect(presets.count == 6)
+    }
+
+    @Test("Battery chemistry presets exclude device-specific presets")
+    func batteryChemistryPresetsExcludeDeviceSpecific() {
+        let presets = OCVPreset.batteryChemistryPresets
+
+        #expect(!presets.contains(.trackerT1000E))
+        #expect(!presets.contains(.heltecPocket5000))
+        #expect(!presets.contains(.custom))
+    }
+
+    @Test("Li-Ion is battery chemistry category")
+    func liIonIsBatteryChemistry() {
+        #expect(OCVPreset.liIon.category == .batteryChemistry)
+    }
+
+    @Test("Tracker T1000-E is device specific category")
+    func trackerIsDeviceSpecific() {
+        #expect(OCVPreset.trackerT1000E.category == .deviceSpecific)
+    }
+
+    @Test("Custom is device specific category")
+    func customIsDeviceSpecific() {
+        #expect(OCVPreset.custom.category == .deviceSpecific)
+    }
 }


### PR DESCRIPTION
## Summary
- Add OCV preset picker and voltage value editing for repeaters in the status sheet
- Calculate battery percentage in Status section using configured OCV curve (updates live when curve changes)
- Add keyboard toolbar with Done button for voltage input fields
- Scroll dismisses keyboard interactively (unified with Advanced Settings)
- Refactor BatteryCurveSection to pure UI component with injected data
- Add Contact model properties for per-repeater OCV settings

## Test plan
- [ ] Open repeater status sheet, expand Battery Curve section
- [ ] Select different presets, verify Status battery percentage updates
- [ ] Edit custom voltage values, verify percentage updates
- [ ] Verify Done button appears above keyboard when editing voltages
- [ ] Verify scrolling dismisses keyboard interactively
- [ ] Verify same behavior in Advanced Settings