### PR TITLE
fix(trace): multi-byte hash support, device ID validation, and SNR attribution

### DIFF
--- a/PocketMeshTests/ViewModels/TracePathViewModelTests.swift
+++ b/PocketMeshTests/ViewModels/TracePathViewModelTests.swift
@@ -179,25 +179,26 @@ struct PreviousRunComparisonTests {
 @MainActor
 struct TraceResponseHopParsingTests {
 
-    @Test("handleTraceResponse creates correct hops for single-hop trace")
+    @Test("handleTraceResponse creates correct hops with sender SNR attribution")
     func singleHopTraceProducesCorrectHops() {
         let viewModel = TracePathViewModel()
 
         // Create a TraceInfo with one repeater hop + final nil node
+        // SNR values: 5.0 = how repeater heard us, 3.0 = how we heard return
         let traceInfo = TraceInfo(
             tag: 12345,
             authCode: 0,
             flags: 0,
             pathLength: 1,
             path: [
-                TraceNode(hash: 0xAB, snr: 5.0),   // Repeater
-                TraceNode(hash: nil, snr: 3.0)     // Return to local
+                TraceNode(hash: 0xAB, snr: 5.0),   // Repeater received at 5.0 dB
+                TraceNode(hash: nil, snr: 3.0)     // We received return at 3.0 dB
             ]
         )
 
         // Set up pending tag to match
         viewModel.setPendingTagForTesting(12345)
-        viewModel.handleTraceResponse(traceInfo)
+        viewModel.handleTraceResponse(traceInfo, deviceID: nil)
 
         guard let result = viewModel.result else {
             Issue.record("Result should not be nil")
@@ -207,42 +208,44 @@ struct TraceResponseHopParsingTests {
         #expect(result.success == true)
         #expect(result.hops.count == 3)  // Start + 1 repeater + End
 
-        // Start node (local device)
+        // Start node gets SNR from first hop (how repeater heard our transmission)
         #expect(result.hops[0].isStartNode == true)
-        #expect(result.hops[0].hashByte == nil)
-        #expect(result.hops[0].snr == 0)  // No incoming SNR for sender
+        #expect(result.hops[0].hashBytes == nil)
+        #expect(result.hops[0].snr == 5.0)  // Sender attribution: how first hop heard us
 
-        // Intermediate hop (repeater)
+        // Intermediate hop gets SNR from next node (how we heard its return)
         #expect(result.hops[1].isStartNode == false)
         #expect(result.hops[1].isEndNode == false)
-        #expect(result.hops[1].hashByte == 0xAB)
-        #expect(result.hops[1].snr == 5.0)
+        #expect(result.hops[1].hashBytes == Data([0xAB]))
+        #expect(result.hops[1].snr == 3.0)  // Sender attribution: how end node heard repeater
 
-        // End node (return to local)
+        // End node has no SNR (no next hop to measure)
         #expect(result.hops[2].isEndNode == true)
-        #expect(result.hops[2].hashByte == nil)
-        #expect(result.hops[2].snr == 3.0)
+        #expect(result.hops[2].hashBytes == nil)
+        #expect(result.hops[2].snr == 0)  // No next hop, so no SNR
     }
 
-    @Test("handleTraceResponse creates correct hops for multi-hop trace")
+    @Test("handleTraceResponse creates correct hops for multi-hop trace with sender SNR attribution")
     func multiHopTraceProducesCorrectHops() {
         let viewModel = TracePathViewModel()
 
+        // Path: Start → AA → BB → CC → End
+        // SNR values represent what each node recorded when receiving
         let traceInfo = TraceInfo(
             tag: 12345,
             authCode: 0,
             flags: 0,
             pathLength: 3,
             path: [
-                TraceNode(hash: 0xAA, snr: 6.0),   // First repeater
-                TraceNode(hash: 0xBB, snr: 4.0),   // Second repeater
-                TraceNode(hash: 0xCC, snr: 2.0),   // Third repeater
-                TraceNode(hash: nil, snr: -1.0)    // Return to local
+                TraceNode(hash: 0xAA, snr: 6.0),   // AA heard Start at 6.0 dB
+                TraceNode(hash: 0xBB, snr: 4.0),   // BB heard AA at 4.0 dB
+                TraceNode(hash: 0xCC, snr: 2.0),   // CC heard BB at 2.0 dB
+                TraceNode(hash: nil, snr: -1.0)    // End heard CC at -1.0 dB
             ]
         )
 
         viewModel.setPendingTagForTesting(12345)
-        viewModel.handleTraceResponse(traceInfo)
+        viewModel.handleTraceResponse(traceInfo, deviceID: nil)
 
         guard let result = viewModel.result else {
             Issue.record("Result should not be nil")
@@ -251,10 +254,17 @@ struct TraceResponseHopParsingTests {
 
         #expect(result.hops.count == 5)  // Start + 3 repeaters + End
 
+        // Sender attribution: each node shows how the NEXT hop heard its transmission
+        #expect(result.hops[0].snr == 6.0)   // Start: how AA heard us
+        #expect(result.hops[1].snr == 4.0)   // AA: how BB heard AA
+        #expect(result.hops[2].snr == 2.0)   // BB: how CC heard BB
+        #expect(result.hops[3].snr == -1.0)  // CC: how End heard CC
+        #expect(result.hops[4].snr == 0)     // End: no next hop
+
         // Verify all intermediate hops are present
-        #expect(result.hops[1].hashByte == 0xAA)
-        #expect(result.hops[2].hashByte == 0xBB)
-        #expect(result.hops[3].hashByte == 0xCC)
+        #expect(result.hops[1].hashBytes == Data([0xAA]))
+        #expect(result.hops[2].hashBytes == Data([0xBB]))
+        #expect(result.hops[3].hashBytes == Data([0xCC]))
     }
 
     @Test("handleTraceResponse ignores non-matching tags")
@@ -273,7 +283,7 @@ struct TraceResponseHopParsingTests {
         )
 
         viewModel.setPendingTagForTesting(12345)  // Different from traceInfo.tag
-        viewModel.handleTraceResponse(traceInfo)
+        viewModel.handleTraceResponse(traceInfo, deviceID: nil)
 
         #expect(viewModel.result == nil)
     }
@@ -304,7 +314,7 @@ struct ResultIDBehaviorTests {
         viewModel.setPendingTagForTesting(12345)
         #expect(viewModel.resultID == nil)
 
-        viewModel.handleTraceResponse(traceInfo)
+        viewModel.handleTraceResponse(traceInfo, deviceID: nil)
 
         #expect(viewModel.resultID != nil)
     }
@@ -325,7 +335,7 @@ struct ResultIDBehaviorTests {
         )
 
         viewModel.setPendingTagForTesting(12345)
-        viewModel.handleTraceResponse(traceInfo)
+        viewModel.handleTraceResponse(traceInfo, deviceID: nil)
         let firstID = viewModel.resultID
 
         // Run another trace
@@ -340,7 +350,7 @@ struct ResultIDBehaviorTests {
                 TraceNode(hash: nil, snr: 3.0)
             ]
         )
-        viewModel.handleTraceResponse(traceInfo2)
+        viewModel.handleTraceResponse(traceInfo2, deviceID: nil)
 
         #expect(viewModel.resultID != firstID)
     }
@@ -483,3 +493,337 @@ struct ErrorHandlingTests {
     }
 }
 
+// MARK: - Multi-byte Hash Tests
+
+@Suite("Multi-byte Hash Handling")
+@MainActor
+struct MultiByteHashTests {
+
+    @Test("multi-byte hash produces hop with full hashBytes and nil resolvedName")
+    func multiByteHashProducesFullHashBytes() {
+        let viewModel = TracePathViewModel()
+
+        let traceInfo = TraceInfo(
+            tag: 12345,
+            authCode: 0,
+            flags: 0,
+            pathLength: 1,
+            path: [
+                TraceNode(hashBytes: Data([0xAB, 0xCD]), snr: 5.0),
+                TraceNode(hashBytes: nil, snr: 3.0)
+            ]
+        )
+
+        viewModel.setPendingTagForTesting(12345)
+        viewModel.handleTraceResponse(traceInfo, deviceID: nil)
+
+        guard let result = viewModel.result else {
+            Issue.record("Result should not be nil")
+            return
+        }
+
+        // Intermediate hop should have full 2-byte hash
+        #expect(result.hops[1].hashBytes == Data([0xAB, 0xCD]))
+        // Multi-byte hash cannot be resolved
+        #expect(result.hops[1].resolvedName == nil)
+        // Display string shows both bytes
+        #expect(result.hops[1].hashDisplayString == "ABCD")
+    }
+
+    @Test("single-byte hash still resolves to contact name")
+    func singleByteHashResolvesToName() {
+        let viewModel = TracePathViewModel()
+
+        let traceInfo = TraceInfo(
+            tag: 12345,
+            authCode: 0,
+            flags: 0,
+            pathLength: 1,
+            path: [
+                TraceNode(hash: 0xAB, snr: 5.0),
+                TraceNode(hash: nil, snr: 3.0)
+            ]
+        )
+
+        viewModel.setPendingTagForTesting(12345)
+        viewModel.handleTraceResponse(traceInfo, deviceID: nil)
+
+        guard let result = viewModel.result else {
+            Issue.record("Result should not be nil")
+            return
+        }
+
+        // Single-byte hash stored correctly
+        #expect(result.hops[1].hashBytes == Data([0xAB]))
+        #expect(result.hops[1].hashDisplayString == "AB")
+    }
+}
+
+// MARK: - Device ID Validation Tests
+
+@Suite("Device ID Validation")
+@MainActor
+struct DeviceIDValidationTests {
+
+    @Test("response from different device is ignored")
+    func responseFromDifferentDeviceIgnored() {
+        let viewModel = TracePathViewModel()
+        let pendingDevice = UUID()
+        let differentDevice = UUID()
+
+        let traceInfo = TraceInfo(
+            tag: 12345,
+            authCode: 0,
+            flags: 0,
+            pathLength: 1,
+            path: [
+                TraceNode(hash: 0xAB, snr: 5.0),
+                TraceNode(hash: nil, snr: 3.0)
+            ]
+        )
+
+        viewModel.setPendingTagForTesting(12345)
+        viewModel.setPendingDeviceIDForTesting(pendingDevice)
+        viewModel.handleTraceResponse(traceInfo, deviceID: differentDevice)
+
+        // Result should be nil - response was ignored
+        #expect(viewModel.result == nil)
+    }
+
+    @Test("response accepted when device IDs match")
+    func responseAcceptedWhenDeviceIDsMatch() {
+        let viewModel = TracePathViewModel()
+        let deviceID = UUID()
+
+        let traceInfo = TraceInfo(
+            tag: 12345,
+            authCode: 0,
+            flags: 0,
+            pathLength: 1,
+            path: [
+                TraceNode(hash: 0xAB, snr: 5.0),
+                TraceNode(hash: nil, snr: 3.0)
+            ]
+        )
+
+        viewModel.setPendingTagForTesting(12345)
+        viewModel.setPendingDeviceIDForTesting(deviceID)
+        viewModel.handleTraceResponse(traceInfo, deviceID: deviceID)
+
+        #expect(viewModel.result != nil)
+        #expect(viewModel.result?.success == true)
+    }
+
+    @Test("tag-only matching works when pendingDeviceID is nil")
+    func tagOnlyMatchingWhenPendingDeviceIDNil() {
+        let viewModel = TracePathViewModel()
+
+        let traceInfo = TraceInfo(
+            tag: 12345,
+            authCode: 0,
+            flags: 0,
+            pathLength: 1,
+            path: [
+                TraceNode(hash: 0xAB, snr: 5.0),
+                TraceNode(hash: nil, snr: 3.0)
+            ]
+        )
+
+        viewModel.setPendingTagForTesting(12345)
+        viewModel.setPendingDeviceIDForTesting(nil)
+        viewModel.handleTraceResponse(traceInfo, deviceID: UUID())
+
+        // Should accept - pendingDeviceID is nil so skip device check
+        #expect(viewModel.result != nil)
+    }
+
+    @Test("tag-only matching works when received deviceID is nil")
+    func tagOnlyMatchingWhenReceivedDeviceIDNil() {
+        let viewModel = TracePathViewModel()
+
+        let traceInfo = TraceInfo(
+            tag: 12345,
+            authCode: 0,
+            flags: 0,
+            pathLength: 1,
+            path: [
+                TraceNode(hash: 0xAB, snr: 5.0),
+                TraceNode(hash: nil, snr: 3.0)
+            ]
+        )
+
+        viewModel.setPendingTagForTesting(12345)
+        viewModel.setPendingDeviceIDForTesting(UUID())
+        viewModel.handleTraceResponse(traceInfo, deviceID: nil)
+
+        // Should accept - received deviceID is nil so skip device check
+        #expect(viewModel.result != nil)
+    }
+}
+
+// MARK: - Path Capture Tests
+
+@Suite("Path Capture in Result")
+@MainActor
+struct PathCaptureTests {
+
+    @Test("result contains original path even if outboundPath modified")
+    func resultContainsOriginalPath() {
+        let viewModel = TracePathViewModel()
+
+        // Set up pending path hash (simulating what runTrace does)
+        let originalPath: [UInt8] = [0xAA, 0xBB, 0xAA]
+        viewModel.setPendingPathHashForTesting(originalPath)
+        viewModel.setPendingTagForTesting(12345)
+
+        let traceInfo = TraceInfo(
+            tag: 12345,
+            authCode: 0,
+            flags: 0,
+            pathLength: 1,
+            path: [
+                TraceNode(hash: 0xAA, snr: 5.0),
+                TraceNode(hash: nil, snr: 3.0)
+            ]
+        )
+
+        viewModel.handleTraceResponse(traceInfo, deviceID: nil)
+
+        guard let result = viewModel.result else {
+            Issue.record("Result should not be nil")
+            return
+        }
+
+        // Result should contain the original path
+        #expect(result.tracedPathBytes == originalPath)
+        #expect(result.tracedPathString == "AA,BB,AA")
+    }
+
+    @Test("canSavePath is false when path modified after trace")
+    func canSavePathFalseWhenPathModified() {
+        let viewModel = TracePathViewModel()
+
+        // Simulate a completed trace with path [0xAA, 0xAA]
+        let originalPath: [UInt8] = [0xAA, 0xAA]
+        viewModel.setPendingPathHashForTesting(originalPath)
+        viewModel.setPendingTagForTesting(12345)
+
+        let traceInfo = TraceInfo(
+            tag: 12345,
+            authCode: 0,
+            flags: 0,
+            pathLength: 1,
+            path: [
+                TraceNode(hash: 0xAA, snr: 5.0),
+                TraceNode(hash: nil, snr: 3.0)
+            ]
+        )
+
+        viewModel.handleTraceResponse(traceInfo, deviceID: nil)
+
+        // Verify result exists and has correct path
+        #expect(viewModel.result?.tracedPathBytes == originalPath)
+
+        // Now modify the outbound path (simulate user adding another hop)
+        let contact = Contact(
+            id: UUID(),
+            deviceID: UUID(),
+            publicKey: Data([0xBB] + Array(repeating: UInt8(0x00), count: 31)),
+            name: "Different",
+            typeRawValue: ContactType.repeater.rawValue,
+            flags: 0,
+            outPathLength: 0,
+            outPath: Data(),
+            lastAdvertTimestamp: 0,
+            latitude: 0,
+            longitude: 0,
+            lastModified: 0
+        )
+        viewModel.addRepeater(ContactDTO(from: contact))
+
+        // fullPathBytes is now different from result.tracedPathBytes
+        // canSavePath should be false
+        #expect(viewModel.canSavePath == false)
+    }
+
+    @Test("canSavePath is true when path unchanged after trace")
+    func canSavePathTrueWhenPathUnchanged() {
+        let viewModel = TracePathViewModel()
+
+        // Add a repeater first so fullPathBytes is populated
+        let contact = Contact(
+            id: UUID(),
+            deviceID: UUID(),
+            publicKey: Data([0xAA] + Array(repeating: UInt8(0x00), count: 31)),
+            name: "Repeater",
+            typeRawValue: ContactType.repeater.rawValue,
+            flags: 0,
+            outPathLength: 0,
+            outPath: Data(),
+            lastAdvertTimestamp: 0,
+            latitude: 0,
+            longitude: 0,
+            lastModified: 0
+        )
+        viewModel.addRepeater(ContactDTO(from: contact))
+
+        // Get the current full path bytes
+        let currentPath = viewModel.fullPathBytes
+
+        // Simulate trace with same path
+        viewModel.setPendingPathHashForTesting(currentPath)
+        viewModel.setPendingTagForTesting(12345)
+
+        let traceInfo = TraceInfo(
+            tag: 12345,
+            authCode: 0,
+            flags: 0,
+            pathLength: 1,
+            path: [
+                TraceNode(hash: 0xAA, snr: 5.0),
+                TraceNode(hash: nil, snr: 3.0)
+            ]
+        )
+
+        viewModel.handleTraceResponse(traceInfo, deviceID: nil)
+
+        // Path unchanged, result successful - canSavePath should be true
+        #expect(viewModel.canSavePath == true)
+    }
+}
+
+// MARK: - Failure Result Tests
+
+@Suite("Failure Result Path Display")
+@MainActor
+struct FailureResultTests {
+
+    @Test("timeout result contains attempted path")
+    func timeoutResultContainsAttemptedPath() {
+        let attemptedPath: [UInt8] = [0xAA, 0xBB, 0xAA]
+        let result = TraceResult.timeout(attemptedPath: attemptedPath)
+
+        #expect(result.success == false)
+        #expect(result.tracedPathBytes == attemptedPath)
+        #expect(result.tracedPathString == "AA,BB,AA")
+    }
+
+    @Test("sendFailed result contains attempted path")
+    func sendFailedResultContainsAttemptedPath() {
+        let attemptedPath: [UInt8] = [0xCC, 0xDD, 0xCC]
+        let result = TraceResult.sendFailed("Connection lost", attemptedPath: attemptedPath)
+
+        #expect(result.success == false)
+        #expect(result.errorMessage == "Connection lost")
+        #expect(result.tracedPathBytes == attemptedPath)
+        #expect(result.tracedPathString == "CC,DD,CC")
+    }
+
+    @Test("empty path produces empty tracedPathString")
+    func emptyPathProducesEmptyString() {
+        let result = TraceResult.timeout(attemptedPath: [])
+
+        #expect(result.tracedPathBytes.isEmpty)
+        #expect(result.tracedPathString == "")
+    }
+}


### PR DESCRIPTION
## Summary

Bug fixes for the trace path feature:

- **Multi-byte hash support**: Changed `TraceHop.hashByte` to `hashBytes` (`Data`) to properly handle multi-byte node hashes
- **Device ID validation**: Added `pendingDeviceID` tracking and validation from trace notifications
- **Path saving fix**: Use `result.tracedPathBytes` for proper path capture when saving
- **SNR attribution**: Changed from receiver to sender attribution to match official MeshCore app behavior

## Test plan

- [ ] Run trace with single-hop path → SNR shows at start node, not end node
- [ ] Run trace with multi-hop path → each node shows how next hop received its signal
- [ ] Save a traced path → path bytes match what was traced
- [ ] Run `TracePathViewModelTests` → all tests pass