### PR TITLE
feat: Add Saved Trace Paths feature

### DIFF
--- a/PocketMesh/Extensions/UInt8+Hex.swift
+++ b/PocketMesh/Extensions/UInt8+Hex.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension UInt8 {
+    /// Two-character uppercase hex string (e.g., "0A", "FF")
+    var hexString: String {
+        let hex = String(self, radix: 16, uppercase: true)
+        return hex.count < 2 ? "0" + hex : hex
+    }
+}

--- a/PocketMesh/Views/Contacts/SavedPathDetailView.swift
+++ b/PocketMesh/Views/Contacts/SavedPathDetailView.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+import Charts
+import PocketMeshServices
+
+struct SavedPathDetailView: View {
+    @Environment(AppState.self) private var appState
+    @State private var viewModel: SavedPathDetailViewModel
+
+    init(savedPath: SavedTracePathDTO) {
+        _viewModel = State(initialValue: SavedPathDetailViewModel(savedPath: savedPath))
+    }
+
+    var body: some View {
+        List {
+            pathSection
+            performanceSection
+            historySection
+        }
+        .navigationTitle(viewModel.savedPath.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            viewModel.configure(appState: appState)
+        }
+        .refreshable {
+            await viewModel.refresh()
+        }
+    }
+
+    // MARK: - Path Section
+
+    private var pathSection: some View {
+        Section("Path") {
+            PathChipsView(pathBytes: viewModel.savedPath.pathHashBytes)
+        }
+    }
+
+    // MARK: - Performance Section
+
+    private var performanceSection: some View {
+        Section("Performance") {
+            // Chart
+            if viewModel.successfulRuns.count >= 2 {
+                Chart(viewModel.successfulRuns) { run in
+                    LineMark(
+                        x: .value("Date", run.date),
+                        y: .value("RTT", run.roundTripMs)
+                    )
+                    .foregroundStyle(.blue)
+
+                    PointMark(
+                        x: .value("Date", run.date),
+                        y: .value("RTT", run.roundTripMs)
+                    )
+                    .foregroundStyle(.blue)
+                }
+                .frame(height: 150)
+                .chartYAxisLabel("Round Trip (ms)")
+            }
+
+            // Summary stats
+            HStack {
+                StatView(label: "Avg", value: viewModel.averageRoundTrip.map { "\($0) ms" } ?? "-")
+                Divider()
+                StatView(label: "Best", value: viewModel.bestRoundTrip.map { "\($0) ms" } ?? "-")
+                Divider()
+                StatView(label: "Success", value: viewModel.successRateText)
+            }
+            .frame(height: 50)
+        }
+    }
+
+    // MARK: - History Section
+
+    private var historySection: some View {
+        Section("History") {
+            ForEach(viewModel.sortedRuns) { run in
+                NavigationLink {
+                    RunDetailView(run: run)
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(run.date.formatted(date: .abbreviated, time: .shortened))
+                            if run.success {
+                                Text("\(run.roundTripMs) ms")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+
+                        Spacer()
+
+                        if !run.success {
+                            Text("Failed")
+                                .font(.caption)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(.red.opacity(0.2), in: .capsule)
+                                .foregroundStyle(.red)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Supporting Views
+
+private struct PathChipsView: View {
+    let pathBytes: [UInt8]
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack(spacing: 4) {
+                ForEach(Array(pathBytes.enumerated()), id: \.offset) { index, byte in
+                    if index > 0 {
+                        Image(systemName: "arrow.right")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Text(byte.hexString)
+                        .font(.caption.monospaced())
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(.fill.tertiary, in: .capsule)
+                }
+            }
+        }
+        .scrollIndicators(.hidden)
+    }
+}
+
+private struct StatView: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack {
+            Text(value)
+                .font(.headline.monospacedDigit())
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+private struct RunDetailView: View {
+    let run: TracePathRunDTO
+
+    var body: some View {
+        List {
+            Section("Overview") {
+                LabeledContent("Date", value: run.date.formatted())
+                LabeledContent("Round Trip", value: "\(run.roundTripMs) ms")
+                LabeledContent("Status", value: run.success ? "Success" : "Failed")
+            }
+
+            if run.success && !run.hopsSNR.isEmpty {
+                Section("Per-Hop SNR") {
+                    ForEach(Array(run.hopsSNR.enumerated()), id: \.offset) { index, snr in
+                        LabeledContent("Hop \(index + 1)") {
+                            Text(snr, format: .number.precision(.fractionLength(2)))
+                            + Text(" dB")
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Run Details")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/PocketMesh/Views/Contacts/SavedPathDetailViewModel.swift
+++ b/PocketMesh/Views/Contacts/SavedPathDetailViewModel.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+import PocketMeshServices
+import os.log
+
+private let logger = Logger(subsystem: "com.pocketmesh", category: "SavedPathDetail")
+
+@MainActor @Observable
+final class SavedPathDetailViewModel {
+
+    // MARK: - State
+
+    var savedPath: SavedTracePathDTO
+    var isLoading = false
+
+    // MARK: - Computed
+
+    var sortedRuns: [TracePathRunDTO] {
+        savedPath.runs.sorted { $0.date > $1.date }
+    }
+
+    var successfulRuns: [TracePathRunDTO] {
+        sortedRuns.filter { $0.success }
+    }
+
+    var bestRoundTrip: Int? {
+        successfulRuns.map(\.roundTripMs).min()
+    }
+
+    var averageRoundTrip: Int? {
+        savedPath.averageRoundTripMs
+    }
+
+    var successRateText: String {
+        "\(savedPath.successRate)%"
+    }
+
+    // MARK: - Initialization
+
+    init(savedPath: SavedTracePathDTO) {
+        self.savedPath = savedPath
+    }
+
+    // MARK: - Dependencies
+
+    private var appState: AppState?
+
+    func configure(appState: AppState) {
+        self.appState = appState
+    }
+
+    // MARK: - Actions
+
+    func refresh() async {
+        guard let dataStore = appState?.services?.dataStore else { return }
+
+        isLoading = true
+        do {
+            if let updated = try await dataStore.fetchSavedTracePath(id: savedPath.id) {
+                savedPath = updated
+            }
+        } catch {
+            logger.error("Failed to refresh: \(error.localizedDescription)")
+        }
+        isLoading = false
+    }
+}

--- a/PocketMesh/Views/Contacts/SavedPathsSheet.swift
+++ b/PocketMesh/Views/Contacts/SavedPathsSheet.swift
@@ -1,0 +1,217 @@
+import SwiftUI
+import PocketMeshServices
+
+/// Sheet displaying saved trace paths for selection
+struct SavedPathsSheet: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+    @State private var viewModel = SavedPathsViewModel()
+
+    /// Callback when a path is selected
+    var onSelect: (SavedTracePathDTO) -> Void
+
+    @State private var pathToDelete: SavedTracePathDTO?
+    @State private var pathToRename: SavedTracePathDTO?
+    @State private var renameText = ""
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.savedPaths.isEmpty && !viewModel.isLoading {
+                    emptyState
+                } else {
+                    pathsList
+                }
+            }
+            .navigationTitle("Saved Paths")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .task {
+                viewModel.configure(appState: appState)
+                await viewModel.loadSavedPaths()
+            }
+            .confirmationDialog(
+                "Delete Path",
+                isPresented: .init(
+                    get: { pathToDelete != nil },
+                    set: { if !$0 { pathToDelete = nil } }
+                ),
+                titleVisibility: .visible
+            ) {
+                Button("Delete", role: .destructive) {
+                    if let path = pathToDelete {
+                        Task { await viewModel.deletePath(path) }
+                    }
+                }
+            } message: {
+                if let path = pathToDelete {
+                    Text("Delete \"\(path.name)\"? This will remove the path and all run history.")
+                }
+            }
+            .alert("Rename Path", isPresented: .init(
+                get: { pathToRename != nil },
+                set: { if !$0 { pathToRename = nil } }
+            )) {
+                TextField("Name", text: $renameText)
+                Button("Cancel", role: .cancel) { }
+                Button("Save") {
+                    if let path = pathToRename {
+                        Task { await viewModel.renamePath(path, to: renameText) }
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("No Saved Paths", systemImage: "bookmark")
+        } description: {
+            Text("Save paths after running traces to quickly re-run them later.")
+        }
+    }
+
+    // MARK: - Paths List
+
+    private var pathsList: some View {
+        List {
+            ForEach(viewModel.savedPaths) { path in
+                Button {
+                    onSelect(path)
+                    dismiss()
+                } label: {
+                    SavedPathRow(path: path)
+                }
+                .buttonStyle(.plain)
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        Button("Delete", role: .destructive) {
+                            pathToDelete = path
+                        }
+                    }
+                    .contextMenu {
+                        Button("Rename", systemImage: "pencil") {
+                            renameText = path.name
+                            pathToRename = path
+                        }
+                        Button("Delete", systemImage: "trash", role: .destructive) {
+                            pathToDelete = path
+                        }
+                    }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .overlay {
+            if viewModel.isLoading {
+                ProgressView()
+            }
+        }
+    }
+}
+
+// MARK: - Saved Path Row
+
+private struct SavedPathRow: View {
+    let path: SavedTracePathDTO
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(path.name)
+                .font(.body)
+
+            HStack(spacing: 8) {
+                // Run count and recency
+                Text(subtitleText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                // Health indicator
+                healthDot
+
+                // Mini sparkline
+                if !path.recentRTTs.isEmpty {
+                    MiniSparkline(values: path.recentRTTs)
+                        .frame(width: 50, height: 16)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var subtitleText: String {
+        var parts: [String] = []
+
+        // Run count
+        let runText = path.runCount == 1 ? "1 run" : "\(path.runCount) runs"
+        parts.append(runText)
+
+        // Last run
+        if let lastDate = path.lastRunDate {
+            parts.append("Last: \(lastDate.relativeFormatted)")
+        }
+
+        return parts.joined(separator: " · ")
+    }
+
+    @ViewBuilder
+    private var healthDot: some View {
+        let rate = path.successRate
+        Circle()
+            .fill(rate >= 90 ? .green : rate >= 50 ? .yellow : .red)
+            .frame(width: 8, height: 8)
+    }
+}
+
+// MARK: - Mini Sparkline
+
+struct MiniSparkline: View {
+    let values: [Int]
+
+    var body: some View {
+        GeometryReader { geometry in
+            if let minVal = values.min(), let maxVal = values.max(), maxVal > minVal {
+                Path { path in
+                    let range = Double(maxVal - minVal)
+                    let stepX = geometry.size.width / Double(max(values.count - 1, 1))
+
+                    for (index, value) in values.enumerated() {
+                        let x = Double(index) * stepX
+                        let y = geometry.size.height - (Double(value - minVal) / range * geometry.size.height)
+
+                        if index == 0 {
+                            path.move(to: CGPoint(x: x, y: y))
+                        } else {
+                            path.addLine(to: CGPoint(x: x, y: y))
+                        }
+                    }
+                }
+                .stroke(Color.accentColor, lineWidth: 1.5)
+            } else {
+                // Flat line for constant values
+                Path { path in
+                    path.move(to: CGPoint(x: 0, y: geometry.size.height / 2))
+                    path.addLine(to: CGPoint(x: geometry.size.width, y: geometry.size.height / 2))
+                }
+                .stroke(Color.accentColor, lineWidth: 1.5)
+            }
+        }
+    }
+}
+
+// MARK: - Date Extension
+
+private extension Date {
+    var relativeFormatted: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: self, relativeTo: Date())
+    }
+}

--- a/PocketMesh/Views/Contacts/SavedPathsViewModel.swift
+++ b/PocketMesh/Views/Contacts/SavedPathsViewModel.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import PocketMeshServices
+import os.log
+
+private let logger = Logger(subsystem: "com.pocketmesh", category: "SavedPaths")
+
+@MainActor @Observable
+final class SavedPathsViewModel {
+
+    // MARK: - State
+
+    var savedPaths: [SavedTracePathDTO] = []
+    var isLoading = false
+    var errorMessage: String?
+
+    // MARK: - Dependencies
+
+    private var appState: AppState?
+
+    // MARK: - Configuration
+
+    func configure(appState: AppState) {
+        self.appState = appState
+    }
+
+    // MARK: - Data Loading
+
+    func loadSavedPaths() async {
+        guard let appState,
+              let deviceID = appState.connectedDevice?.id,
+              let dataStore = appState.services?.dataStore else { return }
+
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            savedPaths = try await dataStore.fetchSavedTracePaths(deviceID: deviceID)
+            logger.info("Loaded \(self.savedPaths.count) saved paths")
+        } catch {
+            logger.error("Failed to load saved paths: \(error.localizedDescription)")
+            errorMessage = "Failed to load saved paths"
+        }
+
+        isLoading = false
+    }
+
+    // MARK: - Actions
+
+    func renamePath(_ path: SavedTracePathDTO, to newName: String) async {
+        guard let dataStore = appState?.services?.dataStore else { return }
+
+        do {
+            try await dataStore.updateSavedTracePathName(id: path.id, name: newName)
+            await loadSavedPaths()
+        } catch {
+            logger.error("Failed to rename path: \(error.localizedDescription)")
+            errorMessage = "Failed to rename path"
+        }
+    }
+
+    func deletePath(_ path: SavedTracePathDTO) async {
+        guard let dataStore = appState?.services?.dataStore else { return }
+
+        do {
+            try await dataStore.deleteSavedTracePath(id: path.id)
+            savedPaths.removeAll { $0.id == path.id }
+            logger.info("Deleted saved path: \(path.name)")
+        } catch {
+            logger.error("Failed to delete path: \(error.localizedDescription)")
+            errorMessage = "Failed to delete path"
+        }
+    }
+}

--- a/PocketMeshServices/Sources/PocketMeshServices/Models/SavedTracePath.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Models/SavedTracePath.swift
@@ -1,0 +1,207 @@
+import Foundation
+import SwiftData
+
+/// A saved trace path configuration for re-use
+@Model
+public final class SavedTracePath {
+    @Attribute(.unique)
+    public var id: UUID
+
+    /// The device this path belongs to
+    public var deviceID: UUID
+
+    /// User-editable name (e.g., "Tower → Barn → Ridge")
+    public var name: String
+
+    /// The full path bytes (outbound + return)
+    public var pathBytes: Data
+
+    /// When this path was first saved
+    public var createdDate: Date
+
+    /// Historical runs of this path
+    @Relationship(deleteRule: .cascade, inverse: \TracePathRun.savedPath)
+    public var runs: [TracePathRun]
+
+    public init(
+        id: UUID = UUID(),
+        deviceID: UUID,
+        name: String,
+        pathBytes: Data,
+        createdDate: Date = Date()
+    ) {
+        self.id = id
+        self.deviceID = deviceID
+        self.name = name
+        self.pathBytes = pathBytes
+        self.createdDate = createdDate
+        self.runs = []
+    }
+}
+
+/// A single execution of a saved trace path
+@Model
+public final class TracePathRun {
+    public var id: UUID
+
+    /// When this run occurred
+    public var date: Date
+
+    /// Whether the trace completed successfully
+    public var success: Bool
+
+    /// Round-trip time in milliseconds (0 if failed)
+    public var roundTripMs: Int
+
+    /// Encoded per-hop SNR data (JSON array of doubles)
+    public var hopsData: Data
+
+    /// The saved path this run belongs to
+    public var savedPath: SavedTracePath?
+
+    public init(
+        id: UUID = UUID(),
+        date: Date = Date(),
+        success: Bool,
+        roundTripMs: Int,
+        hopsData: Data
+    ) {
+        self.id = id
+        self.date = date
+        self.success = success
+        self.roundTripMs = roundTripMs
+        self.hopsData = hopsData
+    }
+}
+
+// MARK: - Computed Properties
+
+public extension SavedTracePath {
+    /// Number of runs for this path
+    var runCount: Int { runs.count }
+
+    /// Most recent run date
+    var lastRunDate: Date? {
+        runs.max(by: { $0.date < $1.date })?.date
+    }
+
+    /// Average round-trip time of successful runs
+    var averageRoundTripMs: Int? {
+        let successful = runs.filter { $0.success }
+        guard !successful.isEmpty else { return nil }
+        let total = successful.reduce(0) { $0 + $1.roundTripMs }
+        return total / successful.count
+    }
+
+    /// Success rate as a percentage (0-100)
+    var successRate: Int {
+        guard !runs.isEmpty else { return 100 }
+        let successful = runs.filter { $0.success }.count
+        return (successful * 100) / runs.count
+    }
+}
+
+public extension TracePathRun {
+    /// Decode hops SNR data to array of doubles
+    var hopsSNR: [Double] {
+        guard let decoded = try? JSONDecoder().decode([Double].self, from: hopsData) else {
+            return []
+        }
+        return decoded
+    }
+}
+
+// MARK: - DTOs
+
+/// Sendable snapshot of SavedTracePath for cross-actor transfers
+public struct SavedTracePathDTO: Sendable, Identifiable, Equatable, Hashable {
+    public let id: UUID
+    public let deviceID: UUID
+    public let name: String
+    public let pathBytes: Data
+    public let createdDate: Date
+    public let runs: [TracePathRunDTO]
+
+    public init(from model: SavedTracePath) {
+        self.id = model.id
+        self.deviceID = model.deviceID
+        self.name = model.name
+        self.pathBytes = model.pathBytes
+        self.createdDate = model.createdDate
+        self.runs = model.runs.map { TracePathRunDTO(from: $0) }
+    }
+
+    public init(
+        id: UUID,
+        deviceID: UUID,
+        name: String,
+        pathBytes: Data,
+        createdDate: Date,
+        runs: [TracePathRunDTO]
+    ) {
+        self.id = id
+        self.deviceID = deviceID
+        self.name = name
+        self.pathBytes = pathBytes
+        self.createdDate = createdDate
+        self.runs = runs
+    }
+
+    public var runCount: Int { runs.count }
+
+    public var lastRunDate: Date? {
+        runs.max(by: { $0.date < $1.date })?.date
+    }
+
+    public var averageRoundTripMs: Int? {
+        let successful = runs.filter { $0.success }
+        guard !successful.isEmpty else { return nil }
+        let total = successful.reduce(0) { $0 + $1.roundTripMs }
+        return total / successful.count
+    }
+
+    public var successRate: Int {
+        guard !runs.isEmpty else { return 100 }
+        let successful = runs.filter { $0.success }.count
+        return (successful * 100) / runs.count
+    }
+
+    /// Recent RTT values for sparkline (most recent 10)
+    public var recentRTTs: [Int] {
+        runs.filter { $0.success }
+            .sorted { $0.date > $1.date }
+            .prefix(10)
+            .reversed()
+            .map { $0.roundTripMs }
+    }
+
+    /// The path as array of hash bytes
+    public var pathHashBytes: [UInt8] {
+        Array(pathBytes)
+    }
+}
+
+/// Sendable snapshot of TracePathRun
+public struct TracePathRunDTO: Sendable, Identifiable, Equatable, Hashable {
+    public let id: UUID
+    public let date: Date
+    public let success: Bool
+    public let roundTripMs: Int
+    public let hopsSNR: [Double]
+
+    public init(from model: TracePathRun) {
+        self.id = model.id
+        self.date = model.date
+        self.success = model.success
+        self.roundTripMs = model.roundTripMs
+        self.hopsSNR = model.hopsSNR
+    }
+
+    public init(id: UUID, date: Date, success: Bool, roundTripMs: Int, hopsSNR: [Double]) {
+        self.id = id
+        self.date = date
+        self.success = success
+        self.roundTripMs = roundTripMs
+        self.hopsSNR = hopsSNR
+    }
+}

--- a/PocketMeshServices/Sources/PocketMeshServices/Protocols/PersistenceStoreProtocol.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Protocols/PersistenceStoreProtocol.swift
@@ -126,4 +126,24 @@ public protocol PersistenceStoreProtocol: Actor {
 
     /// Clear unread count for a channel
     func clearChannelUnreadCount(channelID: UUID) async throws
+
+    // MARK: - Saved Trace Paths
+
+    /// Fetch all saved trace paths for a device
+    func fetchSavedTracePaths(deviceID: UUID) async throws -> [SavedTracePathDTO]
+
+    /// Fetch a single saved trace path by ID
+    func fetchSavedTracePath(id: UUID) async throws -> SavedTracePathDTO?
+
+    /// Create a new saved trace path
+    func createSavedTracePath(deviceID: UUID, name: String, pathBytes: Data, initialRun: TracePathRunDTO?) async throws -> SavedTracePathDTO
+
+    /// Update a saved trace path's name
+    func updateSavedTracePathName(id: UUID, name: String) async throws
+
+    /// Delete a saved trace path
+    func deleteSavedTracePath(id: UUID) async throws
+
+    /// Append a run to a saved trace path
+    func appendTracePathRun(pathID: UUID, run: TracePathRunDTO) async throws
 }

--- a/PocketMeshTests/ViewModels/TracePathViewModelTests.swift
+++ b/PocketMeshTests/ViewModels/TracePathViewModelTests.swift
@@ -1,0 +1,281 @@
+import Testing
+import Foundation
+@testable import PocketMesh
+@testable import PocketMeshServices
+@testable import MeshCore
+
+// MARK: - Test Helpers
+
+private func createTestSavedPath(runs: [TracePathRunDTO]) -> SavedTracePathDTO {
+    SavedTracePathDTO(
+        id: UUID(),
+        deviceID: UUID(),
+        name: "Test Path",
+        pathBytes: Data([0x01, 0x02, 0x01]),
+        createdDate: Date(),
+        runs: runs
+    )
+}
+
+private func createTestRun(date: Date, roundTripMs: Int = 100, success: Bool = true) -> TracePathRunDTO {
+    TracePathRunDTO(
+        id: UUID(),
+        date: date,
+        success: success,
+        roundTripMs: success ? roundTripMs : 0,
+        hopsSNR: success ? [5.0, 3.0, -2.0] : []
+    )
+}
+
+private func createTestContact() -> ContactDTO {
+    let contact = Contact(
+        id: UUID(),
+        deviceID: UUID(),
+        publicKey: Data([0xAB] + Array(repeating: UInt8(0x00), count: 31)),
+        name: "Test Repeater",
+        typeRawValue: ContactType.repeater.rawValue,
+        flags: 0,
+        outPathLength: 0,
+        outPath: Data(),
+        lastAdvertTimestamp: 0,
+        latitude: 0,
+        longitude: 0,
+        lastModified: 0
+    )
+    return ContactDTO(from: contact)
+}
+
+// MARK: - Path Edit Clears Saved Path Tests
+
+@Suite("Path Edit Clears Saved Path")
+@MainActor
+struct PathEditClearsSavedPathTests {
+
+    @Test("addRepeater clears activeSavedPath")
+    func addRepeaterClearsActiveSavedPath() {
+        let viewModel = TracePathViewModel()
+        viewModel.activeSavedPath = createTestSavedPath(runs: [])
+
+        #expect(viewModel.activeSavedPath != nil)
+
+        viewModel.addRepeater(createTestContact())
+
+        #expect(viewModel.activeSavedPath == nil)
+    }
+
+    @Test("removeRepeater clears activeSavedPath")
+    func removeRepeaterClearsActiveSavedPath() {
+        let viewModel = TracePathViewModel()
+        viewModel.activeSavedPath = createTestSavedPath(runs: [])
+        viewModel.addRepeater(createTestContact())
+        // Re-set since addRepeater clears it
+        viewModel.activeSavedPath = createTestSavedPath(runs: [])
+
+        #expect(viewModel.activeSavedPath != nil)
+
+        viewModel.removeRepeater(at: 0)
+
+        #expect(viewModel.activeSavedPath == nil)
+    }
+
+    @Test("moveRepeater clears activeSavedPath")
+    func moveRepeaterClearsActiveSavedPath() {
+        let viewModel = TracePathViewModel()
+
+        // Add two repeaters
+        viewModel.addRepeater(createTestContact())
+        viewModel.addRepeater(createTestContact())
+        viewModel.activeSavedPath = createTestSavedPath(runs: [])
+
+        #expect(viewModel.activeSavedPath != nil)
+
+        viewModel.moveRepeater(from: IndexSet(integer: 0), to: 2)
+
+        #expect(viewModel.activeSavedPath == nil)
+    }
+}
+
+// MARK: - Previous Run Comparison Tests
+
+@Suite("Previous Run Comparison")
+@MainActor
+struct PreviousRunComparisonTests {
+
+    @Test("previousRun returns nil when no runs exist")
+    func previousRunReturnsNilWhenNoRuns() {
+        let viewModel = TracePathViewModel()
+        viewModel.activeSavedPath = createTestSavedPath(runs: [])
+
+        #expect(viewModel.previousRun == nil)
+    }
+
+    @Test("previousRun returns nil when only one run exists")
+    func previousRunReturnsNilWhenOnlyOneRun() {
+        let viewModel = TracePathViewModel()
+        let run = createTestRun(date: Date())
+        viewModel.activeSavedPath = createTestSavedPath(runs: [run])
+
+        #expect(viewModel.previousRun == nil)
+    }
+
+    @Test("previousRun returns second-to-last run when two runs exist")
+    func previousRunReturnsSecondToLastWithTwoRuns() {
+        let viewModel = TracePathViewModel()
+        let olderRun = createTestRun(date: Date().addingTimeInterval(-60), roundTripMs: 150)
+        let newerRun = createTestRun(date: Date(), roundTripMs: 100)
+        viewModel.activeSavedPath = createTestSavedPath(runs: [olderRun, newerRun])
+
+        let previous = viewModel.previousRun
+        #expect(previous != nil)
+        #expect(previous?.roundTripMs == 150)
+    }
+
+    @Test("previousRun returns second-to-last run when multiple runs exist")
+    func previousRunReturnsSecondToLastWithMultipleRuns() {
+        let viewModel = TracePathViewModel()
+        let run1 = createTestRun(date: Date().addingTimeInterval(-120), roundTripMs: 200)
+        let run2 = createTestRun(date: Date().addingTimeInterval(-60), roundTripMs: 150)
+        let run3 = createTestRun(date: Date(), roundTripMs: 100)
+        viewModel.activeSavedPath = createTestSavedPath(runs: [run1, run2, run3])
+
+        let previous = viewModel.previousRun
+        #expect(previous != nil)
+        #expect(previous?.roundTripMs == 150)  // Second-to-last (run2)
+    }
+
+    @Test("previousRun skips failed runs when finding comparison")
+    func previousRunSkipsFailedRuns() {
+        let viewModel = TracePathViewModel()
+        // Oldest: success @ 200ms
+        let run1 = createTestRun(date: Date().addingTimeInterval(-120), roundTripMs: 200)
+        // Middle: failed (roundTripMs = 0)
+        let run2 = createTestRun(date: Date().addingTimeInterval(-60), success: false)
+        // Newest: success @ 100ms
+        let run3 = createTestRun(date: Date(), roundTripMs: 100)
+        viewModel.activeSavedPath = createTestSavedPath(runs: [run1, run2, run3])
+
+        let previous = viewModel.previousRun
+        #expect(previous != nil)
+        // Should skip the failed run2 and return run1 (200ms)
+        #expect(previous?.roundTripMs == 200)
+    }
+
+    @Test("previousRun returns nil when only one successful run exists among failures")
+    func previousRunReturnsNilWithOnlyOneSuccess() {
+        let viewModel = TracePathViewModel()
+        let failedRun1 = createTestRun(date: Date().addingTimeInterval(-120), success: false)
+        let failedRun2 = createTestRun(date: Date().addingTimeInterval(-60), success: false)
+        let successRun = createTestRun(date: Date(), roundTripMs: 100)
+        viewModel.activeSavedPath = createTestSavedPath(runs: [failedRun1, failedRun2, successRun])
+
+        // Only one successful run, so no previous successful run exists
+        #expect(viewModel.previousRun == nil)
+    }
+}
+
+// MARK: - Trace Response Hop Parsing Tests
+
+@Suite("Trace Response Hop Parsing")
+@MainActor
+struct TraceResponseHopParsingTests {
+
+    @Test("handleTraceResponse creates correct hops for single-hop trace")
+    func singleHopTraceProducesCorrectHops() {
+        let viewModel = TracePathViewModel()
+
+        // Create a TraceInfo with one repeater hop + final nil node
+        let traceInfo = TraceInfo(
+            tag: 12345,
+            authCode: 0,
+            flags: 0,
+            pathLength: 1,
+            path: [
+                TraceNode(hash: 0xAB, snr: 5.0),   // Repeater
+                TraceNode(hash: nil, snr: 3.0)     // Return to local
+            ]
+        )
+
+        // Set up pending tag to match
+        viewModel.setPendingTagForTesting(12345)
+        viewModel.handleTraceResponse(traceInfo)
+
+        guard let result = viewModel.result else {
+            Issue.record("Result should not be nil")
+            return
+        }
+
+        #expect(result.success == true)
+        #expect(result.hops.count == 3)  // Start + 1 repeater + End
+
+        // Start node (local device)
+        #expect(result.hops[0].isStartNode == true)
+        #expect(result.hops[0].hashByte == nil)
+        #expect(result.hops[0].snr == 0)  // No incoming SNR for sender
+
+        // Intermediate hop (repeater)
+        #expect(result.hops[1].isStartNode == false)
+        #expect(result.hops[1].isEndNode == false)
+        #expect(result.hops[1].hashByte == 0xAB)
+        #expect(result.hops[1].snr == 5.0)
+
+        // End node (return to local)
+        #expect(result.hops[2].isEndNode == true)
+        #expect(result.hops[2].hashByte == nil)
+        #expect(result.hops[2].snr == 3.0)
+    }
+
+    @Test("handleTraceResponse creates correct hops for multi-hop trace")
+    func multiHopTraceProducesCorrectHops() {
+        let viewModel = TracePathViewModel()
+
+        let traceInfo = TraceInfo(
+            tag: 12345,
+            authCode: 0,
+            flags: 0,
+            pathLength: 3,
+            path: [
+                TraceNode(hash: 0xAA, snr: 6.0),   // First repeater
+                TraceNode(hash: 0xBB, snr: 4.0),   // Second repeater
+                TraceNode(hash: 0xCC, snr: 2.0),   // Third repeater
+                TraceNode(hash: nil, snr: -1.0)    // Return to local
+            ]
+        )
+
+        viewModel.setPendingTagForTesting(12345)
+        viewModel.handleTraceResponse(traceInfo)
+
+        guard let result = viewModel.result else {
+            Issue.record("Result should not be nil")
+            return
+        }
+
+        #expect(result.hops.count == 5)  // Start + 3 repeaters + End
+
+        // Verify all intermediate hops are present
+        #expect(result.hops[1].hashByte == 0xAA)
+        #expect(result.hops[2].hashByte == 0xBB)
+        #expect(result.hops[3].hashByte == 0xCC)
+    }
+
+    @Test("handleTraceResponse ignores non-matching tags")
+    func ignoresNonMatchingTags() {
+        let viewModel = TracePathViewModel()
+
+        let traceInfo = TraceInfo(
+            tag: 99999,  // Different tag
+            authCode: 0,
+            flags: 0,
+            pathLength: 1,
+            path: [
+                TraceNode(hash: 0xAB, snr: 5.0),
+                TraceNode(hash: nil, snr: 3.0)
+            ]
+        )
+
+        viewModel.setPendingTagForTesting(12345)  // Different from traceInfo.tag
+        viewModel.handleTraceResponse(traceInfo)
+
+        #expect(viewModel.result == nil)
+    }
+}
+


### PR DESCRIPTION
## Summary

- Add ability to save trace path configurations after successful traces
- Re-run saved paths with automatic history tracking and performance comparison
- View detailed run history with Swift Charts visualization and sparklines

## Changes

**New Files:**
- `SavedTracePath.swift` - SwiftData models and DTOs for saved paths and runs
- `SavedPathsViewModel.swift` - ViewModel for managing saved paths list
- `SavedPathsSheet.swift` - Sheet UI for browsing/managing saved paths
- `SavedPathDetailViewModel.swift` - ViewModel for detail view
- `SavedPathDetailView.swift` - Detail view with Swift Charts performance graph

**Modified Files:**
- `PersistenceStore.swift` - CRUD operations for saved paths
- `PersistenceStoreProtocol.swift` - Protocol methods for saved paths
- `TracePathView.swift` - Toolbar button, save action, comparison UI
- `TracePathViewModel.swift` - Saved path state and methods

## Test Plan

- [ ] Run a trace, verify "Save Path" button appears in results
- [ ] Save a path, verify it appears in Saved Paths sheet
- [ ] Load a saved path, verify path is restored in outbound section
- [ ] Run a saved path, verify comparison UI shows vs previous run
- [ ] View path detail, verify chart and run history display correctly
- [ ] Delete a saved path, verify it's removed
- [ ] Rename a saved path, verify name updates