### PR TITLE
feat(tools): add RX Log viewer for raw RF packet inspection

### DIFF
--- a/MeshCore/Sources/MeshCore/Events/MeshEvent.swift
+++ b/MeshCore/Sources/MeshCore/Events/MeshEvent.swift
@@ -285,10 +285,12 @@ public enum MeshEvent: Sendable {
     /// Emitted when the device sends diagnostic log data.
     case logData(LogDataInfo)
 
-    /// Indicates raw RF log data.
+    /// Indicates parsed RF log data.
     ///
-    /// Emitted when the device sends low-level radio log data.
-    case rxLogData(LogDataInfo)
+    /// Emitted when the device sends low-level radio log data that has been
+    /// parsed into structured packet information including route type, payload type,
+    /// path nodes, and packet payload.
+    case rxLogData(ParsedRxLogData)
 
     /// Indicates that control protocol data was received.
     ///

--- a/MeshCore/Sources/MeshCore/MeshCore.docc/Extensions/MeshEvent.md
+++ b/MeshCore/Sources/MeshCore/MeshCore.docc/Extensions/MeshEvent.md
@@ -80,6 +80,17 @@
 - ``discoverResponse(_:)``
 - ``privateKey(_:)``
 
+#### rxLogData(_:)
+
+Indicates parsed RF log data.
+
+- Parameter parsed: A ``ParsedRxLogData`` containing structured packet information.
+
+Emitted when the device sends low-level radio log data that has been successfully
+parsed. Malformed payloads fall back to ``logData(_:)`` instead.
+
+> Note: Breaking change from prior versions which used `LogDataInfo`.
+
 ### Diagnostics
 
 - ``parseFailure(data:reason:)``

--- a/MeshCore/Sources/MeshCore/Protocol/ChannelCrypto.swift
+++ b/MeshCore/Sources/MeshCore/Protocol/ChannelCrypto.swift
@@ -1,0 +1,127 @@
+import Foundation
+import CommonCrypto
+import CryptoKit
+
+/// Cryptographic operations for MeshCore channel messages.
+///
+/// Channel messages use AES-128 ECB encryption with HMAC-SHA256 authentication
+/// in an Encrypt-then-MAC pattern.
+public enum ChannelCrypto {
+
+    /// Size of the truncated HMAC (2 bytes).
+    public static let macSize = 2
+
+    /// Size of the AES key (16 bytes for AES-128).
+    public static let keySize = 16
+
+    /// Size of the timestamp in decrypted payload (4 bytes).
+    public static let timestampSize = 4
+
+    /// Size of the txt_type field in decrypted payload (1 byte).
+    public static let txtTypeSize = 1
+
+    /// Total header size before message text: timestamp (4) + txt_type (1) = 5 bytes.
+    public static let plaintextHeaderSize = timestampSize + txtTypeSize
+
+    /// Result of attempting to decrypt a channel message.
+    public enum DecryptResult: Sendable {
+        /// Successfully decrypted the message.
+        /// - Parameters:
+        ///   - timestamp: 4-byte sender timestamp
+        ///   - txtType: Message type indicator (0 = normal text, 1 = command, 2 = signed)
+        ///   - text: The decrypted message text
+        case success(timestamp: UInt32, txtType: UInt8, text: String)
+        /// HMAC verification failed.
+        case hmacFailed
+        /// Decryption failed (invalid padding or data).
+        case decryptFailed
+        /// Payload too short to contain required fields.
+        case payloadTooShort
+    }
+
+    /// Decrypt a channel message payload.
+    ///
+    /// - Parameters:
+    ///   - payload: The channel message payload (after channel index byte).
+    ///              Format: [MAC: 2B] [ciphertext: N bytes]
+    ///   - secret: The 16-byte channel secret.
+    /// - Returns: Decryption result with message text or failure reason.
+    public static func decrypt(payload: Data, secret: Data) -> DecryptResult {
+        // Minimum: 2 bytes MAC + 16 bytes (1 AES block for timestamp + some text)
+        guard payload.count >= macSize + 16 else {
+            return .payloadTooShort
+        }
+
+        let receivedMAC = payload.prefix(macSize)
+        let ciphertext = Data(payload.dropFirst(macSize))
+
+        // Verify HMAC-SHA256 (truncated to 2 bytes)
+        let computedMAC = computeHMAC(data: ciphertext, key: secret)
+        guard receivedMAC == computedMAC else {
+            return .hmacFailed
+        }
+
+        // Decrypt using AES-128 ECB
+        guard let plaintext = decryptAES128ECB(ciphertext: ciphertext, key: secret) else {
+            return .decryptFailed
+        }
+
+        // Parse decrypted payload: [timestamp: 4B] [txt_type: 1B] [message: rest]
+        guard plaintext.count >= plaintextHeaderSize else {
+            return .decryptFailed
+        }
+
+        let timestamp = plaintext.prefix(timestampSize).withUnsafeBytes {
+            $0.loadUnaligned(as: UInt32.self)
+        }
+
+        let txtType = plaintext[timestampSize]
+
+        // Extract message text, trimming null padding
+        let messageData = plaintext.dropFirst(plaintextHeaderSize)
+        let trimmedData = messageData.prefix(while: { $0 != 0 })
+
+        guard let text = String(data: Data(trimmedData), encoding: .utf8) else {
+            return .decryptFailed
+        }
+
+        return .success(timestamp: timestamp, txtType: txtType, text: text)
+    }
+
+    /// Compute truncated HMAC-SHA256.
+    private static func computeHMAC(data: Data, key: Data) -> Data {
+        let symmetricKey = SymmetricKey(data: key)
+        let mac = HMAC<SHA256>.authenticationCode(for: data, using: symmetricKey)
+        return Data(mac.prefix(macSize))
+    }
+
+    /// Decrypt data using AES-128 ECB mode.
+    private static func decryptAES128ECB(ciphertext: Data, key: Data) -> Data? {
+        guard key.count == kCCKeySizeAES128 else { return nil }
+        guard ciphertext.count % kCCBlockSizeAES128 == 0 else { return nil }
+
+        let bufferSize = ciphertext.count
+        var decrypted = Data(count: bufferSize)
+        var numBytesDecrypted: size_t = 0
+
+        let status = decrypted.withUnsafeMutableBytes { decryptedPtr in
+            ciphertext.withUnsafeBytes { ciphertextPtr in
+                key.withUnsafeBytes { keyPtr in
+                    CCCrypt(
+                        CCOperation(kCCDecrypt),
+                        CCAlgorithm(kCCAlgorithmAES),
+                        CCOptions(kCCOptionECBMode),
+                        keyPtr.baseAddress, kCCKeySizeAES128,
+                        nil, // No IV for ECB
+                        ciphertextPtr.baseAddress, bufferSize,
+                        decryptedPtr.baseAddress, bufferSize,
+                        &numBytesDecrypted
+                    )
+                }
+            }
+        }
+
+        guard status == kCCSuccess else { return nil }
+        return Data(decrypted.prefix(numBytesDecrypted))
+    }
+}

--- a/MeshCore/Sources/MeshCore/Protocol/RxLogParser.swift
+++ b/MeshCore/Sources/MeshCore/Protocol/RxLogParser.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Parser for raw RF packets from rxLogData events.
+public enum RxLogParser {
+
+    /// Parse raw payload bytes into structured ParsedRxLogData.
+    public static func parse(snr: Double?, rssi: Int?, payload: Data) -> ParsedRxLogData? {
+        guard !payload.isEmpty else { return nil }
+
+        var offset = 0
+
+        // Parse header byte
+        let header = payload[offset]
+        offset += 1
+
+        let routeTypeBits = header & 0x03
+        let payloadTypeBits = (header >> 2) & 0x0F
+        let payloadVersion = (header >> 6) & 0x03
+
+        guard let routeType = RouteType(rawValue: routeTypeBits) else {
+            return nil
+        }
+        let payloadType = PayloadType(fromBits: payloadTypeBits)
+
+        // Parse transport code if present
+        var transportCode: Data?
+        if routeType.hasTransportCode {
+            guard payload.count >= offset + 4 else { return nil }
+            transportCode = payload[offset..<offset + 4]
+            offset += 4
+        }
+
+        // Parse path length
+        guard payload.count > offset else { return nil }
+        let pathLength = payload[offset]
+        offset += 1
+
+        // Parse path nodes
+        var pathNodes: [UInt8] = []
+        if pathLength > 0 {
+            guard payload.count >= offset + Int(pathLength) else { return nil }
+            pathNodes = Array(payload[offset..<offset + Int(pathLength)])
+            offset += Int(pathLength)
+        }
+
+        // Remaining bytes are packet payload
+        let packetPayload = payload.count > offset ? Data(payload[offset...]) : Data()
+
+        // Extract dest and src hashes for direct text messages
+        // Payload format: [dest: 1B] [src: 1B] [MAC + encrypted content]
+        // dest = recipient pubkey hash, src = sender pubkey hash
+        var senderPubkeyPrefix: Data?
+        var recipientPubkeyPrefix: Data?
+        if (routeType == .direct || routeType == .tcDirect) && payloadType == .textMessage && packetPayload.count >= 2 {
+            senderPubkeyPrefix = Data([packetPayload[1]])      // src is byte 1
+            recipientPubkeyPrefix = Data([packetPayload[0]])   // dest is byte 0
+        }
+
+        return ParsedRxLogData(
+            snr: snr,
+            rssi: rssi,
+            rawPayload: payload,
+            routeType: routeType,
+            payloadType: payloadType,
+            payloadVersion: payloadVersion,
+            transportCode: transportCode,
+            pathLength: pathLength,
+            pathNodes: pathNodes,
+            packetPayload: packetPayload,
+            senderPubkeyPrefix: senderPubkeyPrefix,
+            recipientPubkeyPrefix: recipientPubkeyPrefix
+        )
+    }
+}

--- a/MeshCore/Sources/MeshCore/Protocol/RxLogTypes.swift
+++ b/MeshCore/Sources/MeshCore/Protocol/RxLogTypes.swift
@@ -1,0 +1,135 @@
+import CryptoKit
+import Foundation
+
+/// Route type extracted from header byte bits 0-1.
+/// All 4 possible 2-bit values are valid (cannot be unknown).
+public enum RouteType: UInt8, Sendable, CaseIterable {
+    case tcFlood = 0
+    case flood = 1
+    case direct = 2
+    case tcDirect = 3
+
+    /// Whether this route type includes a 4-byte transport code.
+    public var hasTransportCode: Bool {
+        self == .tcFlood || self == .tcDirect
+    }
+
+    /// Human-readable display name.
+    public var displayName: String {
+        switch self {
+        case .tcFlood: "TC_FLOOD"
+        case .flood: "FLOOD"
+        case .direct: "DIRECT"
+        case .tcDirect: "TC_DIRECT"
+        }
+    }
+}
+
+/// Payload type extracted from header byte bits 2-5.
+/// Values 0-11 are defined; 12-15 map to .unknown.
+public enum PayloadType: UInt8, Sendable, CaseIterable {
+    case request = 0
+    case response = 1
+    case textMessage = 2
+    case ack = 3
+    case advert = 4
+    case groupText = 5
+    case groupData = 6
+    case anonRequest = 7
+    case path = 8
+    case trace = 9
+    case multipart = 10
+    case control = 11
+    case unknown = 255
+
+    /// Initialize from raw 4-bit value (0-15). Values 12-15 return .unknown.
+    public init(fromBits bits: UInt8) {
+        self = PayloadType(rawValue: bits) ?? .unknown
+    }
+
+    /// Human-readable display name.
+    public var displayName: String {
+        switch self {
+        case .request: "REQUEST"
+        case .response: "RESPONSE"
+        case .textMessage: "TEXT_MSG"
+        case .ack: "ACK"
+        case .advert: "ADVERT"
+        case .groupText: "GROUP_TEXT"
+        case .groupData: "GROUP_DATA"
+        case .anonRequest: "ANON_REQ"
+        case .path: "PATH"
+        case .trace: "TRACE"
+        case .multipart: "MULTIPART"
+        case .control: "CONTROL"
+        case .unknown: "UNKNOWN"
+        }
+    }
+}
+
+/// Parsed RF packet data from rxLogData events.
+public struct ParsedRxLogData: Sendable, Equatable {
+    // Always available (raw)
+    public let snr: Double?
+    public let rssi: Int?
+    public let rawPayload: Data
+
+    // Always available (parsed)
+    public let routeType: RouteType
+    public let payloadType: PayloadType
+    public let payloadVersion: UInt8
+
+    // Conditional on route type
+    public let transportCode: Data?
+
+    // Path information (empty if malformed)
+    public let pathLength: UInt8
+    public let pathNodes: [UInt8]
+
+    // Message payload (after header/path extraction)
+    public let packetPayload: Data
+
+    /// 1-byte sender pubkey hash for direct messages (nil for channel/other types).
+    public let senderPubkeyPrefix: Data?
+
+    /// 1-byte recipient pubkey hash for direct messages (nil for channel/other types).
+    public let recipientPubkeyPrefix: Data?
+
+    // Correlation hash for "heard repeats" detection
+    public let packetHash: String
+
+    public init(
+        snr: Double?,
+        rssi: Int?,
+        rawPayload: Data,
+        routeType: RouteType,
+        payloadType: PayloadType,
+        payloadVersion: UInt8,
+        transportCode: Data?,
+        pathLength: UInt8,
+        pathNodes: [UInt8],
+        packetPayload: Data,
+        senderPubkeyPrefix: Data? = nil,
+        recipientPubkeyPrefix: Data? = nil
+    ) {
+        self.snr = snr
+        self.rssi = rssi
+        self.rawPayload = rawPayload
+        self.routeType = routeType
+        self.payloadType = payloadType
+        self.payloadVersion = payloadVersion
+        self.transportCode = transportCode
+        self.pathLength = pathLength
+        self.pathNodes = pathNodes
+        self.packetPayload = packetPayload
+        self.senderPubkeyPrefix = senderPubkeyPrefix
+        self.recipientPubkeyPrefix = recipientPubkeyPrefix
+        self.packetHash = Self.computePacketHash(from: packetPayload)
+    }
+
+    /// Compute SHA256 hash of packetPayload, return first 8 bytes as hex.
+    public static func computePacketHash(from packetPayload: Data) -> String {
+        let hash = SHA256.hash(data: packetPayload)
+        return hash.prefix(8).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/MeshCore/Tests/MeshCoreTests/ChannelCryptoTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/ChannelCryptoTests.swift
@@ -1,0 +1,312 @@
+import XCTest
+import CommonCrypto
+import CryptoKit
+@testable import MeshCore
+
+final class ChannelCryptoTests: XCTestCase {
+
+    // Test channel secret (16 bytes)
+    let testSecret = Data([
+        0x8b, 0x33, 0x87, 0xe9, 0xc5, 0xcd, 0xea, 0x6a,
+        0xc9, 0xe5, 0xed, 0xba, 0xa1, 0x15, 0xcd, 0x72
+    ])
+
+    // MARK: - Helper: Encrypt for testing
+
+    /// Encrypt data using AES-128 ECB (for creating test vectors)
+    private func encryptAES128ECB(plaintext: Data, key: Data) -> Data? {
+        guard key.count == kCCKeySizeAES128 else { return nil }
+
+        // Pad to block size
+        let paddedLength = ((plaintext.count + kCCBlockSizeAES128 - 1) / kCCBlockSizeAES128) * kCCBlockSizeAES128
+        var padded = plaintext
+        while padded.count < paddedLength {
+            padded.append(0)
+        }
+
+        var encrypted = Data(count: paddedLength)
+        var numBytesEncrypted: size_t = 0
+
+        let status = encrypted.withUnsafeMutableBytes { encryptedPtr in
+            padded.withUnsafeBytes { plaintextPtr in
+                key.withUnsafeBytes { keyPtr in
+                    CCCrypt(
+                        CCOperation(kCCEncrypt),
+                        CCAlgorithm(kCCAlgorithmAES),
+                        CCOptions(kCCOptionECBMode),
+                        keyPtr.baseAddress, kCCKeySizeAES128,
+                        nil,
+                        plaintextPtr.baseAddress, paddedLength,
+                        encryptedPtr.baseAddress, paddedLength,
+                        &numBytesEncrypted
+                    )
+                }
+            }
+        }
+
+        guard status == kCCSuccess else { return nil }
+        return Data(encrypted.prefix(numBytesEncrypted))
+    }
+
+    /// Compute truncated HMAC-SHA256 (2 bytes)
+    private func computeMAC(data: Data, key: Data) -> Data {
+        let symmetricKey = SymmetricKey(data: key)
+        let mac = HMAC<SHA256>.authenticationCode(for: data, using: symmetricKey)
+        return Data(mac.prefix(ChannelCrypto.macSize))
+    }
+
+    /// Create an encrypted channel payload for testing
+    /// - Parameters:
+    ///   - timestamp: 4-byte sender timestamp
+    ///   - txtType: Message type (0 = normal text, 1 = command, 2 = signed)
+    ///   - message: The message text
+    ///   - secret: 16-byte channel secret
+    private func createEncryptedPayload(timestamp: UInt32, txtType: UInt8 = 0, message: String, secret: Data) -> Data? {
+        // Build plaintext: [timestamp: 4B] [txt_type: 1B] [message bytes]
+        var plaintext = Data()
+        var ts = timestamp
+        plaintext.append(Data(bytes: &ts, count: 4))
+        plaintext.append(txtType)
+        plaintext.append(Data(message.utf8))
+
+        // Encrypt
+        guard let ciphertext = encryptAES128ECB(plaintext: plaintext, key: secret) else {
+            return nil
+        }
+
+        // Compute MAC over ciphertext
+        let mac = computeMAC(data: ciphertext, key: secret)
+
+        // Return: [MAC: 2B] [ciphertext]
+        return mac + ciphertext
+    }
+
+    // MARK: - Tests
+
+    func testDecryptSuccess() {
+        let message = "Alice: Hello mesh!"
+        let timestamp: UInt32 = 1703123456
+        let txtType: UInt8 = 0  // Normal text
+
+        guard let payload = createEncryptedPayload(
+            timestamp: timestamp,
+            txtType: txtType,
+            message: message,
+            secret: testSecret
+        ) else {
+            XCTFail("Failed to create test payload")
+            return
+        }
+
+        let result = ChannelCrypto.decrypt(payload: payload, secret: testSecret)
+
+        switch result {
+        case .success(let ts, let tt, let text):
+            XCTAssertEqual(ts, timestamp)
+            XCTAssertEqual(tt, txtType)
+            XCTAssertEqual(text, message)
+        case .hmacFailed:
+            XCTFail("HMAC verification failed")
+        case .decryptFailed:
+            XCTFail("Decryption failed")
+        case .payloadTooShort:
+            XCTFail("Payload too short")
+        }
+    }
+
+    func testDecryptWrongKey() {
+        let message = "Bob: Secret message"
+        let timestamp: UInt32 = 1703123456
+
+        guard let payload = createEncryptedPayload(
+            timestamp: timestamp,
+            message: message,
+            secret: testSecret
+        ) else {
+            XCTFail("Failed to create test payload")
+            return
+        }
+
+        // Try to decrypt with wrong key
+        let wrongKey = Data([
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+            0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF
+        ])
+
+        let result = ChannelCrypto.decrypt(payload: payload, secret: wrongKey)
+
+        switch result {
+        case .success:
+            XCTFail("Should have failed with wrong key")
+        case .hmacFailed:
+            // Expected - HMAC should fail with wrong key
+            break
+        case .decryptFailed, .payloadTooShort:
+            XCTFail("Wrong failure type - expected hmacFailed")
+        }
+    }
+
+    func testDecryptCorruptedMAC() {
+        let message = "Test message"
+        let timestamp: UInt32 = 1703123456
+
+        guard var payload = createEncryptedPayload(
+            timestamp: timestamp,
+            message: message,
+            secret: testSecret
+        ) else {
+            XCTFail("Failed to create test payload")
+            return
+        }
+
+        // Corrupt the MAC (first 2 bytes)
+        payload[0] ^= 0xFF
+        payload[1] ^= 0xFF
+
+        let result = ChannelCrypto.decrypt(payload: payload, secret: testSecret)
+
+        switch result {
+        case .success:
+            XCTFail("Should have failed with corrupted MAC")
+        case .hmacFailed:
+            // Expected
+            break
+        case .decryptFailed, .payloadTooShort:
+            XCTFail("Wrong failure type - expected hmacFailed")
+        }
+    }
+
+    func testDecryptPayloadTooShort() {
+        // Less than minimum: 2 bytes MAC + 16 bytes (1 AES block)
+        let shortPayload = Data([0x00, 0x01, 0x02, 0x03])
+
+        let result = ChannelCrypto.decrypt(payload: shortPayload, secret: testSecret)
+
+        switch result {
+        case .payloadTooShort:
+            // Expected
+            break
+        default:
+            XCTFail("Expected payloadTooShort")
+        }
+    }
+
+    func testDecryptEmptyMessage() {
+        let message = ""
+        let timestamp: UInt32 = 0
+        let txtType: UInt8 = 0
+
+        guard let payload = createEncryptedPayload(
+            timestamp: timestamp,
+            txtType: txtType,
+            message: message,
+            secret: testSecret
+        ) else {
+            XCTFail("Failed to create test payload")
+            return
+        }
+
+        let result = ChannelCrypto.decrypt(payload: payload, secret: testSecret)
+
+        switch result {
+        case .success(let ts, let tt, let text):
+            XCTAssertEqual(ts, timestamp)
+            XCTAssertEqual(tt, txtType)
+            XCTAssertEqual(text, message)
+        default:
+            XCTFail("Expected success for empty message")
+        }
+    }
+
+    func testDecryptLongMessage() {
+        // Message that spans multiple AES blocks (>11 bytes after header)
+        let message = "This is a longer message that will definitely span multiple AES blocks for encryption testing"
+        let timestamp: UInt32 = 1703123456
+        let txtType: UInt8 = 0
+
+        guard let payload = createEncryptedPayload(
+            timestamp: timestamp,
+            txtType: txtType,
+            message: message,
+            secret: testSecret
+        ) else {
+            XCTFail("Failed to create test payload")
+            return
+        }
+
+        let result = ChannelCrypto.decrypt(payload: payload, secret: testSecret)
+
+        switch result {
+        case .success(let ts, let tt, let text):
+            XCTAssertEqual(ts, timestamp)
+            XCTAssertEqual(tt, txtType)
+            XCTAssertEqual(text, message)
+        default:
+            XCTFail("Expected success for long message")
+        }
+    }
+
+    func testDecryptUnicodeMessage() {
+        let message = "Hello! 你好! 🌍"
+        let timestamp: UInt32 = 1703123456
+        let txtType: UInt8 = 0
+
+        guard let payload = createEncryptedPayload(
+            timestamp: timestamp,
+            txtType: txtType,
+            message: message,
+            secret: testSecret
+        ) else {
+            XCTFail("Failed to create test payload")
+            return
+        }
+
+        let result = ChannelCrypto.decrypt(payload: payload, secret: testSecret)
+
+        switch result {
+        case .success(let ts, let tt, let text):
+            XCTAssertEqual(ts, timestamp)
+            XCTAssertEqual(tt, txtType)
+            XCTAssertEqual(text, message)
+        default:
+            XCTFail("Expected success for unicode message")
+        }
+    }
+
+    func testConstants() {
+        XCTAssertEqual(ChannelCrypto.macSize, 2)
+        XCTAssertEqual(ChannelCrypto.keySize, 16)
+        XCTAssertEqual(ChannelCrypto.timestampSize, 4)
+        XCTAssertEqual(ChannelCrypto.txtTypeSize, 1)
+        XCTAssertEqual(ChannelCrypto.plaintextHeaderSize, 5)
+    }
+
+    func testDecryptWithDifferentTxtTypes() {
+        let message = "Test message"
+        let timestamp: UInt32 = 1703123456
+
+        // Test all valid txt_type values
+        for txtType: UInt8 in [0, 1, 2] {
+            guard let payload = createEncryptedPayload(
+                timestamp: timestamp,
+                txtType: txtType,
+                message: message,
+                secret: testSecret
+            ) else {
+                XCTFail("Failed to create test payload for txtType \(txtType)")
+                continue
+            }
+
+            let result = ChannelCrypto.decrypt(payload: payload, secret: testSecret)
+
+            switch result {
+            case .success(let ts, let tt, let text):
+                XCTAssertEqual(ts, timestamp)
+                XCTAssertEqual(tt, txtType, "txtType mismatch for value \(txtType)")
+                XCTAssertEqual(text, message)
+            default:
+                XCTFail("Expected success for txtType \(txtType)")
+            }
+        }
+    }
+}

--- a/MeshCore/Tests/MeshCoreTests/RxLogParserTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/RxLogParserTests.swift
@@ -1,0 +1,175 @@
+import Testing
+import Foundation
+@testable import MeshCore
+
+@Suite("RxLogParser")
+struct RxLogParserTests {
+
+    @Test("Parse empty payload returns nil")
+    func parseEmptyPayload() {
+        let result = RxLogParser.parse(snr: 5.0, rssi: -80, payload: Data())
+        #expect(result == nil)
+    }
+
+    @Test("Parse FLOOD GROUP_TEXT packet")
+    func parseFloodGroupText() {
+        // Header: routeType=1 (FLOOD), payloadType=5 (GROUP_TEXT), version=0
+        // Header byte: 0b00_0101_01 = 0x15
+        // pathLen=0, packetPayload follows
+        let payload = Data([0x15, 0x00, 0xAA, 0xBB, 0xCC])
+
+        let result = RxLogParser.parse(snr: 8.0, rssi: -85, payload: payload)
+
+        #expect(result != nil)
+        #expect(result?.routeType == .flood)
+        #expect(result?.payloadType == .groupText)
+        #expect(result?.payloadVersion == 0)
+        #expect(result?.transportCode == nil)
+        #expect(result?.pathLength == 0)
+        #expect(result?.pathNodes == [])
+        #expect(result?.packetPayload == Data([0xAA, 0xBB, 0xCC]))
+    }
+
+    @Test("Parse TC_FLOOD with transport code and path")
+    func parseTcFloodWithPath() {
+        // Header: routeType=0 (TC_FLOOD), payloadType=5 (GROUP_TEXT), version=1
+        // Header byte: 0b01_0101_00 = 0x54
+        let payload = Data([
+            0x54,                           // header
+            0x01, 0x02, 0x03, 0x04,         // transport code
+            0x02,                           // pathLen
+            0x3A, 0x7F,                     // pathNodes
+            0xDE, 0xAD, 0xBE, 0xEF          // packetPayload
+        ])
+
+        let result = RxLogParser.parse(snr: nil, rssi: nil, payload: payload)
+
+        #expect(result != nil)
+        #expect(result?.routeType == .tcFlood)
+        #expect(result?.payloadType == .groupText)
+        #expect(result?.payloadVersion == 1)
+        #expect(result?.transportCode == Data([0x01, 0x02, 0x03, 0x04]))
+        #expect(result?.pathLength == 2)
+        #expect(result?.pathNodes == [0x3A, 0x7F])
+        #expect(result?.packetPayload == Data([0xDE, 0xAD, 0xBE, 0xEF]))
+    }
+
+    @Test("Parse DIRECT packet (no transport code)")
+    func parseDirectPacket() {
+        // Header: routeType=2 (DIRECT), payloadType=2 (TEXT_MSG), version=0
+        // Header byte: 0b00_0010_10 = 0x0A
+        let payload = Data([0x0A, 0x01, 0xFF, 0x48, 0x69])
+
+        let result = RxLogParser.parse(snr: 6.5, rssi: -70, payload: payload)
+
+        #expect(result != nil)
+        #expect(result?.routeType == .direct)
+        #expect(result?.payloadType == .textMessage)
+        #expect(result?.transportCode == nil)
+        #expect(result?.pathLength == 1)
+        #expect(result?.pathNodes == [0xFF])
+        #expect(result?.packetPayload == Data([0x48, 0x69]))
+    }
+
+    @Test("Parse TC_DIRECT with transport code")
+    func parseTcDirectWithTransportCode() {
+        // Header: routeType=3 (TC_DIRECT), payloadType=2 (TEXT_MSG), version=0
+        // Header byte: 0b00_0010_11 = 0x0B
+        let payload = Data([
+            0x0B,                           // header
+            0xAA, 0xBB, 0xCC, 0xDD,         // transport code
+            0x01,                           // pathLen
+            0x42,                           // pathNodes
+            0x48, 0x69                      // packetPayload ("Hi")
+        ])
+
+        let result = RxLogParser.parse(snr: 7.0, rssi: -75, payload: payload)
+
+        #expect(result != nil)
+        #expect(result?.routeType == .tcDirect)
+        #expect(result?.payloadType == .textMessage)
+        #expect(result?.transportCode == Data([0xAA, 0xBB, 0xCC, 0xDD]))
+        #expect(result?.pathLength == 1)
+        #expect(result?.pathNodes == [0x42])
+        #expect(result?.packetPayload == Data([0x48, 0x69]))
+    }
+
+    @Test("Parse packet with unknown payload type")
+    func parseUnknownPayloadType() {
+        // Header: routeType=1 (FLOOD), payloadType=14 (undefined), version=0
+        // Header byte: 0b00_1110_01 = 0x39
+        let payload = Data([0x39, 0x00, 0x01, 0x02])
+
+        let result = RxLogParser.parse(snr: nil, rssi: nil, payload: payload)
+
+        #expect(result != nil)
+        #expect(result?.payloadType == .unknown)
+    }
+
+    @Test("Parse DIRECT TEXT_MSG extracts sender and recipient pubkey hashes")
+    func parseDirectTextMsgExtractsSenderAndRecipient() {
+        // Header: routeType=2 (DIRECT), payloadType=2 (TEXT_MSG), version=0
+        // Header byte: 0b00_0010_10 = 0x0A
+        // pathLen=0, then payload: [dest: 1B] [src: 1B] [MAC + encrypted]
+        let destHash: UInt8 = 0x07  // recipient
+        let srcHash: UInt8 = 0x0A   // sender
+        let encryptedContent = Data([0x48, 0x69, 0xAB, 0xCD]) // MAC + content
+        let payload = Data([0x0A, 0x00, destHash, srcHash]) + encryptedContent
+
+        let result = RxLogParser.parse(snr: 5.0, rssi: -80, payload: payload)
+
+        #expect(result != nil)
+        #expect(result?.senderPubkeyPrefix == Data([srcHash]))
+        #expect(result?.recipientPubkeyPrefix == Data([destHash]))
+    }
+
+    @Test("Parse TC_DIRECT TEXT_MSG extracts sender and recipient pubkey hashes")
+    func parseTcDirectTextMsgExtractsSenderAndRecipient() {
+        // Header: routeType=3 (TC_DIRECT), payloadType=2 (TEXT_MSG), version=0
+        // Header byte: 0b00_0010_11 = 0x0B
+        let destHash: UInt8 = 0x12  // recipient
+        let srcHash: UInt8 = 0x34   // sender
+        let payload = Data([
+            0x0B,                       // header
+            0xAA, 0xBB, 0xCC, 0xDD,     // transport code
+            0x00,                       // pathLen
+            destHash, srcHash,          // dest, src hashes
+            0xDE, 0xAD, 0xBE, 0xEF      // MAC + content
+        ])
+
+        let result = RxLogParser.parse(snr: 5.0, rssi: -80, payload: payload)
+
+        #expect(result != nil)
+        #expect(result?.senderPubkeyPrefix == Data([srcHash]))
+        #expect(result?.recipientPubkeyPrefix == Data([destHash]))
+    }
+
+    @Test("Parse FLOOD GROUP_TEXT has nil sender pubkey prefix")
+    func parseFloodGroupTextNoSender() {
+        let payload = Data([0x15, 0x00, 0xAA, 0xBB, 0xCC])
+
+        let result = RxLogParser.parse(snr: 8.0, rssi: -85, payload: payload)
+
+        #expect(result != nil)
+        #expect(result?.senderPubkeyPrefix == nil)
+    }
+
+    @Test("MeshEvent.rxLogData holds ParsedRxLogData")
+    func meshEventRxLogData() {
+        let parsed = ParsedRxLogData(
+            snr: 5.0, rssi: -80, rawPayload: Data([0x15, 0x00, 0xAA]),
+            routeType: .flood, payloadType: .groupText, payloadVersion: 0,
+            transportCode: nil, pathLength: 0, pathNodes: [],
+            packetPayload: Data([0xAA])
+        )
+
+        let event = MeshEvent.rxLogData(parsed)
+
+        if case .rxLogData(let data) = event {
+            #expect(data.routeType == .flood)
+            #expect(data.packetHash.count == 16)
+        } else {
+            Issue.record("Expected rxLogData event")
+        }
+    }
+}

--- a/MeshCore/Tests/MeshCoreTests/RxLogTypesTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/RxLogTypesTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+@testable import MeshCore
+
+@Suite("RxLogTypes")
+struct RxLogTypesTests {
+
+    @Test("RouteType raw values match protocol spec")
+    func routeTypeRawValues() {
+        #expect(RouteType.tcFlood.rawValue == 0)
+        #expect(RouteType.flood.rawValue == 1)
+        #expect(RouteType.direct.rawValue == 2)
+        #expect(RouteType.tcDirect.rawValue == 3)
+    }
+
+    @Test("RouteType hasTransportCode")
+    func routeTypeTransportCode() {
+        #expect(RouteType.tcFlood.hasTransportCode == true)
+        #expect(RouteType.flood.hasTransportCode == false)
+        #expect(RouteType.direct.hasTransportCode == false)
+        #expect(RouteType.tcDirect.hasTransportCode == true)
+    }
+
+    @Test("PayloadType raw values match protocol spec")
+    func payloadTypeRawValues() {
+        #expect(PayloadType.request.rawValue == 0)
+        #expect(PayloadType.groupText.rawValue == 5)
+        #expect(PayloadType.control.rawValue == 11)
+        #expect(PayloadType.unknown.rawValue == 255)
+    }
+
+    @Test("PayloadType values 12-15 map to unknown via fromBits")
+    func payloadTypeFromBitsUnknown() {
+        #expect(PayloadType(fromBits: 12) == .unknown)
+        #expect(PayloadType(fromBits: 13) == .unknown)
+        #expect(PayloadType(fromBits: 14) == .unknown)
+        #expect(PayloadType(fromBits: 15) == .unknown)
+    }
+
+    @Test("PayloadType rawValue initializer returns nil for undefined values")
+    func payloadTypeRawValueNil() {
+        #expect(PayloadType(rawValue: 12) == nil)
+        #expect(PayloadType(rawValue: 255) == .unknown)
+    }
+
+    @Test("PayloadType fromBits with valid values")
+    func payloadTypeFromBitsValid() {
+        #expect(PayloadType(fromBits: 0) == .request)
+        #expect(PayloadType(fromBits: 5) == .groupText)
+        #expect(PayloadType(fromBits: 11) == .control)
+    }
+
+    @Test("RouteType displayName")
+    func routeTypeDisplayName() {
+        #expect(RouteType.tcFlood.displayName == "TC_FLOOD")
+        #expect(RouteType.flood.displayName == "FLOOD")
+        #expect(RouteType.direct.displayName == "DIRECT")
+        #expect(RouteType.tcDirect.displayName == "TC_DIRECT")
+    }
+
+    @Test("PayloadType displayName")
+    func payloadTypeDisplayName() {
+        #expect(PayloadType.request.displayName == "REQUEST")
+        #expect(PayloadType.groupText.displayName == "GROUP_TEXT")
+        #expect(PayloadType.unknown.displayName == "UNKNOWN")
+    }
+
+    @Test("ParsedRxLogData initializes with all fields")
+    func parsedRxLogDataInit() {
+        let data = ParsedRxLogData(
+            snr: 8.5,
+            rssi: -85,
+            rawPayload: Data([0x01, 0x02, 0x03]),
+            routeType: .flood,
+            payloadType: .groupText,
+            payloadVersion: 1,
+            transportCode: nil,
+            pathLength: 2,
+            pathNodes: [0x3A, 0x7F],
+            packetPayload: Data([0xAA, 0xBB])
+        )
+
+        #expect(data.snr == 8.5)
+        #expect(data.rssi == -85)
+        #expect(data.routeType == .flood)
+        #expect(data.payloadType == .groupText)
+        #expect(data.payloadVersion == 1)
+        #expect(data.transportCode == nil)
+        #expect(data.pathLength == 2)
+        #expect(data.pathNodes == [0x3A, 0x7F])
+        #expect(data.packetHash.count == 16) // 8 bytes as hex
+    }
+
+    @Test("ParsedRxLogData packetHash is stable")
+    func parsedRxLogDataHashStable() {
+        let payload = Data([0xAA, 0xBB, 0xCC])
+        let data1 = ParsedRxLogData(
+            snr: nil, rssi: nil, rawPayload: Data(),
+            routeType: .flood, payloadType: .groupText, payloadVersion: 0,
+            transportCode: nil, pathLength: 0, pathNodes: [],
+            packetPayload: payload
+        )
+        let data2 = ParsedRxLogData(
+            snr: 5.0, rssi: -90, rawPayload: Data([0xFF]),
+            routeType: .direct, payloadType: .ack, payloadVersion: 2,
+            transportCode: Data([0x01, 0x02, 0x03, 0x04]), pathLength: 3, pathNodes: [0x11, 0x22, 0x33],
+            packetPayload: payload  // Same payload
+        )
+
+        // Same packetPayload should produce same hash regardless of other fields
+        #expect(data1.packetHash == data2.packetHash)
+    }
+}

--- a/PocketMesh/Views/Tools/RxLogView.swift
+++ b/PocketMesh/Views/Tools/RxLogView.swift
@@ -1,0 +1,539 @@
+// PocketMesh/Views/Tools/RxLogView.swift
+import SwiftUI
+import UIKit
+import PocketMeshServices
+import MeshCore
+
+struct RxLogView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var viewModel = RxLogViewModel()
+    @State private var expandedHashes: Set<String> = []
+    @State private var groupDuplicates = false
+
+    var body: some View {
+        Group {
+            if appState.services?.rxLogService == nil {
+                disconnectedState
+            } else if viewModel.entries.isEmpty {
+                emptyState
+            } else {
+                entryList
+            }
+        }
+        .navigationTitle("RX Log")
+        .toolbar {
+            toolbarContent
+        }
+        .task(id: appState.servicesVersion) {
+            guard let service = appState.services?.rxLogService else { return }
+            await viewModel.subscribe(to: service)
+        }
+        .onDisappear {
+            viewModel.unsubscribe()
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("Listening...", systemImage: "antenna.radiowaves.left.and.right")
+        } description: {
+            Text("RF packets will appear here as they arrive.")
+        }
+    }
+
+    private var disconnectedState: some View {
+        ContentUnavailableView {
+            Label("Not Connected", systemImage: "antenna.radiowaves.left.and.right.slash")
+        } description: {
+            Text("Connect to a mesh radio to view RF packets.")
+        }
+    }
+
+    // MARK: - Entry List
+
+    private var entryList: some View {
+        List {
+            Section {
+                ForEach(displayEntries, id: \.id) { entry in
+                    RxLogRowView(
+                        entry: entry,
+                        isExpanded: expandedBinding(for: entry.packetHash),
+                        groupCount: groupDuplicates ? viewModel.groupCounts[entry.packetHash, default: 1] : 1,
+                        localPublicKeyPrefix: appState.connectedDevice?.publicKeyPrefix
+                    )
+                }
+            } header: {
+                liveStatusHeader
+                    .textCase(nil)
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    private func expandedBinding(for hash: String) -> Binding<Bool> {
+        Binding(
+            get: { expandedHashes.contains(hash) },
+            set: { isExpanded in
+                if isExpanded {
+                    expandedHashes.insert(hash)
+                } else {
+                    expandedHashes.remove(hash)
+                }
+            }
+        )
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            HStack(spacing: 16) {
+                filterMenu
+                overflowMenu
+            }
+        }
+    }
+
+    private var isConnected: Bool {
+        appState.services?.rxLogService != nil
+    }
+
+    private var liveStatusHeader: some View {
+        HStack(spacing: 8) {
+            statusPill
+
+            Text("\(viewModel.entries.count) packets")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+        }
+        .modifier(GlassContainerModifier())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(isConnected ? "Live" : "Offline"), \(viewModel.entries.count) packets")
+    }
+
+    private var statusPill: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(isConnected ? .green : .gray)
+                .frame(width: 8, height: 8)
+                .modifier(PulseAnimationModifier(isActive: isConnected && !reduceMotion))
+
+            Text(isConnected ? "Live" : "Offline")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .modifier(GlassEffectModifier())
+    }
+
+    private var filterMenu: some View {
+        Menu {
+            Section("Route Type") {
+                ForEach(RxLogViewModel.RouteFilter.allCases, id: \.self) { filter in
+                    Button {
+                        viewModel.setRouteFilter(filter)
+                    } label: {
+                        HStack {
+                            Text(filter.rawValue)
+                            if viewModel.routeFilter == filter {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            }
+
+            Section("Decrypt Status") {
+                ForEach(RxLogViewModel.DecryptFilter.allCases, id: \.self) { filter in
+                    Button {
+                        viewModel.setDecryptFilter(filter)
+                    } label: {
+                        HStack {
+                            Text(filter.rawValue)
+                            if viewModel.decryptFilter == filter {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            }
+        } label: {
+            Label("Filter", systemImage: viewModel.routeFilter == .all && viewModel.decryptFilter == .all
+                ? "line.3.horizontal.decrease.circle"
+                : "line.3.horizontal.decrease.circle.fill")
+        }
+        .modifier(GlassButtonModifier())
+    }
+
+    @State private var showClearConfirmation = false
+
+    private var overflowMenu: some View {
+        Menu {
+            Button {
+                groupDuplicates.toggle()
+            } label: {
+                HStack {
+                    Text("Group Duplicates")
+                    if groupDuplicates { Image(systemName: "checkmark") }
+                }
+            }
+
+            Divider()
+
+            Button(role: .destructive) {
+                showClearConfirmation = true
+            } label: {
+                Label("Delete Logs", systemImage: "trash")
+            }
+        } label: {
+            Label("More", systemImage: "ellipsis.circle")
+        }
+        .modifier(GlassButtonModifier())
+        .confirmationDialog("Delete all logs?", isPresented: $showClearConfirmation, titleVisibility: .visible) {
+            Button("Delete", role: .destructive) {
+                clearLog()
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var displayEntries: [RxLogEntryDTO] {
+        let filtered = viewModel.filteredEntries
+        if groupDuplicates {
+            var seen = Set<String>()
+            return filtered.filter { entry in
+                if seen.contains(entry.packetHash) {
+                    return false
+                }
+                seen.insert(entry.packetHash)
+                return true
+            }
+        }
+        return filtered
+    }
+
+    private func clearLog() {
+        Task {
+            await viewModel.clearLog()
+        }
+        expandedHashes.removeAll()
+    }
+}
+
+// MARK: - Row View
+
+struct RxLogRowView: View {
+    let entry: RxLogEntryDTO
+    @Binding var isExpanded: Bool
+    let groupCount: Int
+    let localPublicKeyPrefix: Data?
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            expandedContent
+        } label: {
+            collapsedContent
+        }
+        .sensoryFeedback(.selection, trigger: isExpanded)
+    }
+
+    // MARK: - Collapsed Content (3 lines)
+
+    private var collapsedContent: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            // Line 1: Route type, time, signal bars
+            HStack {
+                Text(entry.routeTypeSimple)
+                    .font(.caption.bold())
+                    .foregroundStyle(entry.isFlood ? .green : .blue)
+
+                Text(entry.receivedAt, format: .dateTime.hour().minute().second())
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                if entry.rssi != nil {
+                    Image(systemName: "cellularbars", variableValue: entry.rssiLevel)
+                        .foregroundStyle(signalColor)
+                        .accessibilityLabel("Signal strength: \(entry.rssiQualityLabel)")
+                }
+            }
+
+            // Line 2: Path visualization + From/To for direct text messages
+            HStack(spacing: 4) {
+                Text(pathDisplayString)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                // Direct message payload format: [dest: 1B] [src: 1B] [MAC + encrypted]
+                if isDirectTextMessage, entry.packetPayload.count >= 2 {
+                    Text("·")
+                        .foregroundStyle(.tertiary)
+                    Text("<\(String(format: "%02x", entry.packetPayload[1]))> → <\(String(format: "%02x", entry.packetPayload[0]))>")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .lineLimit(1)
+
+            // Line 3: Message preview or packet info, SNR, duplicate count
+            HStack {
+                if let text = entry.decodedText {
+                    Text("\"\(text)\"")
+                        .font(.caption)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                } else {
+                    Text("\(entry.payloadType.displayName) v\(entry.payloadVersion) · \(entry.rawPayload.count) bytes")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                if let snrString = entry.snrDisplayString {
+                    Text(snrString)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                }
+
+                if groupCount > 1 {
+                    Text("×\(groupCount)")
+                        .font(.caption.bold())
+                        .foregroundStyle(.orange)
+                        .accessibilityLabel("Received \(groupCount) times")
+                }
+            }
+        }
+    }
+
+    // MARK: - Path Display
+
+    private var pathDisplayString: String {
+        if entry.pathLength == 0 {
+            return "Direct"
+        }
+
+        var parts: [String] = []
+        for byte in entry.pathNodes {
+            let hex = String(format: "%02X", byte)
+            // Check if this is the local device
+            if let prefix = localPublicKeyPrefix, prefix.first == byte {
+                parts.append("YOU")
+            } else {
+                parts.append(hex)
+            }
+        }
+        return "→ " + parts.joined(separator: " → ")
+    }
+
+    private var pathDetailString: String {
+        if entry.pathLength == 0 {
+            return "Direct"
+        }
+
+        let hopCount = Int(entry.pathLength)
+        let hopLabel = hopCount == 1 ? "hop" : "hops"
+        let nodes = entry.pathNodes.map { String(format: "%02X", $0) }.joined(separator: ", ")
+        return "\(hopCount) \(hopLabel) [\(nodes)]"
+    }
+
+    private var isDirectTextMessage: Bool {
+        (entry.routeType == .direct || entry.routeType == .tcDirect) && entry.payloadType == .textMessage
+    }
+
+    private var signalColor: Color {
+        guard let rssi = entry.rssi else { return .secondary }
+        if rssi > -70 { return .green }
+        if rssi > -90 { return .yellow }
+        return .red
+    }
+
+    // MARK: - Expanded Content
+
+    private var expandedContent: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let rssi = entry.rssi {
+                DetailRow(label: "RSSI:", value: "\(rssi) dBm")
+            }
+            if let snr = entry.snr {
+                DetailRow(label: "SNR:", value: snr.formatted(.number.precision(.fractionLength(1))) + " dB")
+            }
+
+            DetailRow(label: "Type:", value: entry.payloadType.displayName)
+            DetailRow(label: "Size:", value: "\(entry.rawPayload.count) bytes")
+            DetailRow(label: "Path:", value: pathDetailString)
+            DetailRow(label: "Hash:", value: entry.packetHash, truncate: true)
+
+            // Direct message: show sender and recipient
+            // Payload format: [dest: 1B] [src: 1B] [MAC + encrypted content]
+            if isDirectTextMessage, entry.packetPayload.count >= 2 {
+                let destByte = entry.packetPayload[0]  // recipient
+                let srcByte = entry.packetPayload[1]   // sender
+                DetailRow(label: "From:", value: "<\(String(format: "%02x", srcByte))>")
+                DetailRow(label: "To:", value: "<\(String(format: "%02x", destByte))>")
+            }
+
+            // Channel message: show channel info
+            if entry.decryptStatus == .success {
+                if let channelHashByte = entry.packetPayload.first {
+                    DetailRow(label: "Channel Hash:", value: String(format: "%02x", channelHashByte))
+                }
+                if let channelName = entry.channelName {
+                    DetailRow(label: "Channel Name:", value: channelName)
+                }
+                if let text = entry.decodedText {
+                    HStack(alignment: .top) {
+                        Text("Text:")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(text)
+                            .font(.caption)
+                    }
+                }
+            }
+
+            RawPayloadSection(payload: entry.rawPayload)
+        }
+    }
+}
+
+// MARK: - Detail Row
+
+private struct DetailRow: View {
+    let label: String
+    let value: String
+    var truncate: Bool = false
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.caption.monospaced())
+                .lineLimit(1)
+                .truncationMode(truncate ? .middle : .tail)
+        }
+    }
+}
+
+// MARK: - Raw Payload Section
+
+private struct RawPayloadSection: View {
+    let payload: Data
+
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text("Raw Payload")
+                    .font(.caption.bold())
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Button("Copy", systemImage: copied ? "checkmark" : "doc.on.doc", action: copyToClipboard)
+                    .font(.caption)
+                    .foregroundStyle(copied ? .green : .secondary)
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.plain)
+                    .sensoryFeedback(.success, trigger: copied) { _, newValue in newValue }
+            }
+
+            Text(hexString)
+                .font(.caption2.monospaced())
+                .lineLimit(3)
+                .truncationMode(.tail)
+        }
+    }
+
+    private var hexString: String {
+        payload.map { String(format: "%02X", $0) }.joined(separator: " ")
+    }
+
+    private func copyToClipboard() {
+        UIPasteboard.general.string = hexString
+        copied = true
+        Task {
+            try? await Task.sleep(for: .seconds(2))
+            copied = false
+        }
+    }
+}
+
+// MARK: - Glass Effect Modifiers
+
+private struct GlassButtonModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.buttonStyle(.glass)
+        } else {
+            content
+        }
+    }
+}
+
+private struct GlassEffectModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.glassEffect()
+        } else {
+            content.background(.ultraThinMaterial, in: .capsule)
+        }
+    }
+}
+
+private struct GlassContainerModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            GlassEffectContainer { content }
+        } else {
+            content
+        }
+    }
+}
+
+// MARK: - Pulse Animation
+
+private struct PulseAnimationModifier: ViewModifier {
+    let isActive: Bool
+
+    @State private var isPulsing = false
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(isActive && isPulsing ? 0.4 : 1.0)
+            .animation(
+                isActive ? .easeInOut(duration: 1.0).repeatForever(autoreverses: true) : .default,
+                value: isPulsing
+            )
+            .onAppear {
+                if isActive {
+                    isPulsing = true
+                }
+            }
+            .onChange(of: isActive) { _, newValue in
+                isPulsing = newValue
+            }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        RxLogView()
+    }
+    .environment(AppState())
+}

--- a/PocketMesh/Views/Tools/RxLogViewModel.swift
+++ b/PocketMesh/Views/Tools/RxLogViewModel.swift
@@ -1,0 +1,116 @@
+// PocketMesh/Views/Tools/RxLogViewModel.swift
+import Foundation
+import PocketMeshServices
+
+@MainActor
+@Observable
+final class RxLogViewModel {
+    enum RouteFilter: String, CaseIterable {
+        case all = "All"
+        case floodOnly = "Flood Only"
+        case directOnly = "Direct Only"
+    }
+
+    enum DecryptFilter: String, CaseIterable {
+        case all = "All"
+        case decrypted = "Decrypted"
+        case failed = "Failed"
+    }
+
+    private(set) var entries: [RxLogEntryDTO] = []
+    private(set) var groupCounts: [String: Int] = [:]
+    private(set) var routeFilter: RouteFilter = .all
+    private(set) var decryptFilter: DecryptFilter = .all
+
+    private var streamTask: Task<Void, Never>?
+    private var rxLogService: RxLogService?
+
+    func setRouteFilter(_ filter: RouteFilter) {
+        routeFilter = filter
+    }
+
+    func setDecryptFilter(_ filter: DecryptFilter) {
+        decryptFilter = filter
+    }
+
+    /// Entries filtered by current filter settings.
+    var filteredEntries: [RxLogEntryDTO] {
+        entries.filter { entry in
+            // Route filter
+            switch routeFilter {
+            case .all: break
+            case .floodOnly:
+                guard entry.isFlood else { return false }
+            case .directOnly:
+                guard !entry.isFlood else { return false }
+            }
+
+            // Decrypt filter
+            switch decryptFilter {
+            case .all: break
+            case .decrypted:
+                guard entry.decryptStatus == .success else { return false }
+            case .failed:
+                guard entry.decryptStatus == .hmacFailed || entry.decryptStatus == .decryptFailed || entry.decryptStatus == .noMatchingKey else { return false }
+            }
+
+            return true
+        }
+    }
+
+    /// Subscribe to RxLogService for updates while view is visible.
+    func subscribe(to service: RxLogService) async {
+        // If service changed, reset state
+        if rxLogService !== service {
+            unsubscribe()
+            entries.removeAll()
+            groupCounts.removeAll()
+        }
+
+        rxLogService = service
+        entries = await service.loadExistingEntries()
+        rebuildGroupCounts()
+
+        streamTask = Task {
+            for await entry in await service.entryStream() {
+                guard !Task.isCancelled else { break }
+                appendEntry(entry)
+            }
+        }
+    }
+
+    /// Stop listening to updates.
+    func unsubscribe() {
+        streamTask?.cancel()
+        streamTask = nil
+    }
+
+    /// Clear all log entries.
+    func clearLog() async {
+        await rxLogService?.clearEntries()
+        entries.removeAll()
+        groupCounts.removeAll()
+    }
+
+    // MARK: - Incremental Updates
+
+    private func appendEntry(_ entry: RxLogEntryDTO) {
+        // Insert at front to maintain newest-first order (matching DB fetch sort)
+        entries.insert(entry, at: 0)
+        groupCounts[entry.packetHash, default: 0] += 1
+
+        // Prune oldest (now at end) if over cap
+        if entries.count > 1000 {
+            let removed = entries.removeLast()
+            groupCounts[removed.packetHash, default: 1] -= 1
+            if groupCounts[removed.packetHash] == 0 {
+                groupCounts.removeValue(forKey: removed.packetHash)
+            }
+        }
+    }
+
+    private func rebuildGroupCounts() {
+        groupCounts = Dictionary(grouping: entries, by: \.packetHash)
+            .mapValues(\.count)
+    }
+}

--- a/PocketMesh/Views/Tools/ToolsView.swift
+++ b/PocketMesh/Views/Tools/ToolsView.swift
@@ -16,6 +16,12 @@ struct ToolsView: View {
                 } label: {
                     Label("Line of Sight", systemImage: "eye")
                 }
+
+                NavigationLink {
+                    RxLogView()
+                } label: {
+                    Label("RX Log", systemImage: "waveform.badge.magnifyingglass")
+                }
             }
             .navigationTitle("Tools")
         }

--- a/PocketMeshServices/Sources/PocketMeshServices/Models/DecryptStatus.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Models/DecryptStatus.swift
@@ -1,0 +1,36 @@
+// PocketMeshServices/Sources/PocketMeshServices/Models/DecryptStatus.swift
+import Foundation
+
+/// Decryption outcome for channel messages.
+public enum DecryptStatus: Int, Codable, Sendable, CaseIterable {
+    case notApplicable = 0   // Not a channel message (e.g., direct, advert)
+    case noMatchingKey = 1   // No stored channel matches channelHash
+    case hmacFailed = 2      // Key found but HMAC validation failed
+    case decryptFailed = 3   // HMAC passed but AES decrypt failed
+    case success = 4         // Decrypted successfully
+    case pending = 5         // Key found but decryption not yet implemented
+
+    /// Human-readable description for UI display.
+    public var displayName: String {
+        switch self {
+        case .notApplicable: return "N/A"
+        case .noMatchingKey: return "No Key"
+        case .hmacFailed: return "HMAC Failed"
+        case .decryptFailed: return "Decrypt Failed"
+        case .success: return "Decrypted"
+        case .pending: return "Has Key"
+        }
+    }
+
+    /// SF Symbol name for status indicator.
+    public var symbolName: String {
+        switch self {
+        case .notApplicable: return "minus.circle"
+        case .noMatchingKey: return "key.slash"
+        case .hmacFailed: return "exclamationmark.shield"
+        case .decryptFailed: return "lock.slash"
+        case .success: return "checkmark.seal"
+        case .pending: return "key"
+        }
+    }
+}

--- a/PocketMeshServices/Sources/PocketMeshServices/Models/RxLogEntry.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Models/RxLogEntry.swift
@@ -1,0 +1,229 @@
+// PocketMeshServices/Sources/PocketMeshServices/Models/RxLogEntry.swift
+import Foundation
+import MeshCore
+import SwiftData
+
+/// SwiftData model for persisted RX log packets.
+@Model
+public final class RxLogEntry {
+    @Attribute(.unique)
+    public var id: UUID
+
+    public var deviceID: UUID
+
+    public var receivedAt: Date
+
+    // From MeshCore ParsedRxLogData
+    public var snr: Double?
+    public var rssi: Int?
+    public var routeType: Int
+    public var payloadType: Int
+    public var payloadVersion: Int
+    public var transportCode: Data?
+    public var pathLength: Int
+    public var pathNodes: Data  // Raw bytes, 1 byte per hop
+    public var packetPayload: Data
+    public var rawPayload: Data
+
+    // Correlation key for "heard repeats"
+    public var packetHash: String
+
+    // App-level decoding
+    public var channelHash: Int?
+    public var channelName: String?
+    public var decryptStatus: Int
+    public var fromContactName: String?
+    public var toContactName: String?
+
+    // Privacy: Never persisted — decrypted on demand
+    @Transient
+    public var decodedText: String?
+
+    public init(
+        id: UUID = UUID(),
+        deviceID: UUID,
+        receivedAt: Date = Date(),
+        snr: Double? = nil,
+        rssi: Int? = nil,
+        routeType: Int,
+        payloadType: Int,
+        payloadVersion: Int,
+        transportCode: Data? = nil,
+        pathLength: Int,
+        pathNodes: Data,
+        packetPayload: Data,
+        rawPayload: Data,
+        packetHash: String,
+        channelHash: Int? = nil,
+        channelName: String? = nil,
+        decryptStatus: Int = DecryptStatus.notApplicable.rawValue,
+        fromContactName: String? = nil,
+        toContactName: String? = nil
+    ) {
+        self.id = id
+        self.deviceID = deviceID
+        self.receivedAt = receivedAt
+        self.snr = snr
+        self.rssi = rssi
+        self.routeType = routeType
+        self.payloadType = payloadType
+        self.payloadVersion = payloadVersion
+        self.transportCode = transportCode
+        self.pathLength = pathLength
+        self.pathNodes = pathNodes
+        self.packetPayload = packetPayload
+        self.rawPayload = rawPayload
+        self.packetHash = packetHash
+        self.channelHash = channelHash
+        self.channelName = channelName
+        self.decryptStatus = decryptStatus
+        self.fromContactName = fromContactName
+        self.toContactName = toContactName
+    }
+}
+
+/// Sendable DTO for cross-actor transfer of RxLogEntry data.
+public struct RxLogEntryDTO: Sendable, Identifiable, Equatable, Hashable {
+    public let id: UUID
+    public let deviceID: UUID
+    public let receivedAt: Date
+    public let snr: Double?
+    public let rssi: Int?
+    public let routeType: RouteType
+    public let payloadType: PayloadType
+    public let payloadVersion: UInt8
+    public let transportCode: Data?
+    public let pathLength: UInt8
+    public let pathNodes: Data
+    public let packetPayload: Data
+    public let rawPayload: Data
+    public let packetHash: String
+    public let channelHash: UInt8?
+    public let channelName: String?
+    public let decryptStatus: DecryptStatus
+    public let fromContactName: String?
+    public let toContactName: String?
+
+    // Transient - set by UI layer after decryption
+    public var decodedText: String?
+
+    /// Initialize from SwiftData model.
+    public init(from model: RxLogEntry) {
+        self.id = model.id
+        self.deviceID = model.deviceID
+        self.receivedAt = model.receivedAt
+        self.snr = model.snr
+        self.rssi = model.rssi
+        self.routeType = RouteType(rawValue: UInt8(model.routeType)) ?? .flood
+        self.payloadType = PayloadType(rawValue: UInt8(model.payloadType)) ?? .unknown
+        self.payloadVersion = UInt8(model.payloadVersion)
+        self.transportCode = model.transportCode
+        self.pathLength = UInt8(model.pathLength)
+        self.pathNodes = model.pathNodes
+        self.packetPayload = model.packetPayload
+        self.rawPayload = model.rawPayload
+        self.packetHash = model.packetHash
+        self.channelHash = model.channelHash.map { UInt8($0) }
+        self.channelName = model.channelName
+        self.decryptStatus = DecryptStatus(rawValue: model.decryptStatus) ?? .notApplicable
+        self.fromContactName = model.fromContactName
+        self.toContactName = model.toContactName
+        self.decodedText = model.decodedText
+    }
+
+    /// Initialize from ParsedRxLogData (for new entries).
+    public init(
+        id: UUID = UUID(),
+        deviceID: UUID,
+        receivedAt: Date = Date(),
+        from parsed: ParsedRxLogData,
+        channelHash: UInt8? = nil,
+        channelName: String? = nil,
+        decryptStatus: DecryptStatus = .notApplicable,
+        fromContactName: String? = nil,
+        toContactName: String? = nil,
+        decodedText: String? = nil
+    ) {
+        self.id = id
+        self.deviceID = deviceID
+        self.receivedAt = receivedAt
+        self.snr = parsed.snr
+        self.rssi = parsed.rssi
+        self.routeType = parsed.routeType
+        self.payloadType = parsed.payloadType
+        self.payloadVersion = parsed.payloadVersion
+        self.transportCode = parsed.transportCode
+        self.pathLength = parsed.pathLength
+        self.pathNodes = Data(parsed.pathNodes)
+        self.packetPayload = parsed.packetPayload
+        self.rawPayload = parsed.rawPayload
+        self.packetHash = parsed.packetHash
+        self.channelHash = channelHash
+        self.channelName = channelName
+        self.decryptStatus = decryptStatus
+        self.fromContactName = fromContactName
+        self.toContactName = toContactName
+        self.decodedText = decodedText
+    }
+
+    // MARK: - Computed Properties
+
+    /// Path nodes as hex strings for display.
+    public var pathNodesHex: [String] {
+        pathNodes.map { String(format: "%02X", $0) }
+    }
+
+    /// Formatted path string for compact display.
+    public var pathDisplayString: String {
+        if pathLength == 0 {
+            return "direct"
+        }
+        let hexNodes = pathNodesHex.joined(separator: ":")
+        return "via [\(hexNodes)]"
+    }
+
+    /// Whether this is a flood-type route.
+    public var isFlood: Bool {
+        routeType == .flood || routeType == .tcFlood
+    }
+
+    // MARK: - Signal Quality
+
+    /// RSSI mapped to 0-1 for SF Symbol cellularbars variableValue.
+    /// Based on standard LoRa ranges: excellent > -70, good > -90, fair > -110, weak > -120.
+    public var rssiLevel: Double {
+        guard let rssi else { return 0 }
+        if rssi > -70 { return 1.0 }
+        if rssi > -90 { return 0.75 }
+        if rssi > -110 { return 0.5 }
+        if rssi > -120 { return 0.25 }
+        return 0.1
+    }
+
+    /// Human-readable RSSI quality label for accessibility.
+    public var rssiQualityLabel: String {
+        guard let rssi else { return "Unknown" }
+        if rssi > -70 { return "Excellent" }
+        if rssi > -90 { return "Good" }
+        if rssi > -110 { return "Fair" }
+        if rssi > -120 { return "Weak" }
+        return "Marginal"
+    }
+
+    /// Formatted SNR string (no label, includes sign for negative).
+    public var snrDisplayString: String? {
+        guard let snr else { return nil }
+        return snr.formatted(.number.precision(.fractionLength(1))) + " dB"
+    }
+
+    /// Route type display - "FLOOD" or "DIRECT" (simplified from TC variants).
+    public var routeTypeSimple: String {
+        isFlood ? "FLOOD" : "DIRECT"
+    }
+
+    // MARK: - Hashable
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}

--- a/PocketMeshServices/Sources/PocketMeshServices/Services/RxLogService.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Services/RxLogService.swift
@@ -1,0 +1,289 @@
+// PocketMeshServices/Sources/PocketMeshServices/Services/RxLogService.swift
+import Foundation
+import MeshCore
+import OSLog
+
+private let logger = Logger(subsystem: "com.pocketmesh.services", category: "RxLogService")
+
+/// Actor that processes RX log events, decodes channel messages, and persists to database.
+public actor RxLogService {
+    private let session: MeshCoreSession
+    private let persistenceStore: PersistenceStore
+    private var deviceID: UUID?
+
+    // Caches for fast lookup
+    private var channelSecrets: [UInt8: Data] = [:]  // channelIndex -> secret
+    private var channelNames: [UInt8: String] = [:]   // channelIndex -> name
+    private var contactNames: [Data: String] = [:]    // pubkey prefix -> name
+
+    // Stream for UI updates
+    private var streamContinuation: AsyncStream<RxLogEntryDTO>.Continuation?
+
+    // Event monitoring
+    private var eventMonitorTask: Task<Void, Never>?
+
+    public init(session: MeshCoreSession, persistenceStore: PersistenceStore) {
+        self.session = session
+        self.persistenceStore = persistenceStore
+    }
+
+    deinit {
+        eventMonitorTask?.cancel()
+    }
+
+    // MARK: - Event Monitoring
+
+    /// Start monitoring for RX log events from MeshCore.
+    public func startEventMonitoring(deviceID: UUID) {
+        self.deviceID = deviceID
+        eventMonitorTask?.cancel()
+
+        eventMonitorTask = Task { [weak self] in
+            guard let self else { return }
+            let events = await session.events()
+
+            for await event in events {
+                guard !Task.isCancelled else { break }
+                if case .rxLogData(let parsed) = event {
+                    await self.process(parsed)
+                }
+            }
+        }
+    }
+
+    /// Stop monitoring events.
+    public func stopEventMonitoring() {
+        eventMonitorTask?.cancel()
+        eventMonitorTask = nil
+    }
+
+    /// Returns a stream of new entries.
+    /// - Note: Only one active subscriber is supported. Subsequent calls replace the previous subscriber.
+    public func entryStream() -> AsyncStream<RxLogEntryDTO> {
+        AsyncStream { continuation in
+            Task { await self.setContinuation(continuation) }
+            continuation.onTermination = { @Sendable _ in
+                Task { await self.clearContinuation() }
+            }
+        }
+    }
+
+    private func setContinuation(_ continuation: AsyncStream<RxLogEntryDTO>.Continuation) {
+        if streamContinuation != nil {
+            logger.warning("Replacing existing RX log stream subscriber")
+        }
+        streamContinuation?.finish()
+        self.streamContinuation = continuation
+    }
+
+    private func clearContinuation() {
+        streamContinuation = nil
+    }
+
+    /// Update channel cache (secrets and names).
+    public func updateChannels(secrets: [UInt8: Data], names: [UInt8: String]) {
+        channelSecrets = secrets
+        channelNames = names
+    }
+
+    /// Update contact names cache.
+    public func updateContactNames(_ names: [Data: String]) {
+        contactNames = names
+    }
+
+    /// Process a parsed RX log event.
+    public func process(_ parsed: ParsedRxLogData) async {
+        guard let deviceID else { return }
+
+        // Decode channel message if applicable
+        var channelIndex: UInt8?
+        var channelName: String?
+        var decryptStatus = DecryptStatus.notApplicable
+        var decodedText: String?
+        var fromContactName: String?
+
+        if parsed.payloadType == .groupText || parsed.payloadType == .groupData {
+            // Channel payload format: [channelHash: 1B] [MAC: 2B] [ciphertext: NB]
+            // The first byte is a truncated channel hash (not the index), so we must
+            // try all known secrets to find the one where MAC validates.
+            let rawPayload = parsed.packetPayload
+
+            // Need at least: 1 (channel hash) + 2 (MAC) + 16 (min ciphertext block)
+            if rawPayload.count >= 1 + ChannelCrypto.macSize + 16 {
+                let encryptedPayload = Data(rawPayload.dropFirst(1))
+
+                for (index, secret) in self.channelSecrets {
+                    let result = ChannelCrypto.decrypt(payload: encryptedPayload, secret: secret)
+                    if case .success(_, _, let text) = result {
+                        channelIndex = index
+                        channelName = channelNames[index] ?? "Channel \(index)"
+                        decryptStatus = .success
+                        decodedText = text
+                        break
+                    }
+                }
+
+                if decryptStatus == .notApplicable {
+                    decryptStatus = .noMatchingKey
+                }
+            } else {
+                decryptStatus = .pending
+            }
+        }
+
+        // Resolve contact name from sender pubkey prefix (direct messages)
+        if let senderPrefix = parsed.senderPubkeyPrefix {
+            fromContactName = contactNames.first { storedPrefix, _ in
+                storedPrefix.starts(with: senderPrefix) || senderPrefix.starts(with: storedPrefix)
+            }?.value
+        }
+
+        // Create DTO
+        let dto = RxLogEntryDTO(
+            deviceID: deviceID,
+            from: parsed,
+            channelHash: channelIndex,
+            channelName: channelName,
+            decryptStatus: decryptStatus,
+            fromContactName: fromContactName,
+            decodedText: decodedText
+        )
+
+        // Persist
+        do {
+            try await persistenceStore.saveRxLogEntry(dto)
+            try await persistenceStore.pruneRxLogEntries(deviceID: deviceID)
+        } catch {
+            logger.error("Failed to save RX log entry: \(error.localizedDescription)")
+        }
+
+        // Emit to stream
+        streamContinuation?.yield(dto)
+    }
+
+    /// Load existing entries from database, re-decrypting payloads with current secrets.
+    public func loadExistingEntries() async -> [RxLogEntryDTO] {
+        guard let deviceID else { return [] }
+        do {
+            let entries = try await persistenceStore.fetchRxLogEntries(deviceID: deviceID)
+            return entries.map { decryptEntry($0) }
+        } catch {
+            logger.error("Failed to load RX log entries: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    // MARK: - Decryption
+
+    /// Attempt to decrypt a channel message entry using current secrets.
+    /// Returns a copy of the entry with `decodedText` populated if decryption succeeds.
+    /// This is reusable for export and other features that need decrypted content.
+    ///
+    /// If the entry was previously decrypted (`decryptStatus == .success`),
+    /// we use the stored channel index for O(1) secret lookup instead of trying all keys.
+    public func decryptEntry(_ entry: RxLogEntryDTO) -> RxLogEntryDTO {
+        var result = entry
+
+        // Only attempt decryption for channel messages
+        guard entry.payloadType == .groupText || entry.payloadType == .groupData else {
+            return result
+        }
+
+        // Skip if payload is too small
+        guard entry.packetPayload.count >= 1 + ChannelCrypto.macSize + 16 else {
+            return result
+        }
+
+        // Channel payload format: [channelHash: 1B] [MAC: 2B] [ciphertext: NB]
+        let encryptedPayload = Data(entry.packetPayload.dropFirst(1))
+
+        // Fast path: use stored channel index if previously decrypted successfully
+        if entry.decryptStatus == .success, let channelIndex = entry.channelHash,
+           let secret = channelSecrets[channelIndex] {
+            let decryptResult = ChannelCrypto.decrypt(payload: encryptedPayload, secret: secret)
+            if case .success(_, _, let text) = decryptResult {
+                result.decodedText = text
+                return result
+            }
+        }
+
+        // Slow path: try all secrets (for .noMatchingKey entries or if fast path failed)
+        for (_, secret) in channelSecrets {
+            let decryptResult = ChannelCrypto.decrypt(payload: encryptedPayload, secret: secret)
+            if case .success(_, _, let text) = decryptResult {
+                result.decodedText = text
+                break
+            }
+        }
+
+        return result
+    }
+
+    /// Decrypt multiple entries concurrently. Useful for batch export.
+    /// Uses parallel processing for better performance with large datasets.
+    public func decryptEntries(_ entries: [RxLogEntryDTO]) async -> [RxLogEntryDTO] {
+        // Capture secrets for concurrent access
+        let secrets = channelSecrets
+
+        return await withTaskGroup(of: (Int, RxLogEntryDTO).self) { group in
+            for (index, entry) in entries.enumerated() {
+                group.addTask {
+                    let decrypted = Self.decryptEntry(entry, secrets: secrets)
+                    return (index, decrypted)
+                }
+            }
+
+            var results = entries
+            for await (index, decrypted) in group {
+                results[index] = decrypted
+            }
+            return results
+        }
+    }
+
+    /// Static decryption for concurrent use (no actor isolation).
+    private static func decryptEntry(_ entry: RxLogEntryDTO, secrets: [UInt8: Data]) -> RxLogEntryDTO {
+        var result = entry
+
+        guard entry.payloadType == .groupText || entry.payloadType == .groupData else {
+            return result
+        }
+
+        guard entry.packetPayload.count >= 1 + ChannelCrypto.macSize + 16 else {
+            return result
+        }
+
+        let encryptedPayload = Data(entry.packetPayload.dropFirst(1))
+
+        // Fast path: use stored channel index
+        if entry.decryptStatus == .success, let channelIndex = entry.channelHash,
+           let secret = secrets[channelIndex] {
+            let decryptResult = ChannelCrypto.decrypt(payload: encryptedPayload, secret: secret)
+            if case .success(_, _, let text) = decryptResult {
+                result.decodedText = text
+                return result
+            }
+        }
+
+        // Slow path: try all secrets
+        for (_, secret) in secrets {
+            let decryptResult = ChannelCrypto.decrypt(payload: encryptedPayload, secret: secret)
+            if case .success(_, _, let text) = decryptResult {
+                result.decodedText = text
+                break
+            }
+        }
+
+        return result
+    }
+
+    /// Clear all entries.
+    public func clearEntries() async {
+        guard let deviceID else { return }
+        do {
+            try await persistenceStore.clearRxLogEntries(deviceID: deviceID)
+        } catch {
+            logger.error("Failed to clear RX log entries: \(error.localizedDescription)")
+        }
+    }
+}

--- a/docs/api/MeshCore.md
+++ b/docs/api/MeshCore.md
@@ -308,8 +308,8 @@ Represents any event received from the device. Events are organized into categor
 | Case | Payload | Description |
 |------|---------|-------------|
 | `.rawData` | `RawDataInfo` | Raw radio data received |
-| `.logData` | `LogDataInfo` | Log data from device |
-| `.rxLogData` | `LogDataInfo` | Raw RF log data |
+| `.rxLogData` | `ParsedRxLogData` | Emitted when low-level radio log data is successfully parsed into structured packet information |
+| `.logData` | `LogDataInfo` | Emitted for diagnostic logs and malformed RX payloads that failed parsing |
 | `.controlData` | `ControlDataInfo` | Control protocol data received |
 | `.discoverResponse` | `DiscoverResponse` | Node discovery response |
 
@@ -851,6 +851,27 @@ Log data received from the device.
 | `snr` | `Double?` | Optional signal-to-noise ratio |
 | `rssi` | `Int?` | Optional received signal strength indicator |
 | `payload` | `Data` | Raw log payload data |
+
+### ParsedRxLogData (public, struct)
+
+**File:** `MeshCore/Sources/MeshCore/Protocol/RxLogTypes.swift`
+
+Parsed RF packet data from `rxLogData` events.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `snr` | `Double?` | SNR in dB (0.25 dB resolution) |
+| `rssi` | `Int?` | RSSI in dBm |
+| `rawPayload` | `Data` | Original unparsed payload bytes |
+| `routeType` | `RouteType` | Routing method (flood, direct, tc_flood, tc_direct) |
+| `payloadType` | `PayloadType` | Message type (header bits 2-5; values 12-15 map to `.unknown`) |
+| `payloadVersion` | `UInt8` | Protocol version (0-3) |
+| `transportCode` | `Data?` | 4-byte transport code if route type requires it |
+| `pathLength` | `UInt8` | Number of path nodes |
+| `pathNodes` | `[UInt8]` | Path node identifiers (1 byte each) as emitted by firmware |
+| `packetPayload` | `Data` | Payload after header/path extraction |
+| `packetHash` | `String` | First 8 bytes of SHA-256 of `packetPayload`, as 16-char hex |
+| `senderPubkeyPrefix` | `Data?` | 6-byte sender pubkey for direct text messages |
 
 ### ControlDataInfo (public, struct)
 


### PR DESCRIPTION
## Summary

- Add RX Log viewer to Tools tab for raw RF packet inspection
- Parse and display packet headers, routing info, and payloads
- Decrypt channel messages using stored keys with contact name resolution
- Group duplicate packet receipts by hash with expandable detail view
- Persist up to 1000 entries

Closes #28 

## Test plan

- [x] Open Tools tab and verify RX Log appears
- [x] Connect to mesh radio and observe packets streaming live
- [x] Tap packet row to expand and view details
- [x] Verify channel messages show decrypted text when key available
- [x] Toggle "Group Duplicates" and verify grouping behavior
- [x] Clear log and verify entries are removed
- [x] Background app and reopen to verify persistence