### PR TITLE
fix: handle forgotten device and wrong PIN recovery

### DIFF
--- a/PocketMesh/Views/Settings/DeviceSelectionSheet.swift
+++ b/PocketMesh/Views/Settings/DeviceSelectionSheet.swift
@@ -107,12 +107,19 @@ struct DeviceSelectionSheet: View {
         ContentUnavailableView {
             Label("No Paired Devices", systemImage: "antenna.radiowaves.left.and.right.slash")
         } description: {
-            Text("You haven't paired any devices yet.")
-        } actions: {
-            Button("Scan for Devices") {
-                scanForNewDevice()
+            VStack(spacing: 20) {
+                Text("You haven't paired any devices yet.")
+
+                Button {
+                    scanForNewDevice()
+                } label: {
+                    Text("Scan for Devices")
+                        .font(.headline)
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 12)
+                }
+                .liquidGlassProminentButtonStyle()
             }
-            .buttonStyle(.borderedProminent)
         }
     }
 

--- a/PocketMesh/Views/Settings/Sections/BluetoothSection.swift
+++ b/PocketMesh/Views/Settings/Sections/BluetoothSection.swift
@@ -268,6 +268,11 @@ struct BluetoothSection: View {
             try await appState.connectionManager.forgetDevice()
             try await Task.sleep(for: .milliseconds(500))
             try await appState.connectionManager.pairNewDevice()
+        } catch let pairingError as PairingError {
+            // Wrong PIN during re-pairing - use AppState's recovery flow
+            appState.failedPairingDeviceID = pairingError.deviceID
+            appState.connectionFailedMessage = "Authentication failed. The device was added but couldn't connect — this usually means the wrong PIN was entered."
+            appState.showingConnectionFailedAlert = true
         } catch {
             showError = "Re-pairing failed: \(error.localizedDescription)"
         }

--- a/PocketMeshServices/Sources/PocketMeshServices/ConnectionManager.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/ConnectionManager.swift
@@ -32,6 +32,27 @@ public enum ConnectionError: LocalizedError {
     }
 }
 
+/// Errors that can occur during device pairing
+public enum PairingError: LocalizedError {
+    /// ASK pairing succeeded but BLE connection failed (e.g., wrong PIN)
+    case connectionFailed(deviceID: UUID, underlying: Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .connectionFailed(_, let underlying):
+            return "Connection failed: \(underlying.localizedDescription)"
+        }
+    }
+
+    /// The device ID that failed to connect (for recovery UI)
+    public var deviceID: UUID? {
+        switch self {
+        case .connectionFailed(let deviceID, _):
+            return deviceID
+        }
+    }
+}
+
 /// Manages the connection lifecycle for mesh devices.
 ///
 /// `ConnectionManager` owns the transport, session, and services. It handles:
@@ -240,7 +261,8 @@ public final class ConnectionManager {
     }
 
     /// Pairs a new device using AccessorySetupKit picker.
-    /// - Throws: AccessorySetupKitError if pairing fails
+    /// - Returns: The device ID if pairing succeeds but connection fails (for recovery UI)
+    /// - Throws: `PairingError` with device ID if connection fails after ASK pairing succeeds
     public func pairNewDevice() async throws {
         logger.info("Starting device pairing")
 
@@ -251,7 +273,40 @@ public final class ConnectionManager {
         let deviceID = try await accessorySetupKit.showPicker()
 
         // Connect to the newly paired device
-        try await connectAfterPairing(deviceID: deviceID)
+        do {
+            try await connectAfterPairing(deviceID: deviceID)
+        } catch {
+            // Connection failed (e.g., wrong PIN causes "Authentication is insufficient")
+            // Don't auto-remove - throw error with device ID so UI can offer recovery
+            logger.error("Connection after pairing failed: \(error.localizedDescription)")
+            throw PairingError.connectionFailed(deviceID: deviceID, underlying: error)
+        }
+    }
+
+    /// Removes a device that failed to connect after pairing.
+    /// Call this when user explicitly chooses to remove and retry.
+    /// - Parameter deviceID: The device ID from `PairingError.connectionFailed`
+    public func removeFailedPairing(deviceID: UUID) async {
+        logger.info("Removing failed pairing for device: \(deviceID)")
+
+        // Remove from ASK
+        if let accessory = accessorySetupKit.accessory(for: deviceID) {
+            do {
+                try await accessorySetupKit.removeAccessory(accessory)
+                logger.info("Removed device from ASK")
+            } catch {
+                logger.warning("Failed to remove from ASK: \(error.localizedDescription)")
+            }
+        }
+
+        // Clean up SwiftData (may not exist for fresh pairing)
+        let dataStore = PersistenceStore(modelContainer: modelContainer)
+        try? await dataStore.deleteDevice(id: deviceID)
+
+        // Clear persisted connection if needed
+        if lastConnectedDeviceID == deviceID {
+            clearPersistedConnection()
+        }
     }
 
     /// Connects to a previously paired device.
@@ -934,6 +989,37 @@ extension ConnectionManager: AccessorySetupKitServiceDelegate {
                 try await dataStore.deleteDevice(id: bluetoothID)
             } catch {
                 logger.warning("Failed to delete device data from SwiftData: \(error.localizedDescription)")
+            }
+        }
+
+        // Clear persisted connection if it was this device
+        if lastConnectedDeviceID == bluetoothID {
+            clearPersistedConnection()
+        }
+    }
+
+    public func accessorySetupKitService(
+        _ service: AccessorySetupKitService,
+        didFailPairingForAccessoryWithID bluetoothID: UUID
+    ) {
+        // Handle pairing failure (e.g., wrong PIN)
+        // Clean up any existing device data so the device can appear in picker again
+        logger.info("Pairing failed for device: \(bluetoothID)")
+
+        Task {
+            // Disconnect if this was somehow the connected device
+            if connectedDevice?.id == bluetoothID {
+                await disconnect()
+            }
+
+            // Delete from SwiftData (may not exist if this was a fresh pairing attempt)
+            let dataStore = PersistenceStore(modelContainer: modelContainer)
+            do {
+                try await dataStore.deleteDevice(id: bluetoothID)
+                logger.info("Deleted device data after failed pairing")
+            } catch {
+                // Expected if device wasn't previously saved
+                logger.debug("No device data to delete: \(error.localizedDescription)")
             }
         }
 


### PR DESCRIPTION
## Problem

Issue #78 covers two related device pairing problems:

### 1. Forgotten device persists in Connect Device sheet
When a user forgets a device from Settings, the device persists in the Connect Device sheet. This happens because `ConnectionManager.forgetDevice()` removes the device from AccessorySetupKit but does not delete it from SwiftData.

### 2. Wrong PIN leaves user stuck
When user enters wrong PIN during device pairing:
1. Device gets added to AccessorySetupKit (pairing appears to succeed)
2. BLE authentication fails with "Authentication is insufficient"
3. Device remains in ASK `pairedAccessories` but can't connect
4. Device won't appear in ASK picker for fresh pairing attempt
5. User is stuck unable to re-pair

## Solution

### Fix 1: SwiftData cleanup on forget
Added SwiftData deletion to both code paths that handle device removal:
- **`forgetDevice()`** - Deletes device and cascades to all associated data
- **`accessorySetupKitService(_:didRemoveAccessoryWithID:)`** - Handles external removal via iOS Settings

### Fix 2: Wrong PIN recovery flow
- Added `PairingError` enum to distinguish wrong PIN failures from other errors
- Added `removeFailedPairing()` method for explicit cleanup
- Show "Remove & Try Again" alert explaining the issue to user
- Auto-show ASK picker after removal using `scenePhase` observation (SwiftUI-native, no magic delays)
- Consolidated all error handling to centralized alert system in ContentView
- Added shared `isPairing` state for consistent button UI during auto-retry

## Changes

- `ConnectionManager.swift` - PairingError enum, removeFailedPairing(), SwiftData cleanup
- `AppState.swift` - failedPairingDeviceID, isPairing, removeFailedPairingAndRetry(), handleBecameActive()
- `ContentView.swift` - Centralized alert with conditional "Remove & Try Again" button, scenePhase observation
- `DeviceScanView.swift` - Uses AppState's alert system and shared isPairing state
- `BluetoothSection.swift` - PairingError handling for PIN changes
- `DeviceSelectionSheet.swift` - Liquid glass button style

## Manual Testing

### Forgotten device flow:
1. Pair a device
2. Go to Settings and tap "Forget Device"
3. Open the Connect Device sheet
4. Verify the forgotten device no longer appears

### Wrong PIN flow:
1. Pair a device and enter wrong PIN
2. Verify "Connection Failed" alert appears with "Remove & Try Again" button
3. Tap "Remove & Try Again"
4. Confirm iOS removal dialog
5. Verify ASK picker automatically appears for retry
6. Enter correct PIN
7. Verify radio preset screen appears (not skipped)
8. Complete onboarding

Fixes #78