### PR TITLE
fix: reset PIN visibility when returning to Settings

### DIFF
--- a/PocketMesh/Views/Settings/Sections/BluetoothSection.swift
+++ b/PocketMesh/Views/Settings/Sections/BluetoothSection.swift
@@ -106,6 +106,7 @@ struct BluetoothSection: View {
             }
         }
         .onAppear {
+            isPinVisible = false
             pinType = currentPinType
             Task { @MainActor in
                 hasInitialized = true


### PR DESCRIPTION
## Problem

The "Current PIN" field in Settings does not re-hide when navigating away and back. When a user:
1. Opens Settings and taps to reveal the PIN
2. Navigates to another tab
3. Returns to Settings

The PIN remains visible instead of being hidden. This is a security concern since sensitive information stays exposed.

### Root Cause

The `@State private var isPinVisible` in `BluetoothSection.swift` was not being reset in the `.onAppear` modifier. SwiftUI preserves `@State` variables for views that remain in the view hierarchy (due to the Tab API), so the visibility state persists across tab switches.

## Solution

Added `isPinVisible = false` to the existing `.onAppear` block in `BluetoothSection.swift`. This ensures the PIN is hidden whenever the user navigates back to Settings, while maintaining normal toggle behavior when tapping the PIN field.

```diff
 .onAppear {
+    isPinVisible = false
     pinType = currentPinType
     Task { @MainActor in
         hasInitialized = true
     }
 }
```

## Manual Testing

1. Build and run the app in simulator
2. Navigate to Settings tab
3. Tap "Current PIN" row to reveal the PIN (eye icon changes, digits become visible)
4. Navigate to a different tab (e.g., Chats or Map)
5. Navigate back to Settings tab
6. **Expected**: PIN should be hidden again (showing "------" with eye.slash icon)
7. Tap to reveal again - should work normally

Fixes #16