### PR TITLE
feat(meshcore): protocol compliance for firmware v1.11+

### DIFF
--- a/MeshCore/Package.resolved
+++ b/MeshCore/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "d466adc75c7bf0e594b3268717c8e1c7990bcfa7b2851845b5972faca919e01e",
+  "originHash" : "7102575be6b54dd064d1c7542a11ed3c6eb83fc995eabb3306cebbe2205adfa3",
   "pins" : [
-    {
-      "identity" : "datascoutcompanion",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/alex566/DataScoutCompanion.git",
-      "state" : {
-        "revision" : "3f98e91e4eba308331d6aa6fbe21ad2a92b20d8a",
-        "version" : "0.3.0"
-      }
-    },
     {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",

--- a/MeshCore/Sources/MeshCore/Protocol/DataExtensions.swift
+++ b/MeshCore/Sources/MeshCore/Protocol/DataExtensions.swift
@@ -115,3 +115,43 @@ extension UInt8 {
         Int8(bitPattern: self).snrValue
     }
 }
+
+// MARK: - Data Padding and Writing
+
+extension Data {
+    /// Returns data padded with zeros or truncated to the specified length.
+    ///
+    /// - Parameter length: The target length.
+    /// - Returns: Data of exactly the specified length, or empty data if length is negative.
+    public func paddedOrTruncated(to length: Int) -> Data {
+        guard length >= 0 else { return Data() }
+        if count >= length {
+            return Data(prefix(length))
+        }
+        return self + Data(repeating: 0, count: length - count)
+    }
+
+    /// Appends a little-endian UInt32 to the data.
+    ///
+    /// - Parameter value: The value to append.
+    public mutating func appendLittleEndian(_ value: UInt32) {
+        Swift.withUnsafeBytes(of: value.littleEndian) { append(contentsOf: $0) }
+    }
+
+    /// Appends a little-endian Int32 to the data.
+    ///
+    /// - Parameter value: The value to append.
+    public mutating func appendLittleEndian(_ value: Int32) {
+        Swift.withUnsafeBytes(of: value.littleEndian) { append(contentsOf: $0) }
+    }
+}
+
+extension String {
+    /// Returns the UTF-8 bytes of the string, padded or truncated to the specified length.
+    ///
+    /// - Parameter length: The target length.
+    /// - Returns: Data of exactly the specified length.
+    public func utf8PaddedOrTruncated(to length: Int) -> Data {
+        Data(utf8).paddedOrTruncated(to: length)
+    }
+}

--- a/MeshCore/Sources/MeshCore/Protocol/PacketCodes.swift
+++ b/MeshCore/Sources/MeshCore/Protocol/PacketCodes.swift
@@ -48,12 +48,18 @@ public enum CommandCode: UInt8, Sendable {
     case exportPrivateKey = 0x17
     /// Imports a private key to the node.
     case importPrivateKey = 0x18
+    /// Sends raw data through the mesh.
+    case sendRawData = 0x19
     /// Initiates a remote node login.
     case sendLogin = 0x1A
     /// Requests status information from a remote node.
     case sendStatusRequest = 0x1B
+    /// Checks if a connection exists to a specific node.
+    case hasConnection = 0x1C
     /// Logs out from a remote node.
     case sendLogout = 0x1D
+    /// Retrieves a contact by public key.
+    case getContactByKey = 0x1E
     /// Requests channel configuration for a specific index.
     case getChannel = 0x1F
     /// Sets channel configuration for a specific index.
@@ -76,6 +82,10 @@ public enum CommandCode: UInt8, Sendable {
     case getCustomVars = 0x28
     /// Sets a custom variable value.
     case setCustomVar = 0x29
+    /// Retrieves the advertisement path to a contact.
+    case getAdvertPath = 0x2A
+    /// Retrieves tuning parameters.
+    case getTuningParams = 0x2B
     /// Initiates a binary data request.
     case binaryRequest = 0x32
     /// Performs a factory reset of the device.
@@ -136,6 +146,10 @@ public enum ResponseCode: UInt8, Sendable {
     case signature = 0x14
     /// Contains custom variable values.
     case customVars = 0x15
+    /// Contains advertisement path information.
+    case advertPath = 0x16
+    /// Contains tuning parameters.
+    case tuningParams = 0x17
     /// Contains device statistics.
     case stats = 0x18
 
@@ -244,7 +258,7 @@ extension ResponseCode {
         switch self {
         case .ok, .error:
             return .simple
-        case .selfInfo, .deviceInfo, .battery, .currentTime, .privateKey, .disabled:
+        case .selfInfo, .deviceInfo, .battery, .currentTime, .privateKey, .disabled, .advertPath, .tuningParams:
             return .device
         case .contactStart, .contact, .contactEnd, .contactURI:
             return .contact

--- a/MeshCore/Sources/MeshCore/Protocol/PacketParser.swift
+++ b/MeshCore/Sources/MeshCore/Protocol/PacketParser.swift
@@ -137,6 +137,12 @@ extension PacketParser {
             // Extracted - needs validation
             return Parsers.PrivateKey.parse(payload)
 
+        case .advertPath:
+            return Parsers.AdvertPathResponse.parse(payload)
+
+        case .tuningParams:
+            return Parsers.TuningParamsResponse.parse(payload)
+
         default:
             return .parseFailure(data: payload, reason: "Unexpected code in device response: \(code)")
         }

--- a/MeshCore/Tests/MeshCoreTests/Protocol/DataExtensionsTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Protocol/DataExtensionsTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import MeshCore
+
+final class DataExtensionsTests: XCTestCase {
+
+    func test_paddedOrTruncated_padsShortData() {
+        let data = Data([0x01, 0x02, 0x03])
+        let result = data.paddedOrTruncated(to: 6)
+        XCTAssertEqual(result, Data([0x01, 0x02, 0x03, 0x00, 0x00, 0x00]))
+    }
+
+    func test_paddedOrTruncated_truncatesLongData() {
+        let data = Data([0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
+        let result = data.paddedOrTruncated(to: 3)
+        XCTAssertEqual(result, Data([0x01, 0x02, 0x03]))
+    }
+
+    func test_paddedOrTruncated_returnsExactSizeUnchanged() {
+        let data = Data([0x01, 0x02, 0x03])
+        let result = data.paddedOrTruncated(to: 3)
+        XCTAssertEqual(result, data)
+    }
+
+    func test_paddedOrTruncated_returnsEmptyForNegativeLength() {
+        let data = Data([0x01, 0x02, 0x03])
+        let result = data.paddedOrTruncated(to: -1)
+        XCTAssertEqual(result, Data())
+    }
+
+    func test_utf8PaddedOrTruncated_padsShortString() {
+        let result = "Hi".utf8PaddedOrTruncated(to: 6)
+        XCTAssertEqual(result, Data([0x48, 0x69, 0x00, 0x00, 0x00, 0x00]))
+    }
+
+    func test_utf8PaddedOrTruncated_truncatesLongString() {
+        let result = "Hello World".utf8PaddedOrTruncated(to: 5)
+        XCTAssertEqual(result, Data([0x48, 0x65, 0x6C, 0x6C, 0x6F])) // "Hello"
+    }
+
+    func test_appendLittleEndianUInt32() {
+        var data = Data()
+        data.appendLittleEndian(UInt32(0x12345678))
+        XCTAssertEqual(data, Data([0x78, 0x56, 0x34, 0x12]))
+    }
+
+    func test_appendLittleEndianInt32() {
+        var data = Data()
+        data.appendLittleEndian(Int32(-1))
+        XCTAssertEqual(data, Data([0xFF, 0xFF, 0xFF, 0xFF]))
+    }
+}

--- a/MeshCore/Tests/MeshCoreTests/Protocol/FactoryResetTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Protocol/FactoryResetTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import MeshCore
+
+final class FactoryResetTests: XCTestCase {
+
+    func test_factoryReset_includesGuardString() {
+        let packet = PacketBuilder.factoryReset()
+
+        // Firmware requires: [0x33]['r']['e']['s']['e']['t']
+        XCTAssertEqual(packet.count, 6, "Should be 6 bytes: command + 'reset'")
+        XCTAssertEqual(packet[0], 0x33, "Byte 0 should be command code 0x33")
+
+        let guardString = String(data: Data(packet[1...]), encoding: .utf8)
+        XCTAssertEqual(guardString, "reset", "Bytes 1-5 should be 'reset'")
+    }
+
+    func test_factoryReset_exactBytes() {
+        let packet = PacketBuilder.factoryReset()
+
+        let expected = Data([0x33, 0x72, 0x65, 0x73, 0x65, 0x74])  // 0x33 + "reset"
+        XCTAssertEqual(packet, expected)
+    }
+}

--- a/MeshCore/Tests/MeshCoreTests/Protocol/NewCommandsTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Protocol/NewCommandsTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import MeshCore
+
+final class NewCommandsTests: XCTestCase {
+
+    func test_sendRawData_format() {
+        let path = Data([0x11, 0x22])
+        let payload = Data([0xAA, 0xBB, 0xCC])
+
+        let packet = PacketBuilder.sendRawData(path: path, payload: payload)
+
+        XCTAssertEqual(packet[0], 0x19, "Command code")
+        XCTAssertEqual(packet[1], 0x02, "Path length")
+        XCTAssertEqual(Data(packet[2..<4]), path, "Path data")
+        XCTAssertEqual(Data(packet[4...]), payload, "Payload")
+    }
+
+    func test_sendRawData_emptyPath() {
+        let packet = PacketBuilder.sendRawData(path: Data(), payload: Data([0xAA]))
+        XCTAssertEqual(packet[1], 0x00, "Empty path length")
+        XCTAssertEqual(packet.count, 3, "command + pathLen + payload")
+    }
+
+    func test_hasConnection_format() {
+        let pubkey = Data(repeating: 0xAA, count: 32)
+
+        let packet = PacketBuilder.hasConnection(publicKey: pubkey)
+
+        XCTAssertEqual(packet.count, 33, "1 + 32 bytes")
+        XCTAssertEqual(packet[0], 0x1C, "Command code")
+        XCTAssertEqual(Data(packet[1...]), pubkey, "Public key")
+    }
+
+    func test_getContactByKey_format() {
+        let pubkey = Data(repeating: 0xBB, count: 32)
+
+        let packet = PacketBuilder.getContactByKey(publicKey: pubkey)
+
+        XCTAssertEqual(packet.count, 33, "1 + 32 bytes")
+        XCTAssertEqual(packet[0], 0x1E, "Command code")
+        XCTAssertEqual(Data(packet[1...]), pubkey, "Public key")
+    }
+
+    func test_getAdvertPath_format() {
+        let pubkey = Data(repeating: 0xCC, count: 32)
+
+        let packet = PacketBuilder.getAdvertPath(publicKey: pubkey)
+
+        XCTAssertEqual(packet.count, 34, "1 + 1 + 32 bytes")
+        XCTAssertEqual(packet[0], 0x2A, "Command code")
+        XCTAssertEqual(packet[1], 0x00, "Reserved byte")
+        XCTAssertEqual(Data(packet[2...]), pubkey, "Public key")
+    }
+
+    func test_getTuningParams_format() {
+        let packet = PacketBuilder.getTuningParams()
+
+        XCTAssertEqual(packet.count, 1)
+        XCTAssertEqual(packet[0], 0x2B, "Command code")
+    }
+}

--- a/MeshCore/Tests/MeshCoreTests/Protocol/UpdateContactTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Protocol/UpdateContactTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import MeshCore
+
+final class UpdateContactTests: XCTestCase {
+
+    func test_updateContact_produces147Bytes() {
+        let contact = MeshContact(
+            id: "test",
+            publicKey: Data(repeating: 0xAA, count: 32),
+            type: 0x01,
+            flags: 0x02,
+            outPathLength: 3,
+            outPath: Data([0x11, 0x22, 0x33]),
+            advertisedName: "TestNode",
+            lastAdvertisement: Date(timeIntervalSince1970: 1704067200),  // 2024-01-01
+            latitude: 37.7749,
+            longitude: -122.4194,
+            lastModified: Date()
+        )
+
+        let packet = PacketBuilder.updateContact(contact)
+
+        XCTAssertEqual(packet.count, 147, "Full contact update should be 147 bytes")
+    }
+
+    func test_updateContact_correctLayout() {
+        let pubkey = Data(repeating: 0xAA, count: 32)
+        let outPath = Data([0x11, 0x22, 0x33])
+        let contact = MeshContact(
+            id: "test",
+            publicKey: pubkey,
+            type: 0x05,
+            flags: 0x03,
+            outPathLength: 3,
+            outPath: outPath,
+            advertisedName: "Node",
+            lastAdvertisement: Date(timeIntervalSince1970: 1000),
+            latitude: 10.0,
+            longitude: -20.0,
+            lastModified: Date()
+        )
+
+        let packet = PacketBuilder.updateContact(contact)
+
+        // Verify layout
+        XCTAssertEqual(packet[0], 0x09, "Byte 0: command code")
+        XCTAssertEqual(Data(packet[1..<33]), pubkey, "Bytes 1-32: public key")
+        XCTAssertEqual(packet[33], 0x05, "Byte 33: type")
+        XCTAssertEqual(packet[34], 0x03, "Byte 34: flags")
+        XCTAssertEqual(packet[35], 0x03, "Byte 35: outPathLength")
+
+        // Bytes 36-99: outPath (64 bytes, padded)
+        XCTAssertEqual(Data(packet[36..<39]), outPath, "Bytes 36-38: outPath data")
+        XCTAssertEqual(packet[39], 0x00, "Byte 39: padding")
+
+        // Bytes 100-131: name (32 bytes, padded)
+        let nameBytes = Data(packet[100..<132])
+        let name = String(data: nameBytes.prefix(4), encoding: .utf8)
+        XCTAssertEqual(name, "Node", "Bytes 100-103: name")
+        XCTAssertEqual(packet[104], 0x00, "Byte 104: name padding")
+
+        // Bytes 132-135: lastAdvertTimestamp (UInt32 LE)
+        let timestamp = packet.readUInt32LE(at: 132)
+        XCTAssertEqual(timestamp, 1000, "Bytes 132-135: timestamp")
+
+        // Bytes 136-139: latitude (Int32 LE, scaled by 1M)
+        let lat = packet.readInt32LE(at: 136)
+        XCTAssertEqual(lat, 10_000_000, "Bytes 136-139: latitude")
+
+        // Bytes 140-143: longitude (Int32 LE, scaled by 1M)
+        let lon = packet.readInt32LE(at: 140)
+        XCTAssertEqual(lon, -20_000_000, "Bytes 140-143: longitude")
+    }
+
+    func test_updateContact_signedPathLength() {
+        let contact = MeshContact(
+            id: "test",
+            publicKey: Data(repeating: 0x00, count: 32),
+            type: 0x00,
+            flags: 0x00,
+            outPathLength: -1,  // Flood path
+            outPath: Data(),
+            advertisedName: "",
+            lastAdvertisement: Date(timeIntervalSince1970: 0),
+            latitude: 0,
+            longitude: 0,
+            lastModified: Date()
+        )
+
+        let packet = PacketBuilder.updateContact(contact)
+
+        // -1 as UInt8 bit pattern = 0xFF
+        XCTAssertEqual(packet[35], 0xFF, "outPathLength -1 should be 0xFF")
+    }
+}

--- a/MeshCore/Tests/MeshCoreTests/Validation/DiscoverResponseParsingTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Validation/DiscoverResponseParsingTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import MeshCore
+
+final class DiscoverResponseParsingTests: XCTestCase {
+
+    func test_controlData_parsesDiscoverResponse() {
+        // Control data format: [snr:1][rssi:1][pathLen:1][payloadType:1][payload...]
+        // DISCOVER_RESP payload: [snr_in:1][tag:4][pubkey:8 or 32]
+        var payload = Data()
+        payload.append(0x28)  // SNR: 10.0 (40 / 4.0)
+        payload.append(0xAB)  // RSSI: -85 (signed)
+        payload.append(0x02)  // path length
+        payload.append(0x95)  // payloadType: 0x90 | 0x05 (DISCOVER_RESP, nodeType=5)
+        // DISCOVER_RESP inner payload
+        payload.append(0x14)  // snr_in: 5.0 (20 / 4.0)
+        payload.appendLittleEndian(UInt32(12345))  // tag
+        payload.append(contentsOf: [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88])  // 8-byte prefix
+
+        let event = Parsers.ControlData.parse(payload)
+
+        guard case .discoverResponse(let response) = event else {
+            XCTFail("Expected discoverResponse, got \(event)")
+            return
+        }
+
+        XCTAssertEqual(response.nodeType, 5)
+        XCTAssertEqual(response.snrIn, 5.0, accuracy: 0.001)
+        XCTAssertEqual(response.snr, 10.0, accuracy: 0.001)
+        XCTAssertEqual(response.rssi, -85)
+        XCTAssertEqual(response.pathLength, 2)
+        XCTAssertEqual(response.tag, Data([0x39, 0x30, 0x00, 0x00]))  // 12345 in LE
+        XCTAssertEqual(response.publicKey.hexString, "1122334455667788")
+    }
+
+    func test_controlData_parsesFullPubkey() {
+        var payload = Data()
+        payload.append(0x28)  // SNR
+        payload.append(0xAB)  // RSSI
+        payload.append(0x01)  // path length
+        payload.append(0x91)  // DISCOVER_RESP, nodeType=1
+        payload.append(0x28)  // snr_in
+        payload.appendLittleEndian(UInt32(999))  // tag
+        payload.append(Data(repeating: 0xAA, count: 32))  // full 32-byte pubkey
+
+        let event = Parsers.ControlData.parse(payload)
+
+        guard case .discoverResponse(let response) = event else {
+            XCTFail("Expected discoverResponse")
+            return
+        }
+
+        XCTAssertEqual(response.publicKey.count, 32)
+        XCTAssertEqual(response.publicKey, Data(repeating: 0xAA, count: 32))
+    }
+
+    func test_controlData_nonDiscoverReturnsRaw() {
+        var payload = Data()
+        payload.append(0x28)  // SNR
+        payload.append(0xAB)  // RSSI
+        payload.append(0x01)  // path length
+        payload.append(0x80)  // payloadType: NODE_DISCOVER_REQ (not RESP)
+        payload.append(contentsOf: [0x01, 0x02, 0x03])  // some payload
+
+        let event = Parsers.ControlData.parse(payload)
+
+        guard case .controlData(let info) = event else {
+            XCTFail("Expected controlData, got \(event)")
+            return
+        }
+
+        XCTAssertEqual(info.payloadType, 0x80)
+        XCTAssertEqual(info.payload, Data([0x01, 0x02, 0x03]))
+    }
+
+    func test_controlData_discoverRespTooShortFallsBackToControlData() {
+        // DISCOVER_RESP with insufficient payload (less than 5 bytes for inner payload)
+        var payload = Data()
+        payload.append(0x28)  // SNR
+        payload.append(0xAB)  // RSSI
+        payload.append(0x01)  // path length
+        payload.append(0x91)  // DISCOVER_RESP
+        payload.append(contentsOf: [0x01, 0x02, 0x03, 0x04])  // Only 4 bytes (need at least 5)
+
+        let event = Parsers.ControlData.parse(payload)
+
+        // Should fall back to controlData since inner payload is too short
+        guard case .controlData(let info) = event else {
+            XCTFail("Expected controlData for short DISCOVER_RESP payload, got \(event)")
+            return
+        }
+
+        XCTAssertEqual(info.payloadType, 0x91)
+    }
+}

--- a/MeshCore/Tests/MeshCoreTests/Validation/NewResponseParsingTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Validation/NewResponseParsingTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import MeshCore
+
+final class NewResponseParsingTests: XCTestCase {
+
+    func test_advertPathResponse_parse() {
+        var payload = Data()
+        payload.appendLittleEndian(UInt32(1704067200))  // timestamp
+        payload.append(0x03)  // path length
+        payload.append(contentsOf: [0x11, 0x22, 0x33])  // path
+
+        let event = Parsers.AdvertPathResponse.parse(payload)
+
+        guard case .advertPathResponse(let response) = event else {
+            XCTFail("Expected advertPathResponse, got \(event)")
+            return
+        }
+
+        XCTAssertEqual(response.recvTimestamp, 1704067200)
+        XCTAssertEqual(response.pathLength, 3)
+        XCTAssertEqual(response.path, Data([0x11, 0x22, 0x33]))
+    }
+
+    func test_advertPathResponse_emptyPath() {
+        var payload = Data()
+        payload.appendLittleEndian(UInt32(1000))
+        payload.append(0x00)  // path length = 0
+
+        let event = Parsers.AdvertPathResponse.parse(payload)
+
+        guard case .advertPathResponse(let response) = event else {
+            XCTFail("Expected advertPathResponse")
+            return
+        }
+
+        XCTAssertEqual(response.pathLength, 0)
+        XCTAssertEqual(response.path.count, 0)
+    }
+
+    func test_advertPathResponse_tooShort() {
+        // Less than 5 bytes should fail
+        let shortPayload = Data([0x01, 0x02, 0x03, 0x04])
+
+        let event = Parsers.AdvertPathResponse.parse(shortPayload)
+
+        guard case .parseFailure = event else {
+            XCTFail("Expected parseFailure for short payload")
+            return
+        }
+    }
+
+    func test_tuningParamsResponse_parse() {
+        var payload = Data()
+        // rx_delay_base * 1000 = 1500 (1.5ms)
+        payload.appendLittleEndian(UInt32(1500))
+        // airtime_factor * 1000 = 2500 (2.5)
+        payload.appendLittleEndian(UInt32(2500))
+
+        let event = Parsers.TuningParamsResponse.parse(payload)
+
+        guard case .tuningParamsResponse(let response) = event else {
+            XCTFail("Expected tuningParamsResponse, got \(event)")
+            return
+        }
+
+        XCTAssertEqual(response.rxDelayBase, 1.5, accuracy: 0.001)
+        XCTAssertEqual(response.airtimeFactor, 2.5, accuracy: 0.001)
+    }
+
+    func test_tuningParamsResponse_tooShort() {
+        // Less than 8 bytes should fail
+        let shortPayload = Data([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07])
+
+        let event = Parsers.TuningParamsResponse.parse(shortPayload)
+
+        guard case .parseFailure = event else {
+            XCTFail("Expected parseFailure for short payload")
+            return
+        }
+    }
+
+    func test_tuningParamsResponse_zeroValues() {
+        var payload = Data()
+        payload.appendLittleEndian(UInt32(0))
+        payload.appendLittleEndian(UInt32(0))
+
+        let event = Parsers.TuningParamsResponse.parse(payload)
+
+        guard case .tuningParamsResponse(let response) = event else {
+            XCTFail("Expected tuningParamsResponse")
+            return
+        }
+
+        XCTAssertEqual(response.rxDelayBase, 0.0, accuracy: 0.001)
+        XCTAssertEqual(response.airtimeFactor, 0.0, accuracy: 0.001)
+    }
+}

--- a/MeshCore/Tests/MeshCoreTests/Validation/PathDiscoveryParsingTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Validation/PathDiscoveryParsingTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import MeshCore
+
+final class PathDiscoveryParsingTests: XCTestCase {
+
+    func test_pathDiscoveryResponse_skipsReservedByte() {
+        // Firmware format: [reserved:1][pubkey:6][out_len:1][out_path...][in_len:1][in_path...]
+        var payload = Data()
+        payload.append(0x00)  // Reserved byte (should be skipped)
+        payload.append(contentsOf: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF])  // Pubkey prefix
+        payload.append(0x02)  // out_path_len = 2
+        payload.append(contentsOf: [0x11, 0x22])  // out_path
+        payload.append(0x03)  // in_path_len = 3
+        payload.append(contentsOf: [0x33, 0x44, 0x55])  // in_path
+
+        let event = Parsers.PathDiscoveryResponse.parse(payload)
+
+        guard case .pathResponse(let pathInfo) = event else {
+            XCTFail("Expected pathResponse, got \(event)")
+            return
+        }
+
+        XCTAssertEqual(pathInfo.publicKeyPrefix.hexString, "aabbccddeeff",
+            "Pubkey should start at byte 1")
+        XCTAssertEqual(pathInfo.outPath, Data([0x11, 0x22]),
+            "Out path should be [0x11, 0x22]")
+        XCTAssertEqual(pathInfo.inPath, Data([0x33, 0x44, 0x55]),
+            "In path should be [0x33, 0x44, 0x55]")
+    }
+
+    func test_pathDiscoveryResponse_handlesEmptyPaths() {
+        var payload = Data()
+        payload.append(0x00)  // Reserved
+        payload.append(contentsOf: [0x11, 0x22, 0x33, 0x44, 0x55, 0x66])  // Pubkey
+        payload.append(0x00)  // out_path_len = 0
+        payload.append(0x00)  // in_path_len = 0
+
+        let event = Parsers.PathDiscoveryResponse.parse(payload)
+
+        guard case .pathResponse(let pathInfo) = event else {
+            XCTFail("Expected pathResponse")
+            return
+        }
+
+        XCTAssertEqual(pathInfo.outPath.count, 0)
+        XCTAssertEqual(pathInfo.inPath.count, 0)
+    }
+
+    func test_pathDiscoveryResponse_rejectsShortPayload() {
+        let shortPayload = Data([0x00, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE])  // Only 6 bytes
+
+        let event = Parsers.PathDiscoveryResponse.parse(shortPayload)
+
+        guard case .parseFailure = event else {
+            XCTFail("Expected parseFailure for short payload")
+            return
+        }
+    }
+}

--- a/MeshCore/Tests/MeshCoreTests/Validation/RawDataParsingTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Validation/RawDataParsingTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import MeshCore
+
+final class RawDataParsingTests: XCTestCase {
+
+    func test_rawData_skipsReservedByte() {
+        // Firmware format: [snr:1][rssi:1][reserved:1][payload...]
+        var payload = Data()
+        payload.append(0x28)  // SNR: 40/4 = 10.0
+        payload.append(0xAB)  // RSSI: -85 (signed)
+        payload.append(0xFF)  // Reserved byte (should be skipped)
+        payload.append(contentsOf: [0x01, 0x02, 0x03, 0x04])  // Actual payload
+
+        let event = Parsers.RawData.parse(payload)
+
+        guard case .rawData(let info) = event else {
+            XCTFail("Expected rawData, got \(event)")
+            return
+        }
+
+        XCTAssertEqual(info.snr, 10.0, accuracy: 0.001)
+        XCTAssertEqual(info.rssi, -85)
+        XCTAssertEqual(info.payload, Data([0x01, 0x02, 0x03, 0x04]),
+            "Payload should not include reserved byte 0xFF")
+    }
+
+    func test_rawData_rejectsShortPayload() {
+        let shortPayload = Data([0x28, 0xAB])  // Only 2 bytes, need 3
+
+        let event = Parsers.RawData.parse(shortPayload)
+
+        guard case .parseFailure = event else {
+            XCTFail("Expected parseFailure for short payload")
+            return
+        }
+    }
+
+    func test_rawData_handlesEmptyPayload() {
+        // Minimum valid: snr + rssi + reserved = 3 bytes, no actual payload
+        let payload = Data([0x28, 0xAB, 0xFF])
+
+        let event = Parsers.RawData.parse(payload)
+
+        guard case .rawData(let info) = event else {
+            XCTFail("Expected rawData")
+            return
+        }
+
+        XCTAssertEqual(info.payload.count, 0, "Should have empty payload")
+    }
+}

--- a/MeshCore/Tests/MeshCoreTests/Validation/TelemetryParsingTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Validation/TelemetryParsingTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import MeshCore
+
+final class TelemetryParsingTests: XCTestCase {
+
+    func test_telemetryResponse_skipsReservedByte() {
+        // Firmware format: [reserved:1][pubkey_prefix:6][lpp_data...]
+        var payload = Data()
+        payload.append(0x00)  // Reserved byte (should be skipped)
+        payload.append(contentsOf: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF])  // Pubkey prefix
+        payload.append(contentsOf: [0x01, 0x67, 0x00, 0xFA])  // LPP: channel 1, temp, 25.0C
+
+        let event = Parsers.TelemetryResponse.parse(payload)
+
+        guard case .telemetryResponse(let response) = event else {
+            XCTFail("Expected telemetryResponse, got \(event)")
+            return
+        }
+
+        XCTAssertEqual(response.publicKeyPrefix.hexString, "aabbccddeeff",
+            "Pubkey should start at byte 1, not byte 0")
+        XCTAssertNil(response.tag, "Push telemetry should have no tag")
+        XCTAssertEqual(response.rawData, Data([0x01, 0x67, 0x00, 0xFA]),
+            "LPP data should start at byte 7")
+    }
+
+    func test_telemetryResponse_rejectsShortPayload() {
+        let shortPayload = Data([0x00, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE])  // Only 6 bytes
+
+        let event = Parsers.TelemetryResponse.parse(shortPayload)
+
+        guard case .parseFailure = event else {
+            XCTFail("Expected parseFailure for short payload")
+            return
+        }
+    }
+
+    func test_telemetryResponse_handlesEmptyLPPData() {
+        // Minimum valid: reserved + pubkey = 7 bytes, no LPP data
+        var payload = Data()
+        payload.append(0x00)  // Reserved
+        payload.append(contentsOf: [0x11, 0x22, 0x33, 0x44, 0x55, 0x66])  // Pubkey
+
+        let event = Parsers.TelemetryResponse.parse(payload)
+
+        guard case .telemetryResponse(let response) = event else {
+            XCTFail("Expected telemetryResponse")
+            return
+        }
+
+        XCTAssertEqual(response.rawData.count, 0, "Should have empty LPP data")
+    }
+}

--- a/MeshCore/Tests/MeshCoreTests/Validation/TraceDataParsingTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Validation/TraceDataParsingTests.swift
@@ -1,0 +1,211 @@
+import XCTest
+@testable import MeshCore
+
+final class TraceDataParsingTests: XCTestCase {
+
+    func test_traceData_pathSz0_singleByteHashes() {
+        // path_sz=0: 1-byte hashes, pathLength = hop count
+        var payload = Data()
+        payload.append(0x00)  // Reserved
+        payload.append(0x02)  // pathLength = 2 hashes
+        payload.append(0x00)  // flags: path_sz = 0
+        payload.appendLittleEndian(UInt32(12345))  // tag
+        payload.appendLittleEndian(UInt32(67890))  // authCode
+        payload.append(contentsOf: [0xAA, 0xBB])   // 2 hash bytes
+        payload.append(contentsOf: [0x28, 0x14])   // 2 SNR bytes (10.0, 5.0)
+        payload.append(0x0C)                        // final SNR (3.0)
+
+        let event = Parsers.TraceData.parse(payload)
+
+        guard case .traceData(let trace) = event else {
+            XCTFail("Expected traceData, got \(event)")
+            return
+        }
+
+        XCTAssertEqual(trace.tag, 12345)
+        XCTAssertEqual(trace.authCode, 67890)
+        XCTAssertEqual(trace.path.count, 3, "Should have 2 hops + 1 destination")
+
+        // Check hash bytes
+        XCTAssertEqual(trace.path[0].hashBytes, Data([0xAA]))
+        XCTAssertEqual(trace.path[1].hashBytes, Data([0xBB]))
+        XCTAssertNil(trace.path[2].hashBytes, "Destination has no hash")
+
+        // Check SNRs
+        XCTAssertEqual(trace.path[0].snr, 10.0, accuracy: 0.001)
+        XCTAssertEqual(trace.path[1].snr, 5.0, accuracy: 0.001)
+        XCTAssertEqual(trace.path[2].snr, 3.0, accuracy: 0.001)
+    }
+
+    func test_traceData_pathSz2_fourByteHashes() {
+        // path_sz=2: 4-byte hashes, hopCount = pathLength / 4
+        var payload = Data()
+        payload.append(0x00)  // Reserved
+        payload.append(0x08)  // pathLength = 8 hash bytes = 2 hops
+        payload.append(0x02)  // flags: path_sz = 2 (means 4 bytes per hash)
+        payload.appendLittleEndian(UInt32(111))  // tag
+        payload.appendLittleEndian(UInt32(222))  // authCode
+        // 8 hash bytes (2 hops x 4 bytes)
+        payload.append(contentsOf: [0x11, 0x22, 0x33, 0x44])  // hop 0
+        payload.append(contentsOf: [0x55, 0x66, 0x77, 0x88])  // hop 1
+        // 2 SNR bytes (one per hop)
+        payload.append(contentsOf: [0x28, 0x14])  // SNRs: 10.0, 5.0
+        payload.append(0x0C)  // final SNR: 3.0
+
+        let event = Parsers.TraceData.parse(payload)
+
+        guard case .traceData(let trace) = event else {
+            XCTFail("Expected traceData, got \(event)")
+            return
+        }
+
+        XCTAssertEqual(trace.path.count, 3, "Should have 2 hops + 1 destination")
+
+        // Check 4-byte hashes
+        XCTAssertEqual(trace.path[0].hashBytes, Data([0x11, 0x22, 0x33, 0x44]))
+        XCTAssertEqual(trace.path[1].hashBytes, Data([0x55, 0x66, 0x77, 0x88]))
+        XCTAssertNil(trace.path[2].hashBytes)
+
+        // Legacy hash accessor (first byte only)
+        XCTAssertEqual(trace.path[0].hash, 0x11)
+    }
+
+    func test_traceData_pathSz1_twoByteHashes() {
+        // path_sz=1: 2-byte hashes, hopCount = pathLength / 2
+        var payload = Data()
+        payload.append(0x00)  // Reserved
+        payload.append(0x04)  // pathLength = 4 hash bytes = 2 hops
+        payload.append(0x01)  // flags: path_sz = 1 (means 2 bytes per hash)
+        payload.appendLittleEndian(UInt32(100))  // tag
+        payload.appendLittleEndian(UInt32(200))  // authCode
+        // 4 hash bytes (2 hops x 2 bytes)
+        payload.append(contentsOf: [0xAA, 0xBB])  // hop 0
+        payload.append(contentsOf: [0xCC, 0xDD])  // hop 1
+        // 2 SNR bytes (one per hop)
+        payload.append(contentsOf: [0x28, 0x14])  // SNRs: 10.0, 5.0
+        payload.append(0x0C)  // final SNR: 3.0
+
+        let event = Parsers.TraceData.parse(payload)
+
+        guard case .traceData(let trace) = event else {
+            XCTFail("Expected traceData, got \(event)")
+            return
+        }
+
+        XCTAssertEqual(trace.path.count, 3, "Should have 2 hops + 1 destination")
+
+        // Check 2-byte hashes
+        XCTAssertEqual(trace.path[0].hashBytes, Data([0xAA, 0xBB]))
+        XCTAssertEqual(trace.path[1].hashBytes, Data([0xCC, 0xDD]))
+        XCTAssertNil(trace.path[2].hashBytes)
+    }
+
+    func test_traceData_destinationMarker() {
+        // 0xFF hash means destination (no hash)
+        var payload = Data()
+        payload.append(0x00)  // Reserved
+        payload.append(0x01)  // pathLength = 1
+        payload.append(0x00)  // flags: path_sz = 0
+        payload.appendLittleEndian(UInt32(1))  // tag
+        payload.appendLittleEndian(UInt32(2))  // authCode
+        payload.append(0xFF)  // hash = 0xFF (destination marker)
+        payload.append(0x28)  // SNR
+        payload.append(0x14)  // final SNR
+
+        let event = Parsers.TraceData.parse(payload)
+
+        guard case .traceData(let trace) = event else {
+            XCTFail("Expected traceData")
+            return
+        }
+
+        // 0xFF hash should be interpreted as destination (nil)
+        XCTAssertNil(trace.path[0].hashBytes)
+    }
+
+    func test_traceData_emptyPath() {
+        // pathLength = 0 means direct connection (no intermediate hops)
+        var payload = Data()
+        payload.append(0x00)  // Reserved
+        payload.append(0x00)  // pathLength = 0
+        payload.append(0x00)  // flags: path_sz = 0
+        payload.appendLittleEndian(UInt32(999))  // tag
+        payload.appendLittleEndian(UInt32(888))  // authCode
+        payload.append(0x28)  // final SNR only
+
+        let event = Parsers.TraceData.parse(payload)
+
+        guard case .traceData(let trace) = event else {
+            XCTFail("Expected traceData, got \(event)")
+            return
+        }
+
+        XCTAssertEqual(trace.path.count, 1, "Should have destination only")
+        XCTAssertNil(trace.path[0].hashBytes, "Destination has no hash")
+        XCTAssertEqual(trace.path[0].snr, 10.0, accuracy: 0.001)
+    }
+
+    func test_traceData_legacyHashAccessor() {
+        // Verify legacy hash property works correctly
+        var payload = Data()
+        payload.append(0x00)  // Reserved
+        payload.append(0x01)  // pathLength = 1
+        payload.append(0x00)  // flags: path_sz = 0
+        payload.appendLittleEndian(UInt32(1))  // tag
+        payload.appendLittleEndian(UInt32(2))  // authCode
+        payload.append(0x42)  // hash
+        payload.append(0x28)  // SNR
+        payload.append(0x14)  // final SNR
+
+        let event = Parsers.TraceData.parse(payload)
+
+        guard case .traceData(let trace) = event else {
+            XCTFail("Expected traceData")
+            return
+        }
+
+        // Legacy accessor should return first byte
+        XCTAssertEqual(trace.path[0].hash, 0x42)
+        XCTAssertNil(trace.path[1].hash, "Destination has no hash")
+    }
+
+    func test_traceData_tooShortPayload() {
+        // Less than 11 bytes should fail
+        let shortPayload = Data([0x00, 0x01, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07])
+
+        let event = Parsers.TraceData.parse(shortPayload)
+
+        guard case .parseFailure = event else {
+            XCTFail("Expected parseFailure for short payload")
+            return
+        }
+    }
+
+    func test_traceNode_initWithHashBytes() {
+        let node = TraceNode(hashBytes: Data([0x11, 0x22, 0x33]), snr: 5.5)
+        XCTAssertEqual(node.hashBytes, Data([0x11, 0x22, 0x33]))
+        XCTAssertEqual(node.snr, 5.5)
+        XCTAssertEqual(node.hash, 0x11, "Legacy accessor returns first byte")
+    }
+
+    func test_traceNode_initWithNilHashBytes() {
+        let node = TraceNode(hashBytes: nil, snr: 3.0)
+        XCTAssertNil(node.hashBytes)
+        XCTAssertNil(node.hash)
+        XCTAssertEqual(node.snr, 3.0)
+    }
+
+    func test_traceNode_legacyInitWithHash() {
+        let node = TraceNode(hash: 0xAB, snr: 7.5)
+        XCTAssertEqual(node.hashBytes, Data([0xAB]))
+        XCTAssertEqual(node.hash, 0xAB)
+        XCTAssertEqual(node.snr, 7.5)
+    }
+
+    func test_traceNode_legacyInitWithNilHash() {
+        let node = TraceNode(hash: nil, snr: 2.0)
+        XCTAssertNil(node.hashBytes)
+        XCTAssertNil(node.hash)
+        XCTAssertEqual(node.snr, 2.0)
+    }
+}


### PR DESCRIPTION
## Summary

This PR makes the MeshCore Swift library fully compliant with companion firmware v1.11+, addressing 8 protocol compliance issues identified in the audit.

### Parsing Fixes
- Skip reserved byte at offset 0 in telemetry, path discovery, and raw data responses
- Trace data parser handles variable-size `path_sz` hashes (1/2/4/8 bytes)
- DISCOVER_RESP payloads auto-decoded in ControlData parser

### Command Fixes
- `factoryReset` includes required "reset" guard string
- `updateContact` sends full 147-byte contact structure

### New Features
- Added 5 missing command codes (`sendRawData`, `hasConnection`, `getContactByKey`, `getAdvertPath`, `getTuningParams`)
- Added 5 corresponding command builders
- Added 2 new response models (`AdvertPathResponse`, `TuningParamsResponse`)
- Added `Data` helper extensions for padding and little-endian encoding

## Test plan

- [x] All 128 tests passing (was 79, added 49 new tests)
- [x] Main project builds successfully
- [x] No regressions in existing functionality