### PR TITLE
feat(los): Line of Sight obstruction analysis UI

### DIFF
--- a/PocketMesh/Views/LineOfSight/Components/ShareSheet.swift
+++ b/PocketMesh/Views/LineOfSight/Components/ShareSheet.swift
@@ -1,0 +1,24 @@
+import MapKit
+import SwiftUI
+
+/// A SwiftUI wrapper for UIActivityViewController
+struct ShareSheet: UIViewControllerRepresentable {
+    let activityItems: [Any]
+    var applicationActivities: [UIActivity]? = nil
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(
+            activityItems: activityItems,
+            applicationActivities: applicationActivities
+        )
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}
+
+/// Extension to make MKMapItem work with sheet(item:)
+extension MKMapItem: @retroactive Identifiable {
+    public var id: String {
+        "\(placemark.coordinate.latitude),\(placemark.coordinate.longitude)"
+    }
+}

--- a/PocketMeshTests/Calculations/SegmentAnalysisTests.swift
+++ b/PocketMeshTests/Calculations/SegmentAnalysisTests.swift
@@ -1,0 +1,78 @@
+import CoreLocation
+import Testing
+
+@testable import PocketMesh
+
+@Suite("Segment Analysis Types")
+struct SegmentAnalysisTypeTests {
+
+    @Test("SegmentAnalysisResult stores segment data")
+    func segmentResultStoresData() {
+        let result = SegmentAnalysisResult(
+            startLabel: "A",
+            endLabel: "R",
+            clearanceStatus: .clear,
+            distanceMeters: 5000,
+            worstClearancePercent: 85
+        )
+
+        #expect(result.startLabel == "A")
+        #expect(result.endLabel == "R")
+        #expect(result.clearanceStatus == .clear)
+        #expect(result.distanceMeters == 5000)
+        #expect(result.worstClearancePercent == 85)
+    }
+
+    @Test("RelayPathAnalysisResult combines segments")
+    func relayResultCombinesSegments() {
+        let segmentAR = SegmentAnalysisResult(
+            startLabel: "A",
+            endLabel: "R",
+            clearanceStatus: .clear,
+            distanceMeters: 5000,
+            worstClearancePercent: 85
+        )
+        let segmentRB = SegmentAnalysisResult(
+            startLabel: "R",
+            endLabel: "B",
+            clearanceStatus: .marginal,
+            distanceMeters: 3000,
+            worstClearancePercent: 65
+        )
+
+        let result = RelayPathAnalysisResult(
+            segmentAR: segmentAR,
+            segmentRB: segmentRB
+        )
+
+        #expect(result.segmentAR.distanceMeters == 5000)
+        #expect(result.segmentRB.distanceMeters == 3000)
+        #expect(result.totalDistanceMeters == 8000)
+        #expect(result.overallStatus == .marginal)  // worst of the two
+    }
+
+    @Test("RelayPathAnalysisResult overall status is worst of segments")
+    func relayResultOverallStatus() {
+        // Both clear -> clear
+        let bothClear = RelayPathAnalysisResult(
+            segmentAR: SegmentAnalysisResult(
+                startLabel: "A", endLabel: "R", clearanceStatus: .clear, distanceMeters: 1000,
+                worstClearancePercent: 90),
+            segmentRB: SegmentAnalysisResult(
+                startLabel: "R", endLabel: "B", clearanceStatus: .clear, distanceMeters: 1000,
+                worstClearancePercent: 85)
+        )
+        #expect(bothClear.overallStatus == .clear)
+
+        // One blocked -> blocked
+        let oneBlocked = RelayPathAnalysisResult(
+            segmentAR: SegmentAnalysisResult(
+                startLabel: "A", endLabel: "R", clearanceStatus: .clear, distanceMeters: 1000,
+                worstClearancePercent: 90),
+            segmentRB: SegmentAnalysisResult(
+                startLabel: "R", endLabel: "B", clearanceStatus: .blocked, distanceMeters: 1000,
+                worstClearancePercent: -10)
+        )
+        #expect(oneBlocked.overallStatus == .blocked)
+    }
+}


### PR DESCRIPTION
## Summary

Add comprehensive Line of Sight analysis with obstruction detection and repeater placement:

- Redesigned terrain profile canvas with Fresnel zone visualization
- Off-path repeater support with A→R and R→B segment analysis
- Draggable on-path repeater marker with tooltip guidance
- Share menu for point and repeater coordinates
- Liquid Glass button styles with iOS 26 support
- Collapsible RF settings section
- Results cards for direct and relay path analysis

## Fixes

- Liquid Glass rendering at small sheet detents via presentationBackground
- Add Repeater button only shows when obstruction points exist
- Map pan/zoom works during pin relocation mode

## Test plan

- [x] Select two points and run analysis
- [x] Verify terrain profile shows Fresnel zones
- [x] Add repeater via "Add Repeater" button when path is obstructed
- [x] Drag repeater marker along terrain profile
- [x] Relocate repeater off-path and verify segment analysis
- [x] Test share menu for coordinates
- [x] Verify Liquid Glass buttons render at all sheet detent levels