### PR TITLE
fix: simplify PIN change flow by removing unnecessary re-pairing

### DIFF
--- a/PocketMesh/Views/Settings/Sections/BluetoothSection.swift
+++ b/PocketMesh/Views/Settings/Sections/BluetoothSection.swift
@@ -186,7 +186,12 @@ struct BluetoothSection: View {
                 try await settingsService.setBlePin(pinValue)
 
                 // Reboot device to apply PIN change - iOS auto-reconnects
-                try await settingsService.reboot()
+                // Timeout is expected since device disconnects before write callback
+                do {
+                    try await settingsService.reboot()
+                } catch BLEError.operationTimeout {
+                    // Expected - device reboots before BLE write callback arrives
+                }
             } catch {
                 showError = error.localizedDescription
                 // Revert
@@ -224,7 +229,12 @@ struct BluetoothSection: View {
                 try await settingsService.setBlePin(pin)
 
                 // Reboot device to apply PIN change - iOS auto-reconnects
-                try await settingsService.reboot()
+                // Timeout is expected since device disconnects before write callback
+                do {
+                    try await settingsService.reboot()
+                } catch BLEError.operationTimeout {
+                    // Expected - device reboots before BLE write callback arrives
+                }
             } catch {
                 showError = error.localizedDescription
                 // Revert


### PR DESCRIPTION
## Problem

Two issues with PIN settings:

1. **Timeout error:** Changing PIN type (e.g., custom to default) showed "Operation timed out" error
2. **Wrong PIN type displayed:** After pairing with default PIN (123456), app showed "Random (Screen Required)" instead of "Default"

## Root Cause

### Issue 1: Timeout
Two causes:
1. The flow tried to forget and re-pair the device after PIN change — unnecessary since BLE PIN is only used during initial pairing to derive the Long Term Key (LTK)
2. The `reboot()` command uses `.withResponse` BLE writes, but the device disconnects before the write callback arrives, causing `BLEError.operationTimeout`

### Issue 2: Wrong display
MeshCore firmware returns `blePin: 0` for factory-fresh devices, but uses 123456 as the actual pairing PIN for screenless devices. The app incorrectly mapped `blePin == 0` → "Random".

## Solution

### PIN change flow
- Remove unnecessary forget/re-pair flow: `setBlePin → reboot → iOS auto-reconnects`
- Catch and ignore `BLEError.operationTimeout` after reboot (expected behavior)

### PIN type display
- Treat both `blePin == 0` and `blePin == 123456` as "Default"
- Remove "Random" option from picker (only relevant internally for display devices)
- Add footer explaining default PIN behavior

### UX improvements
- Rename button: "Rename Device" → "Change Display Name" (clearer, platform-agnostic for iOS/iPadOS/macOS)
- Remove redundant footer text about renaming

## Test Plan

- [x] Default → Custom PIN: reboots, reconnects, shows custom PIN
- [x] Custom → Default PIN: reboots, reconnects, shows default PIN
- [x] No "operation timed out" error
- [x] No AccessorySetupKit picker appears
- [x] Device remains paired in ASK and SwiftData
- [x] Factory-fresh device shows "Default" not "Random"
- [x] Footer shows PIN explanation when Default is selected

Fixes #77