### PR TITLE
feat: Add Trace Path network diagnostic feature

### DIFF
--- a/PocketMesh/Views/Contacts/ContactsListView.swift
+++ b/PocketMesh/Views/Contacts/ContactsListView.swift
@@ -67,6 +67,12 @@ struct ContactsListView: View {
                             Label("Discovery", systemImage: "antenna.radiowaves.left.and.right")
                         }
 
+                        NavigationLink {
+                            TracePathView()
+                        } label: {
+                            Label("Trace Path", systemImage: "point.3.connected.trianglepath.dotted")
+                        }
+
                         Divider()
 
                         Button {

--- a/PocketMesh/Views/Contacts/TracePathView.swift
+++ b/PocketMesh/Views/Contacts/TracePathView.swift
@@ -1,0 +1,302 @@
+import SwiftUI
+import PocketMeshServices
+
+/// View for building and executing network path traces
+struct TracePathView: View {
+    @Environment(AppState.self) private var appState
+    @State private var viewModel = TracePathViewModel()
+    @State private var editMode: EditMode = .inactive
+
+    // Haptic feedback triggers
+    @State private var addHapticTrigger = 0
+    @State private var dragHapticTrigger = 0
+    @State private var copyHapticTrigger = 0
+
+    var body: some View {
+        List {
+            headerSection
+            outboundPathSection
+            availableRepeatersSection
+            if viewModel.result != nil {
+                resultsSection
+            }
+        }
+        .navigationTitle("Trace Path")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                EditButton()
+            }
+        }
+        .environment(\.editMode, $editMode)
+        .safeAreaInset(edge: .bottom) {
+            runTraceButton
+        }
+        .sensoryFeedback(.impact(weight: .light), trigger: addHapticTrigger)
+        .sensoryFeedback(.impact(weight: .light), trigger: dragHapticTrigger)
+        .sensoryFeedback(.success, trigger: copyHapticTrigger)
+        .task {
+            viewModel.configure(appState: appState)
+            viewModel.startListening()
+            if let deviceID = appState.connectedDevice?.id {
+                await viewModel.loadContacts(deviceID: deviceID)
+            }
+        }
+        .onDisappear {
+            viewModel.stopListening()
+        }
+    }
+
+    // MARK: - Header Section
+
+    private var headerSection: some View {
+        Section {
+            Label {
+                Text("Build a path through repeaters. Return path is added automatically.")
+            } icon: {
+                Image(systemName: "info.circle")
+                    .foregroundStyle(.blue)
+            }
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Outbound Path Section
+
+    private var outboundPathSection: some View {
+        Section {
+            if viewModel.outboundPath.isEmpty {
+                Text("Tap a repeater below to start building your path")
+                    .foregroundStyle(.secondary)
+                    .frame(minHeight: 44)
+            } else {
+                ForEach(viewModel.outboundPath) { hop in
+                    TracePathHopRow(hop: hop)
+                }
+                .onMove { source, destination in
+                    dragHapticTrigger += 1
+                    viewModel.moveRepeater(from: source, to: destination)
+                }
+                .onDelete { indexSet in
+                    for index in indexSet.sorted().reversed() {
+                        viewModel.removeRepeater(at: index)
+                    }
+                }
+                .animation(.default, value: viewModel.outboundPath.map(\.id))
+
+                // Full path display with copy button
+                HStack {
+                    Text(viewModel.fullPathString)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    Button("Copy Path", systemImage: "doc.on.doc") {
+                        copyHapticTrigger += 1
+                        viewModel.copyPathToClipboard()
+                    }
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.borderless)
+                }
+            }
+        } header: {
+            Text("Outbound Path")
+        } footer: {
+            if !viewModel.outboundPath.isEmpty {
+                if editMode == .active {
+                    Text("Drag to reorder. Swipe to remove.")
+                } else {
+                    Text("Tap Edit to reorder or remove hops.")
+                }
+            }
+        }
+    }
+
+    // MARK: - Available Repeaters Section
+
+    private var availableRepeatersSection: some View {
+        Section {
+            if viewModel.availableRepeaters.isEmpty {
+                ContentUnavailableView(
+                    "No Repeaters Available",
+                    systemImage: "antenna.radiowaves.left.and.right.slash",
+                    description: Text("Repeaters appear here once they're discovered in your mesh network.")
+                )
+            } else {
+                ForEach(viewModel.availableRepeaters) { repeater in
+                    Button {
+                        addHapticTrigger += 1
+                        viewModel.addRepeater(repeater)
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading) {
+                                Text(repeater.displayName)
+                                Text(String(format: "%02X", repeater.publicKey[0]))
+                                    .font(.caption.monospaced())
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Image(systemName: "plus.circle")
+                                .foregroundStyle(.tint)
+                        }
+                    }
+                    .foregroundStyle(.primary)
+                    .accessibilityLabel("Add \(repeater.displayName) to path")
+                }
+            }
+        } header: {
+            Text("Available Repeaters")
+        }
+    }
+
+    // MARK: - Results Section
+
+    private var resultsSection: some View {
+        Section {
+            if let result = viewModel.result {
+                if result.success {
+                    ForEach(result.hops) { hop in
+                        TraceResultHopRow(hop: hop)
+                    }
+
+                    // Duration row
+                    HStack {
+                        Text("Round Trip")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text("\(result.durationMs) ms")
+                            .font(.body.monospacedDigit())
+                    }
+                } else if let error = result.errorMessage {
+                    Label(error, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.orange)
+                }
+            }
+        } header: {
+            Text("Trace Results")
+        }
+    }
+
+    // MARK: - Run Trace Button
+
+    private var runTraceButton: some View {
+        VStack {
+            Button {
+                Task {
+                    await viewModel.runTrace()
+                }
+            } label: {
+                HStack {
+                    if viewModel.isRunning {
+                        ProgressView()
+                            .tint(.white)
+                    } else {
+                        Text("Run Trace")
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .modifier(GlassProminentButtonStyle())
+            .disabled(!viewModel.canRunTrace)
+        }
+        .padding()
+    }
+}
+
+// MARK: - iOS 26 Liquid Glass Support
+
+/// Applies `.glassProminent` on iOS 26+, falls back to `.borderedProminent` on earlier versions
+private struct GlassProminentButtonStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.buttonStyle(.glassProminent)
+        } else {
+            content.buttonStyle(.borderedProminent)
+        }
+    }
+}
+
+// MARK: - Path Hop Row
+
+/// Row for displaying a hop in the path building section
+private struct TracePathHopRow: View {
+    let hop: PathHop
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            if let name = hop.resolvedName {
+                Text(name)
+                Text(String(format: "%02X", hop.hashByte))
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+            } else {
+                Text(String(format: "%02X", hop.hashByte))
+                    .font(.body.monospaced())
+            }
+        }
+        .frame(minHeight: 44)
+    }
+}
+
+// MARK: - Result Hop Row
+
+/// Row for displaying a hop in the trace results
+private struct TraceResultHopRow: View {
+    let hop: TraceHop
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                // Node identifier
+                if hop.isStartNode {
+                    Label(hop.resolvedName ?? "My Device", systemImage: "iphone")
+                        .font(.body)
+                    Text("Started trace")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else if hop.isEndNode {
+                    Label(hop.resolvedName ?? "My Device", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Text("Received response")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else if let hashByte = hop.hashByte {
+                    HStack {
+                        Text(String(format: "%02X", hashByte))
+                            .font(.body.monospaced())
+                        if let name = hop.resolvedName {
+                            Text(name)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    Text("Repeated")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                // SNR display (not for end node)
+                if !hop.isEndNode {
+                    Text("SNR: \(hop.snr, format: .number.precision(.fractionLength(2))) dB")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Duration shown below")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            // Signal strength indicator (not for end node)
+            if !hop.isEndNode {
+                Image(systemName: "cellularbars", variableValue: hop.signalLevel)
+                    .foregroundStyle(hop.signalColor)
+                    .font(.title2)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/PocketMesh/Views/Contacts/TracePathViewModel.swift
+++ b/PocketMesh/Views/Contacts/TracePathViewModel.swift
@@ -1,0 +1,296 @@
+import Combine
+import SwiftUI
+import UIKit
+import MeshCore
+import PocketMeshServices
+import os.log
+
+private let logger = Logger(subsystem: "com.pocketmesh", category: "TracePath")
+
+/// Represents a single hop in a trace result
+struct TraceHop: Identifiable {
+    let id = UUID()
+    let hashByte: UInt8?          // nil for start/end node (local device)
+    let resolvedName: String?     // From contacts lookup
+    let snr: Double
+    let isStartNode: Bool
+    let isEndNode: Bool
+
+    var signalLevel: Double {
+        // Map SNR to 0-1 range for cellularbars variableValue
+        if snr >= 5 { return 1.0 }
+        if snr >= -5 { return 0.66 }
+        return 0.33
+    }
+
+    var signalColor: Color {
+        if snr >= 5 { return .green }
+        if snr >= -5 { return .yellow }
+        return .red
+    }
+}
+
+/// Result of a trace operation
+struct TraceResult {
+    let hops: [TraceHop]
+    let durationMs: Int
+    let success: Bool
+    let errorMessage: String?
+
+    static func timeout() -> TraceResult {
+        TraceResult(hops: [], durationMs: 0, success: false, errorMessage: "No response received")
+    }
+
+    static func sendFailed(_ message: String) -> TraceResult {
+        TraceResult(hops: [], durationMs: 0, success: false, errorMessage: message)
+    }
+}
+
+@MainActor @Observable
+final class TracePathViewModel {
+
+    // MARK: - Path Building State
+
+    var outboundPath: [PathHop] = []
+    var availableRepeaters: [ContactDTO] = []
+    private var allContacts: [ContactDTO] = []
+
+    // MARK: - Execution State
+
+    var isRunning = false
+    var result: TraceResult?
+
+    // MARK: - Trace Correlation
+
+    private var pendingTag: UInt32?
+    private var traceStartTime: Date?
+    private var traceTask: Task<Void, Never>?
+
+    // MARK: - Event Subscription
+
+    private var cancellables = Set<AnyCancellable>()
+
+    /// Start listening for trace responses
+    func startListening() {
+        NotificationCenter.default.publisher(for: .traceDataReceived)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                guard let traceInfo = notification.userInfo?["traceInfo"] as? TraceInfo else { return }
+                self?.handleTraceResponse(traceInfo)
+            }
+            .store(in: &cancellables)
+    }
+
+    /// Stop listening for trace responses
+    func stopListening() {
+        cancellables.removeAll()
+    }
+
+    // MARK: - Dependencies
+
+    private var appState: AppState?
+
+    // MARK: - Computed Properties
+
+    /// Full path: outbound + mirrored return (minus last hop to avoid duplicate)
+    var fullPathBytes: [UInt8] {
+        let outbound = outboundPath.map { $0.hashByte }
+        guard !outbound.isEmpty else { return [] }
+        let returnPath = outbound.reversed().dropFirst()
+        return outbound + returnPath
+    }
+
+    /// Comma-separated path string for display/copy
+    var fullPathString: String {
+        fullPathBytes.map { String(format: "%02X", $0) }.joined(separator: ",")
+    }
+
+    /// Can run trace if path has at least one hop and device connected
+    var canRunTrace: Bool {
+        !outboundPath.isEmpty && appState?.connectedDevice != nil && !isRunning
+    }
+
+    // MARK: - Configuration
+
+    func configure(appState: AppState) {
+        self.appState = appState
+    }
+
+    // MARK: - Name Resolution
+
+    /// Resolve a hash byte to contact name (single match only)
+    func resolveHashToName(_ hashByte: UInt8) -> String? {
+        let matches = allContacts.filter { $0.publicKey.first == hashByte }
+        return matches.count == 1 ? matches[0].displayName : nil
+    }
+
+    // MARK: - Data Loading
+
+    /// Load contacts for name resolution and available repeaters
+    func loadContacts(deviceID: UUID) async {
+        guard let appState,
+              let dataStore = appState.services?.dataStore else { return }
+        do {
+            let contacts = try await dataStore.fetchContacts(deviceID: deviceID)
+            allContacts = contacts
+            availableRepeaters = contacts.filter { $0.type == .repeater }
+        } catch {
+            logger.error("Failed to load contacts: \(error.localizedDescription)")
+            allContacts = []
+            availableRepeaters = []
+        }
+    }
+
+    // MARK: - Path Manipulation
+
+    /// Add a repeater to the outbound path
+    func addRepeater(_ repeater: ContactDTO) {
+        let hashByte = repeater.publicKey[0]
+        let hop = PathHop(hashByte: hashByte, resolvedName: repeater.displayName)
+        outboundPath.append(hop)
+    }
+
+    /// Remove a repeater from the path
+    func removeRepeater(at index: Int) {
+        guard outboundPath.indices.contains(index) else { return }
+        outboundPath.remove(at: index)
+    }
+
+    /// Move a repeater within the path
+    func moveRepeater(from source: IndexSet, to destination: Int) {
+        outboundPath.move(fromOffsets: source, toOffset: destination)
+    }
+
+    /// Copy full path string to clipboard
+    func copyPathToClipboard() {
+        UIPasteboard.general.string = fullPathString
+    }
+
+    // MARK: - Trace Execution
+
+    /// Execute the trace and wait for response
+    func runTrace() async {
+        guard let appState,
+              let session = appState.services?.session,
+              !outboundPath.isEmpty else { return }
+
+        // Cancel any pending trace
+        traceTask?.cancel()
+
+        isRunning = true
+        result = nil
+
+        // Generate random tag for correlation
+        let tag = UInt32.random(in: 0...UInt32.max)
+        pendingTag = tag
+        traceStartTime = Date()
+
+        // Build path data
+        let pathData = Data(fullPathBytes)
+
+        // Send trace command
+        do {
+            _ = try await session.sendTrace(
+                tag: tag,
+                authCode: 0,  // Not used for basic trace
+                flags: 0,
+                path: pathData
+            )
+            logger.info("Sent trace with tag \(tag), path: \(self.fullPathString)")
+        } catch {
+            logger.error("Failed to send trace: \(error.localizedDescription)")
+            result = .sendFailed("Failed to send trace packet")
+            isRunning = false
+            pendingTag = nil
+            return
+        }
+
+        // Wait for response with timeout
+        traceTask = Task { @MainActor in
+            do {
+                try await Task.sleep(for: .seconds(15))
+
+                // Timeout - no response received
+                if !Task.isCancelled && pendingTag == tag {
+                    logger.warning("Trace timeout for tag \(tag)")
+                    result = .timeout()
+                    isRunning = false
+                    pendingTag = nil
+                }
+            } catch {
+                // Task cancelled (response received)
+            }
+        }
+    }
+
+    /// Handle trace response from event stream
+    func handleTraceResponse(_ traceInfo: TraceInfo) {
+        guard traceInfo.tag == pendingTag else {
+            logger.debug("Ignoring trace response with non-matching tag \(traceInfo.tag)")
+            return
+        }
+
+        // Cancel timeout
+        traceTask?.cancel()
+        traceTask = nil
+
+        // Calculate duration
+        let durationMs: Int
+        if let startTime = traceStartTime {
+            durationMs = Int(Date().timeIntervalSince(startTime) * 1000)
+        } else {
+            durationMs = 0
+        }
+
+        // Build hops from response
+        var hops: [TraceHop] = []
+
+        // Start node (local device)
+        if let firstNode = traceInfo.path.first {
+            hops.append(TraceHop(
+                hashByte: nil,
+                resolvedName: appState?.connectedDevice?.nodeName ?? "My Device",
+                snr: firstNode.snr,
+                isStartNode: true,
+                isEndNode: false
+            ))
+        }
+
+        // Intermediate hops
+        for node in traceInfo.path.dropFirst().dropLast() {
+            let hashByte = node.hash
+            let resolvedName = hashByte.flatMap { resolveHashToName($0) }
+            hops.append(TraceHop(
+                hashByte: hashByte,
+                resolvedName: resolvedName,
+                snr: node.snr,
+                isStartNode: false,
+                isEndNode: false
+            ))
+        }
+
+        // End node (response received back)
+        if traceInfo.path.count > 1, let lastNode = traceInfo.path.last {
+            hops.append(TraceHop(
+                hashByte: nil,
+                resolvedName: appState?.connectedDevice?.nodeName ?? "My Device",
+                snr: lastNode.snr,
+                isStartNode: false,
+                isEndNode: true
+            ))
+        }
+
+        result = TraceResult(
+            hops: hops,
+            durationMs: durationMs,
+            success: true,
+            errorMessage: nil
+        )
+
+        isRunning = false
+        pendingTag = nil
+        traceStartTime = nil
+
+        logger.info("Trace completed: \(hops.count) hops, \(durationMs)ms")
+    }
+}

--- a/PocketMeshServices/Sources/PocketMeshServices/Extensions/Notification+Extensions.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Extensions/Notification+Extensions.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public extension Notification.Name {
+    static let traceDataReceived = Notification.Name("traceDataReceived")
+}

--- a/PocketMeshServices/Sources/PocketMeshServices/Services/AdvertisementService.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Services/AdvertisementService.swift
@@ -146,6 +146,9 @@ public actor AdvertisementService {
         case .pathResponse(let result):
             await handlePathDiscoveryResponse(result: result, deviceID: deviceID)
 
+        case .traceData(let traceInfo):
+            await handleTraceData(traceInfo: traceInfo, deviceID: deviceID)
+
         default:
             break
         }
@@ -315,6 +318,19 @@ public actor AdvertisementService {
             pathDiscoveryHandler?(result)
         } catch {
             logger.error("Error handling path discovery response: \(error.localizedDescription)")
+        }
+    }
+
+    /// Handle trace data response
+    private func handleTraceData(traceInfo: TraceInfo, deviceID: UUID) async {
+        logger.info("Received trace data: tag=\(traceInfo.tag), hops=\(traceInfo.path.count)")
+        // Post notification for ViewModel to handle
+        await MainActor.run {
+            NotificationCenter.default.post(
+                name: .traceDataReceived,
+                object: nil,
+                userInfo: ["traceInfo": traceInfo, "deviceID": deviceID]
+            )
         }
     }
 }


### PR DESCRIPTION
Closes #55

## Summary

- Add Trace Path feature for network diagnostics via Contacts tab menu
- Build paths through repeaters with drag-to-reorder support
- Display per-hop SNR with signal strength indicators
- Auto-mirror return path for round-trip traces
- iOS 26 Liquid Glass button style with iOS 18 fallback

## Test Plan

- [x] Open Contacts tab → Menu → Trace Path
- [x] Add repeaters to path, verify drag reorder works
- [ ] Run trace with connected device, verify results display
- [x] Test copy path to clipboard
- [x] Verify timeout handling (15s)
- [ ] Test on iOS 18 simulator for fallback button style