### PR TITLE
feat(ChatViewModel): immediate message display with serial queue

### DIFF
--- a/PocketMesh/Views/Chats/ChannelChatView.swift
+++ b/PocketMesh/Views/Chats/ChannelChatView.swift
@@ -217,7 +217,6 @@ struct ChannelChatView: View {
             isFocused: $isInputFocused,
             placeholder: channel.isPublicChannel || channel.name.hasPrefix("#") ? "Public Channel" : "Private Channel",
             accentColor: channel.isPublicChannel || channel.name.hasPrefix("#") ? .green : .blue,
-            isSending: viewModel.isSending,
             maxCharacters: maxChannelMessageLength
         ) {
             Task {

--- a/PocketMesh/Views/Chats/ChatView.swift
+++ b/PocketMesh/Views/Chats/ChatView.swift
@@ -240,12 +240,9 @@ struct ChatView: View {
             isFocused: $isInputFocused,
             placeholder: "Private Message",
             accentColor: .blue,
-            isSending: viewModel.isSending,
             maxCharacters: ProtocolLimits.maxDirectMessageLength
         ) {
-            Task {
-                await viewModel.sendMessage()
-            }
+            Task { await viewModel.sendMessage() }
         }
     }
 }

--- a/PocketMesh/Views/Chats/Components/ChatInputBar.swift
+++ b/PocketMesh/Views/Chats/Components/ChatInputBar.swift
@@ -7,7 +7,6 @@ struct ChatInputBar: View {
     @FocusState.Binding var isFocused: Bool
     let placeholder: String
     let accentColor: Color
-    let isSending: Bool
     let maxCharacters: Int
     let onSend: () -> Void
 
@@ -67,7 +66,7 @@ struct ChatInputBar: View {
     private var sendButton: some View {
         if #available(iOS 26.0, *) {
             Button(action: onSend) {
-                Image(systemName: isSending ? "hourglass" : "arrow.up.circle.fill")
+                Image(systemName: "arrow.up.circle.fill")
                     .font(.title2)
                     .foregroundStyle(canSend ? accentColor : .secondary)
             }
@@ -77,7 +76,7 @@ struct ChatInputBar: View {
             .accessibilityHint(sendAccessibilityHint)
         } else {
             Button(action: onSend) {
-                Image(systemName: isSending ? "hourglass" : "arrow.up.circle.fill")
+                Image(systemName: "arrow.up.circle.fill")
                     .font(.title2)
                     .foregroundStyle(canSend ? accentColor : .secondary)
             }
@@ -88,9 +87,7 @@ struct ChatInputBar: View {
     }
 
     private var sendAccessibilityLabel: String {
-        if isSending {
-            return "Sending message"
-        } else if isOverLimit {
+        if isOverLimit {
             return "Message too long"
         } else {
             return "Send message"
@@ -108,7 +105,7 @@ struct ChatInputBar: View {
     }
 
     private var canSend: Bool {
-        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSending && !isOverLimit
+        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isOverLimit
     }
 }
 

--- a/PocketMesh/Views/RemoteNodes/RoomConversationView.swift
+++ b/PocketMesh/Views/RemoteNodes/RoomConversationView.swift
@@ -149,7 +149,6 @@ struct RoomConversationView: View {
             isFocused: $isInputFocused,
             placeholder: "Public Message",
             accentColor: .orange,
-            isSending: viewModel.isSending,
             maxCharacters: ProtocolLimits.maxDirectMessageLength
         ) {
             Task {

--- a/PocketMeshServices/Sources/PocketMeshServices/Services/PersistenceStore.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Services/PersistenceStore.swift
@@ -490,7 +490,10 @@ public actor PersistenceStore: PersistenceStoreProtocol {
         }
         var descriptor = FetchDescriptor(
             predicate: predicate,
-            sortBy: [SortDescriptor(\Message.timestamp, order: .reverse)]
+            sortBy: [
+                SortDescriptor(\Message.timestamp, order: .reverse),
+                SortDescriptor(\Message.createdAt, order: .reverse)
+            ]
         )
         descriptor.fetchLimit = limit
         descriptor.fetchOffset = offset
@@ -508,7 +511,10 @@ public actor PersistenceStore: PersistenceStoreProtocol {
         }
         var descriptor = FetchDescriptor(
             predicate: predicate,
-            sortBy: [SortDescriptor(\Message.timestamp, order: .reverse)]
+            sortBy: [
+                SortDescriptor(\Message.timestamp, order: .reverse),
+                SortDescriptor(\Message.createdAt, order: .reverse)
+            ]
         )
         descriptor.fetchLimit = limit
         descriptor.fetchOffset = offset

--- a/PocketMeshTests/ChatViewModelQueueTests.swift
+++ b/PocketMeshTests/ChatViewModelQueueTests.swift
@@ -1,0 +1,264 @@
+import XCTest
+@testable import PocketMesh
+@testable import PocketMeshServices
+import SwiftData
+import MeshCore
+
+// MARK: - Tests
+
+@MainActor
+final class ChatViewModelQueueTests: XCTestCase {
+
+    var container: ModelContainer!
+    var dataStore: PersistenceStore!
+    var session: MeshCoreSession!
+    var messageService: MessageService!
+
+    override func setUp() async throws {
+        // Create in-memory container
+        container = try PersistenceStore.createContainer(inMemory: true)
+
+        // Create persistence store
+        dataStore = PersistenceStore(modelContainer: container)
+
+        // Create test device
+        let device = Device(
+            publicKey: Data(repeating: 1, count: 32),
+            nodeName: "Test Device"
+        )
+        try container.mainContext.insert(device)
+        try container.mainContext.save()
+
+        // Create mock session
+        let transport = MockTransport()
+        session = MeshCoreSession(transport: transport)
+
+        // Create message service
+        messageService = MessageService(
+            session: session,
+            dataStore: dataStore
+        )
+    }
+
+    override func tearDown() async throws {
+        container = nil
+        dataStore = nil
+        session = nil
+        messageService = nil
+    }
+
+    func testQueueStartsEmpty() {
+        let viewModel = ChatViewModel()
+        XCTAssertEqual(viewModel.sendQueueCount, 0)
+        XCTAssertFalse(viewModel.isProcessingQueue)
+    }
+
+    func testSendMessageClearsInputImmediately() async throws {
+        let viewModel = ChatViewModel()
+        viewModel.configure(dataStore: dataStore, messageService: messageService)
+
+        // Get the device ID
+        let devices = try await dataStore.fetchDevices()
+        guard let device = devices.first else {
+            XCTFail("No device found")
+            return
+        }
+
+        // Create a contact
+        let contact = Contact(
+            deviceID: device.id,
+            publicKey: Data(repeating: 2, count: 32),
+            name: "Test Contact"
+        )
+        try container.mainContext.insert(contact)
+        try container.mainContext.save()
+
+        let contactDTO = try await dataStore.fetchContact(id: contact.id)!
+        viewModel.currentContact = contactDTO
+        viewModel.composingText = "Hello world"
+
+        // Send message
+        await viewModel.sendMessage()
+
+        // Input should be cleared
+        XCTAssertTrue(viewModel.composingText.isEmpty)
+        XCTAssertEqual(viewModel.sendQueueCount, 1)
+    }
+
+    func testProcessQueueSendsMessagesInOrder() async throws {
+        let viewModel = ChatViewModel()
+        viewModel.configure(dataStore: dataStore, messageService: messageService)
+
+        // Get the device ID
+        let devices = try await dataStore.fetchDevices()
+        guard let device = devices.first else {
+            XCTFail("No device found")
+            return
+        }
+
+        // Create a contact
+        let contact = Contact(
+            deviceID: device.id,
+            publicKey: Data(repeating: 2, count: 32),
+            name: "Test Contact"
+        )
+        try container.mainContext.insert(contact)
+        try container.mainContext.save()
+
+        let contactDTO = try await dataStore.fetchContact(id: contact.id)!
+        viewModel.currentContact = contactDTO
+
+        // Create messages in DB first
+        let msg1 = try await messageService.createPendingMessage(text: "First", to: contactDTO)
+        let msg2 = try await messageService.createPendingMessage(text: "Second", to: contactDTO)
+        let msg3 = try await messageService.createPendingMessage(text: "Third", to: contactDTO)
+
+        // Queue message IDs for sending
+        viewModel.enqueueMessage(msg1.id, contactID: contact.id)
+        viewModel.enqueueMessage(msg2.id, contactID: contact.id)
+        viewModel.enqueueMessage(msg3.id, contactID: contact.id)
+
+        XCTAssertEqual(viewModel.sendQueueCount, 3)
+
+        // Process the queue
+        await viewModel.processQueueForTesting()
+
+        // Verify queue is empty and processing is done
+        XCTAssertEqual(viewModel.sendQueueCount, 0)
+        XCTAssertFalse(viewModel.isProcessingQueue)
+
+        // Verify messages were saved (fetchMessages returns newest first)
+        let messages = try await dataStore.fetchMessages(contactID: contact.id)
+        XCTAssertEqual(messages.count, 3)
+        XCTAssertEqual(messages[2].text, "First")
+        XCTAssertEqual(messages[1].text, "Second")
+        XCTAssertEqual(messages[0].text, "Third")
+    }
+
+    func testQueueContinuesAfterFailure() async throws {
+        // This test verifies that when one message fails, the queue continues
+        // processing remaining messages. With real services, we verify the queue
+        // processes all messages and ends in a clean state. The error handling
+        // behavior is implemented in processQueue() - the catch block sets
+        // errorMessage but doesn't break out of the loop.
+
+        let viewModel = ChatViewModel()
+        viewModel.configure(dataStore: dataStore, messageService: messageService)
+
+        // Get the device ID
+        let devices = try await dataStore.fetchDevices()
+        guard let device = devices.first else {
+            XCTFail("No device found")
+            return
+        }
+
+        // Create a contact
+        let contact = Contact(
+            deviceID: device.id,
+            publicKey: Data(repeating: 2, count: 32),
+            name: "Test Contact"
+        )
+        try container.mainContext.insert(contact)
+        try container.mainContext.save()
+
+        let contactDTO = try await dataStore.fetchContact(id: contact.id)!
+        viewModel.currentContact = contactDTO
+
+        // Create messages in DB first
+        let msg1 = try await messageService.createPendingMessage(text: "First", to: contactDTO)
+        let msg2 = try await messageService.createPendingMessage(text: "Second", to: contactDTO)
+        let msg3 = try await messageService.createPendingMessage(text: "Third", to: contactDTO)
+
+        // Queue message IDs for sending
+        viewModel.enqueueMessage(msg1.id, contactID: contact.id)
+        viewModel.enqueueMessage(msg2.id, contactID: contact.id)
+        viewModel.enqueueMessage(msg3.id, contactID: contact.id)
+
+        // Process the queue
+        await viewModel.processQueueForTesting()
+
+        // Verify all messages were attempted (queue is empty)
+        XCTAssertEqual(viewModel.sendQueueCount, 0)
+        XCTAssertFalse(viewModel.isProcessingQueue)
+    }
+
+    func testMessagesGoToCorrectContactEvenAfterNavigatingAway() async throws {
+        let viewModel = ChatViewModel()
+        viewModel.configure(dataStore: dataStore, messageService: messageService)
+
+        // Get the device ID
+        let devices = try await dataStore.fetchDevices()
+        guard let device = devices.first else {
+            XCTFail("No device found")
+            return
+        }
+
+        // Create two contacts: Alice and Bob
+        let alice = Contact(
+            deviceID: device.id,
+            publicKey: Data(repeating: 2, count: 32),
+            name: "Alice"
+        )
+        let bob = Contact(
+            deviceID: device.id,
+            publicKey: Data(repeating: 3, count: 32),
+            name: "Bob"
+        )
+        try container.mainContext.insert(alice)
+        try container.mainContext.insert(bob)
+        try container.mainContext.save()
+
+        let aliceDTO = try await dataStore.fetchContact(id: alice.id)!
+        let bobDTO = try await dataStore.fetchContact(id: bob.id)!
+
+        // User is chatting with Alice
+        viewModel.currentContact = aliceDTO
+
+        // Create messages for Alice in DB first
+        let msg1 = try await messageService.createPendingMessage(text: "Hello Alice", to: aliceDTO)
+        let msg2 = try await messageService.createPendingMessage(text: "How are you?", to: aliceDTO)
+
+        // Queue message IDs for sending
+        viewModel.enqueueMessage(msg1.id, contactID: alice.id)
+        viewModel.enqueueMessage(msg2.id, contactID: alice.id)
+
+        // User navigates to Bob's chat before queue finishes
+        viewModel.currentContact = bobDTO
+
+        // Process the queue
+        await viewModel.processQueueForTesting()
+
+        // Verify messages went to Alice, not Bob (fetchMessages returns newest first)
+        let aliceMessages = try await dataStore.fetchMessages(contactID: alice.id)
+        let bobMessages = try await dataStore.fetchMessages(contactID: bob.id)
+
+        XCTAssertEqual(aliceMessages.count, 2, "Messages should go to Alice")
+        XCTAssertEqual(aliceMessages[1].text, "Hello Alice")
+        XCTAssertEqual(aliceMessages[0].text, "How are you?")
+        XCTAssertEqual(bobMessages.count, 0, "Bob should have no messages")
+    }
+}
+
+// MARK: - Mock Transport
+
+actor MockTransport: MeshTransport {
+    func connect() async throws {
+        // No-op for testing
+    }
+
+    func disconnect() async {
+        // No-op for testing
+    }
+
+    func send(_ data: Data) async throws {
+        // No-op for testing
+    }
+
+    var receivedData: AsyncStream<Data> {
+        AsyncStream { _ in }
+    }
+
+    var isConnected: Bool {
+        true
+    }
+}


### PR DESCRIPTION
## Summary

- Messages now appear instantly when user taps Send
- Background queue processes sends serially (no change to delivery behavior)
- Fixes race condition where rapid navigation could send messages to wrong contact
- Preserves message order for rapid sends via secondary sort on createdAt

## Problem

Previously, when sending messages rapidly:
1. Message 1 is created, shown, and sent (waits for ACK ~500ms)
2. Message 2 waits for message 1 to finish before being created/shown
3. Result: The last message appears ~1 second late

## Solution

Decouple message creation from message sending:
1. `sendMessage()` creates message in DB immediately and displays it
2. Queue stores message IDs (not text)
3. `processQueue()` sends existing messages serially in background

## Changes

| File | Change |
|------|--------|
| `MessageService.swift` | Add `createPendingMessage` and `sendExistingMessage` |
| `ChatViewModel.swift` | Immediate message creation, queue stores messageID |
| `ChatView.swift` | Update caller to async |
| `PersistenceStore.swift` | Add createdAt as secondary sort tiebreaker |
| `ChatViewModelQueueTests.swift` | New test file with queue tests |

## Test plan

- [x] 118 tests pass
- [ ] Manual: Send single message, verify instant display → status updates
- [ ] Manual: Send 3 messages rapidly, verify all appear instantly in order
- [ ] Manual: Navigate away during send, verify messages still deliver correctly