### PR TITLE
fix: improve Nodes tab with location service and distance display

### DIFF
--- a/PocketMesh/Services/LocationService.swift
+++ b/PocketMesh/Services/LocationService.swift
@@ -2,7 +2,7 @@ import CoreLocation
 import OSLog
 
 /// App-wide location service for managing location permissions and access.
-/// Used by MapView, LineOfSightView, and other location-dependent features.
+/// Used by MapView, LineOfSightView, ContactsListView, and other location-dependent features.
 @MainActor
 @Observable
 public final class LocationService: NSObject, CLLocationManagerDelegate {
@@ -15,6 +15,12 @@ public final class LocationService: NSObject, CLLocationManagerDelegate {
     /// Current authorization status
     public private(set) var authorizationStatus: CLAuthorizationStatus
 
+    /// Current device location (nil if unavailable or not yet determined)
+    public private(set) var currentLocation: CLLocation?
+
+    /// Whether a location request is in progress
+    public private(set) var isRequestingLocation = false
+
     /// Whether location services are authorized for use
     public var isAuthorized: Bool {
         authorizationStatus == .authorizedWhenInUse || authorizationStatus == .authorizedAlways
@@ -25,6 +31,11 @@ public final class LocationService: NSObject, CLLocationManagerDelegate {
         authorizationStatus != .notDetermined
     }
 
+    /// Whether location is denied or restricted
+    public var isLocationDenied: Bool {
+        authorizationStatus == .denied || authorizationStatus == .restricted
+    }
+
     // MARK: - Initialization
 
     public override init() {
@@ -32,6 +43,7 @@ public final class LocationService: NSObject, CLLocationManagerDelegate {
         authorizationStatus = locationManager.authorizationStatus
         super.init()
         locationManager.delegate = self
+        locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
     }
 
     // MARK: - Public Methods
@@ -48,6 +60,25 @@ public final class LocationService: NSObject, CLLocationManagerDelegate {
         locationManager.requestWhenInUseAuthorization()
     }
 
+    /// Request a one-shot location update.
+    /// Call this when you need the current location (e.g., for distance sorting).
+    public func requestLocation() {
+        guard isAuthorized else {
+            logger.debug("Cannot request location: not authorized")
+            requestPermissionIfNeeded()
+            return
+        }
+
+        guard !isRequestingLocation else {
+            logger.debug("Location request already in progress")
+            return
+        }
+
+        logger.info("Requesting one-shot location update")
+        isRequestingLocation = true
+        locationManager.requestLocation()
+    }
+
     // MARK: - CLLocationManagerDelegate
 
     nonisolated public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
@@ -55,6 +86,22 @@ public final class LocationService: NSObject, CLLocationManagerDelegate {
         Task { @MainActor in
             self.authorizationStatus = status
             self.logger.info("Location authorization changed: \(String(describing: status.rawValue))")
+        }
+    }
+
+    nonisolated public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+        Task { @MainActor in
+            self.currentLocation = location
+            self.isRequestingLocation = false
+            self.logger.info("Location updated: \(location.coordinate.latitude), \(location.coordinate.longitude)")
+        }
+    }
+
+    nonisolated public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        Task { @MainActor in
+            self.isRequestingLocation = false
+            self.logger.error("Location request failed: \(error.localizedDescription)")
         }
     }
 }

--- a/PocketMesh/Views/Components/RelativeTimestampText.swift
+++ b/PocketMesh/Views/Components/RelativeTimestampText.swift
@@ -4,36 +4,41 @@ import SwiftUI
 struct RelativeTimestampText: View {
     let timestamp: UInt32
 
+    private enum Constants {
+        static let minute: TimeInterval = 60
+        static let hour: TimeInterval = 3_600
+        static let day: TimeInterval = 86_400
+        static let twoDays: TimeInterval = 172_800
+        static let week: TimeInterval = 604_800
+    }
+
     var body: some View {
         TimelineView(.everyMinute) { context in
-            Text(formattedTimestamp(relativeTo: context.date))
+            Text(Self.format(timestamp: timestamp, relativeTo: context.date))
                 .font(.caption2)
                 .foregroundStyle(.secondary)
         }
     }
 
-    private var date: Date {
-        Date(timeIntervalSince1970: TimeInterval(timestamp))
-    }
-
-    private func formattedTimestamp(relativeTo now: Date) -> String {
+    /// Formats a timestamp relative to the given date. Exposed for testing.
+    static func format(timestamp: UInt32, relativeTo now: Date) -> String {
+        let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
         let interval = now.timeIntervalSince(date)
 
-        if interval < 60 {
+        if interval < Constants.minute {
             return "Now"
-        } else if interval < 3600 {
-            let minutes = Int(interval / 60)
+        } else if interval < Constants.hour {
+            let minutes = Int(interval / Constants.minute)
             return "\(minutes)m ago"
-        } else if interval < 86400 {
-            let hours = Int(interval / 3600)
+        } else if interval < Constants.day {
+            let hours = Int(interval / Constants.hour)
             return "\(hours)h ago"
-        } else if interval < 172800 {
+        } else if interval < Constants.twoDays {
             return "Yesterday"
-        } else if interval < 604800 {
-            let days = Int(interval / 86400)
+        } else if interval < Constants.week {
+            let days = Int(interval / Constants.day)
             return "\(days)d ago"
         } else {
-            // Older than a week, show date
             return date.formatted(.dateTime.month(.abbreviated).day())
         }
     }

--- a/PocketMeshTests/Views/RelativeTimestampTextTests.swift
+++ b/PocketMeshTests/Views/RelativeTimestampTextTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Testing
+@testable import PocketMesh
+
+@Suite("RelativeTimestampText Tests")
+struct RelativeTimestampTextTests {
+
+    private let referenceDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func timestamp(secondsAgo: TimeInterval) -> UInt32 {
+        UInt32(referenceDate.addingTimeInterval(-secondsAgo).timeIntervalSince1970)
+    }
+
+    // MARK: - Now (< 1 minute)
+
+    @Test("Now is returned for 0 seconds ago")
+    func format_justNow_returnsNow() {
+        let result = RelativeTimestampText.format(
+            timestamp: timestamp(secondsAgo: 0),
+            relativeTo: referenceDate
+        )
+        #expect(result == "Now")
+    }
+
+    @Test("Now is returned for 30 seconds ago")
+    func format_30SecondsAgo_returnsNow() {
+        let result = RelativeTimestampText.format(
+            timestamp: timestamp(secondsAgo: 30),
+            relativeTo: referenceDate
+        )
+        #expect(result == "Now")
+    }
+
+    @Test("Now is returned for 59 seconds ago")
+    func format_59SecondsAgo_returnsNow() {
+        let result = RelativeTimestampText.format(
+            timestamp: timestamp(secondsAgo: 59),
+            relativeTo: referenceDate
+        )
+        #expect(result == "Now")
+    }
+
+    // MARK: - Minutes (1-59 min)
+
+    @Test("1m ago is returned for exactly 60 seconds")
+    func format_1MinuteAgo_returns1mAgo() {
+        let result = RelativeTimestampText.format(
+            timestamp: timestamp(secondsAgo: 60),
+            relativeTo: referenceDate
+        )
+        #expect(result == "1m ago")
+    }
+
+    @Test("30m ago is returned for 1800 seconds")
+    func format_30MinutesAgo_returns30mAgo() {
+        let result = RelativeTimestampText.format(
+            timestamp: timestamp(secondsAgo: 1800),
+            relativeTo: referenceDate
+        )
+        #expect(result == "30m ago")
+    }
+
+    @Test("59m ago is returned for 3599 seconds")
+    func format_59MinutesAgo_returns59mAgo() {
+        let result = RelativeTimestampText.format(
+            timestamp: timestamp(secondsAgo: 3599),
+            relativeTo: referenceDate
+        )
+        #expect(result == "59m ago")
+    }
+
+    // MARK: - Hours (1-23 hours)
+
+    @Test("1h ago is returned for exactly 3600 seconds")
+    func format_1HourAgo_returns1hAgo() {
+        let result = RelativeTimestampText.format(
+            timestamp: timestamp(secondsAgo: 3600),
+            relativeTo: referenceDate
+        )
+        #expect(result == "1h ago")
+    }
+
+    @Test("12h ago is returned for 43200 seconds")
+    func format_12HoursAgo_returns12hAgo() {
+        let result = RelativeTimestampText.format(
+            timestamp: timestamp(secondsAgo: 43200),
+            relativeTo: referenceDate
+        )
+        #expect(result == "12h ago")
+    }
+
+    @Test("23h ago is returned for 86399 seconds")
+    func format_23HoursAgo_returns23hAgo() {
+        let result = RelativeTimestampText.format(
+            timestamp: timestamp(secondsAgo: 86399),
+            relativeTo: referenceDate
+        )
+        #expect(result == "23h ago")
+    }
+
+    // MARK: - Yesterday (24-47 hours)
+
+    @Test("Yesterday is returned for exactly 86400 seconds (24 hours)")
+    func format_24HoursAgo_returnsYesterday() {
+        let result = RelativeTimestampText.format(
+            timestamp: timestamp(secondsAgo: 86400),
+            relativeTo: referenceDate
+        )
+        #expect(result == "Yesterday")
+    }
+
+    @Test("Yesterday is returned for 172799 seconds (47h 59m 59s)")
+    func format_47HoursAgo_returnsYesterday() {
+        let result = RelativeTimestampText.format(
+            timestamp: timestamp(secondsAgo: 172799),
+            relativeTo: referenceDate
+        )
+        #expect(result == "Yesterday")
+    }
+
+    // MARK: - Days (2-6 days)
+
+    @Test("2d ago is returned for exactly 172800 seconds (48 hours)")
+    func format_2DaysAgo_returns2dAgo() {
+        let result = RelativeTimestampText.format(
+            timestamp: timestamp(secondsAgo: 172800),
+            relativeTo: referenceDate
+        )
+        #expect(result == "2d ago")
+    }
+
+    @Test("6d ago is returned for 604799 seconds")
+    func format_6DaysAgo_returns6dAgo() {
+        let result = RelativeTimestampText.format(
+            timestamp: timestamp(secondsAgo: 604799),
+            relativeTo: referenceDate
+        )
+        #expect(result == "6d ago")
+    }
+
+    // MARK: - Week+ (formatted date)
+
+    @Test("Formatted date is returned for 7+ days ago")
+    func format_7DaysAgo_returnsFormattedDate() {
+        let result = RelativeTimestampText.format(
+            timestamp: timestamp(secondsAgo: 604800),
+            relativeTo: referenceDate
+        )
+        // Should return abbreviated month and day, e.g., "Nov 7"
+        #expect(result.contains(" "))
+        #expect(!result.contains("ago"))
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up fixes from PR #113 code review, plus a new distance display feature:

- **Magic numbers removed**: Extract time interval constants in `RelativeTimestampText` with testable static `format()` function
- **Unit tests added**: 14 tests for `RelativeTimestampText` timestamp formatting using Swift Testing
- **Search prompt fixed**: "Search contacts" → "Search nodes" to match tab rename
- **LocationService enhanced**: Added `currentLocation`, `requestLocation()`, and proper delegate methods for one-shot location updates
- **ContactsListView improved**: Uses `LocationService` instead of private `CLLocationManager`, with proper permission handling and alert for denied state
- **Distance display**: Shows distance beside location icon for nodes with positions (e.g., "1.2 km away"), locale-aware formatting

## Test plan

- [x] Build succeeds
- [x] All 392 tests pass (378 existing + 14 new)
- [x] Search placeholder shows "Search nodes"
- [x] Distance sorting works with location permission granted
- [x] Alert appears when selecting distance sort with location denied
- [x] Permission prompt appears when selecting distance sort without prior authorization
- [x] Distances display beside location icons (locale-aware: km vs mi)
- [x] Timestamps display correctly (Now, minutes, hours, Yesterday, days, formatted dates)