### PR TITLE
Implement synchronous CLI command-response pattern for Repeater Settings

### DIFF
--- a/MeshCore/Package.resolved
+++ b/MeshCore/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "7102575be6b54dd064d1c7542a11ed3c6eb83fc995eabb3306cebbe2205adfa3",
+  "originHash" : "d466adc75c7bf0e594b3268717c8e1c7990bcfa7b2851845b5972faca919e01e",
   "pins" : [
+    {
+      "identity" : "datascoutcompanion",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/alex566/DataScoutCompanion.git",
+      "state" : {
+        "revision" : "3f98e91e4eba308331d6aa6fbe21ad2a92b20d8a",
+        "version" : "0.3.0"
+      }
+    },
     {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",

--- a/PocketMesh/Views/Components/ExpandableSettingsSection.swift
+++ b/PocketMesh/Views/Components/ExpandableSettingsSection.swift
@@ -17,18 +17,12 @@ struct ExpandableSettingsSection<Content: View>: View {
     var body: some View {
         Section {
             DisclosureGroup(isExpanded: $isExpanded) {
-                // Priority: Show content as soon as ANY data is available
-                // This ensures partial data displays immediately while other queries complete
-                if isLoaded() {
-                    content()
-                } else if isLoading {
-                    HStack {
-                        Spacer()
-                        ProgressView("Loading...")
-                        Spacer()
-                    }
-                    .padding(.vertical, 8)
-                } else if let error {
+                // Always show content - individual fields handle nil/loading states
+                // with "loading..." overlays when their values haven't arrived yet
+                content()
+
+                // Show error banner if something failed
+                if let error, !isLoaded() {
                     VStack(spacing: 12) {
                         Label("Failed to load", systemImage: "exclamationmark.triangle")
                             .foregroundStyle(.red)
@@ -41,19 +35,16 @@ struct ExpandableSettingsSection<Content: View>: View {
                         .buttonStyle(.bordered)
                     }
                     .padding(.vertical, 8)
-                } else {
-                    // Should auto-load, but show placeholder if not
-                    HStack {
-                        Spacer()
-                        ProgressView()
-                        Spacer()
-                    }
                 }
             } label: {
                 HStack {
                     Label(title, systemImage: icon)
                     Spacer()
-                    if isLoaded() && !isLoading {
+                    if isLoading {
+                        ProgressView()
+                            .scaleEffect(0.8)
+                            .padding(.trailing)
+                    } else if isLoaded() {
                         Button {
                             Task { await onLoad() }
                         } label: {


### PR DESCRIPTION
## Summary

- Replace fragile FIFO response matching with AsyncStream-based synchronous command-response
- Each CLI command now waits for its specific response before proceeding, fixing race conditions
- Add response validation to discard late/mismatched responses from previous commands
- Convert advert interval controls from Stepper to keyboard entry with validation
- Add success checkmark animation to Apply buttons (matching Advanced Settings pattern)
- Various UI polish improvements

## Test plan

- [ ] Open Repeater Settings and expand each section - verify data loads correctly
- [ ] Modify behavior settings and tap Apply - verify checkmark animation appears
- [ ] Verify Apply button is disabled after successful apply until values change
- [ ] Test advert interval validation (0-hop: 0 or 60-240, flood: 3-48)
- [ ] Rapidly expand/collapse sections to verify no response misrouting