### PR TITLE
feat(tools): add Tools tab with Trace Path and Line of Sight

### DIFF
--- a/PocketMesh/ContentView.swift
+++ b/PocketMesh/ContentView.swift
@@ -65,7 +65,11 @@ struct MainTabView: View {
                 MapView()
             }
 
-            Tab("Settings", systemImage: "gear", value: 3) {
+            Tab("Tools", systemImage: "wrench.and.screwdriver", value: 3) {
+                ToolsView()
+            }
+
+            Tab("Settings", systemImage: "gear", value: 4) {
                 SettingsView()
             }
         }

--- a/PocketMesh/Views/Contacts/ContactsListView.swift
+++ b/PocketMesh/Views/Contacts/ContactsListView.swift
@@ -67,12 +67,6 @@ struct ContactsListView: View {
                             Label("Discovery", systemImage: "antenna.radiowaves.left.and.right")
                         }
 
-                        NavigationLink {
-                            TracePathView()
-                        } label: {
-                            Label("Trace Path", systemImage: "point.3.connected.trianglepath.dotted")
-                        }
-
                         Divider()
 
                         Button {

--- a/PocketMesh/Views/Map/MapView.swift
+++ b/PocketMesh/Views/Map/MapView.swift
@@ -7,8 +7,6 @@ struct MapView: View {
     @Environment(AppState.self) private var appState
     @State private var viewModel = MapViewModel()
     @State private var selectedContactForDetail: ContactDTO?
-    @State private var showLineOfSight = false
-    @State private var lineOfSightContact: ContactDTO?
     @Namespace private var mapScope
 
     var body: some View {
@@ -27,13 +25,6 @@ struct MapView: View {
                     BLEStatusIndicatorView()
                 }
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        showLineOfSight = true
-                    } label: {
-                        Label("Line of Sight", systemImage: "eye")
-                    }
-                }
-                ToolbarItem(placement: .topBarTrailing) {
                     refreshButton
                 }
             }
@@ -46,19 +37,10 @@ struct MapView: View {
             .sheet(item: $selectedContactForDetail) { contact in
                 ContactDetailSheet(
                     contact: contact,
-                    onMessage: { navigateToChat(with: contact) },
-                    onLineOfSight: { lineOfSightContact = contact }
+                    onMessage: { navigateToChat(with: contact) }
                 )
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
-            }
-            .fullScreenCover(isPresented: $showLineOfSight) {
-                LineOfSightView()
-                    .environment(appState)
-            }
-            .fullScreenCover(item: $lineOfSightContact) { contact in
-                LineOfSightView(preselectedContact: contact)
-                    .environment(appState)
             }
         }
     }
@@ -214,7 +196,6 @@ struct MapView: View {
 private struct ContactDetailSheet: View {
     let contact: ContactDTO
     let onMessage: () -> Void
-    let onLineOfSight: () -> Void
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -270,15 +251,6 @@ private struct ContactDetailSheet: View {
                         onMessage()
                     } label: {
                         Label("Send Message", systemImage: "message.fill")
-                    }
-
-                    if contact.hasLocation {
-                        Button {
-                            dismiss()
-                            onLineOfSight()
-                        } label: {
-                            Label("Line of Sight", systemImage: "eye")
-                        }
                     }
                 }
             }

--- a/PocketMesh/Views/Tools/ToolsView.swift
+++ b/PocketMesh/Views/Tools/ToolsView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// Container view for diagnostic and analysis tools
+struct ToolsView: View {
+    var body: some View {
+        NavigationStack {
+            List {
+                NavigationLink {
+                    TracePathView()
+                } label: {
+                    Label("Trace Path", systemImage: "point.3.connected.trianglepath.dotted")
+                }
+
+                NavigationLink {
+                    LineOfSightView()
+                } label: {
+                    Label("Line of Sight", systemImage: "eye")
+                }
+            }
+            .navigationTitle("Tools")
+        }
+    }
+}
+
+#Preview {
+    ToolsView()
+        .environment(AppState())
+}


### PR DESCRIPTION
## Summary

- Add new Tools tab between Map and Settings with `wrench.and.screwdriver` icon
- Create `ToolsView` containing navigation to Trace Path and Line of Sight
- Remove Trace Path from Contacts toolbar menu
- Remove Line of Sight access from Map view

## Test plan

- [x] Verify Tools tab appears between Map and Settings
- [x] Verify Trace Path accessible from Tools tab
- [x] Verify Line of Sight accessible from Tools tab
- [x] Verify Trace Path no longer in Contacts menu
- [x] Verify Line of Sight no longer in Map toolbar