### PR TITLE
fix(MeshCoreSession): Prevent message loss during reconnection sync

### DIFF
--- a/MeshCore/Sources/MeshCore/Session/MeshCoreSession.swift
+++ b/MeshCore/Sources/MeshCore/Session/MeshCoreSession.swift
@@ -336,12 +336,9 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
             guard let self else { return }
             await self.autoMessageFetchLoop()
         }
-        
-        do {
-            _ = try await getMessage()
-        } catch {
-            logger.debug("Initial message fetch: \(error.localizedDescription)")
-        }
+
+        // The auto-fetch loop polls messages in response to messagesWaiting events.
+        // For immediate polling, callers should use getMessage() or consume the events directly.
     }
 
     /// Stops automatic message fetching.


### PR DESCRIPTION
# fix(MeshCoreSession): Prevent message loss during reconnection sync

  ## Problem

  Channel messages that arrived while the device was disconnected were being lost after reconnection, even though they were queued on the radio. Direct messages worked fine - only channel messages were affected.

  ## Root Cause

  `MeshCoreSession.startAutoMessageFetching()` was immediately calling `getMessage()` to poll for messages. This happened **before** the sync phase could:
  1. Wire up message handlers
  2. Sync channel information from the device to the local database

  As a result, messages were consumed and discarded because handlers weren't ready and channels didn't exist in the database yet.

  ## Solution

  Removed the immediate `getMessage()` call from `startAutoMessageFetching()`. The connection flow now ensures proper sequencing:

  1. Connection establishes
  2. Auto-fetch background loop starts (without initial poll)
  3. Message handlers are wired up
  4. Channels are synced to the database
  5. `pollAllMessages()` is called during the sync phase
  6. Background auto-fetch loop continues

  Messages are only polled after the application is ready to handle them.

  ## Testing

  **Before fix:**
  - Connect to device → Disconnect → Send channel messages → Reconnect
  - Result: Channel messages lost ❌

  **After fix:**
  - Connect to device → Disconnect → Send channel messages → Reconnect
  - Result: All channel messages appear correctly ✅

  ## Changes

  - **File:** `MeshCore/Sources/MeshCore/Session/MeshCoreSession.swift`
  - **Method:** `startAutoMessageFetching()`
  - **Change:** Removed immediate `getMessage()` call and added explanatory comment