### PR TITLE
feat: add Online Map tool with MeshCore web view

### DIFF
--- a/PocketMesh/Views/Tools/OnlineMap/OnlineMapView.swift
+++ b/PocketMesh/Views/Tools/OnlineMap/OnlineMapView.swift
@@ -1,0 +1,59 @@
+import Network
+import SwiftUI
+
+struct OnlineMapView: View {
+    private static let mapURL = URL(string: "https://meshcore.co.uk/map.html")!
+
+    @State private var isLoading = true
+    @State private var isOnline = true
+    @State private var networkMonitor: NWPathMonitor?
+
+    var body: some View {
+        Group {
+            if isOnline {
+                ZStack {
+                    OnlineMapWebView(url: Self.mapURL, isLoading: $isLoading)
+
+                    if isLoading {
+                        ProgressView()
+                    }
+                }
+            } else {
+                ContentUnavailableView(
+                    "No Internet Connection",
+                    systemImage: "wifi.slash",
+                    description: Text("The online map requires an internet connection.")
+                )
+            }
+        }
+        .onAppear {
+            startNetworkMonitoring()
+        }
+        .onDisappear {
+            stopNetworkMonitoring()
+        }
+    }
+
+    private func startNetworkMonitoring() {
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { path in
+            Task { @MainActor in
+                isOnline = path.status == .satisfied
+            }
+        }
+        monitor.start(queue: DispatchQueue.global(qos: .background))
+        networkMonitor = monitor
+    }
+
+    private func stopNetworkMonitoring() {
+        networkMonitor?.cancel()
+        networkMonitor = nil
+    }
+}
+
+#Preview {
+    NavigationStack {
+        OnlineMapView()
+            .navigationTitle("Online Map")
+    }
+}

--- a/PocketMesh/Views/Tools/OnlineMap/OnlineMapWebView.swift
+++ b/PocketMesh/Views/Tools/OnlineMap/OnlineMapWebView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import WebKit
+
+struct OnlineMapWebView: UIViewRepresentable {
+    let url: URL
+    @Binding var isLoading: Bool
+
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = WKWebView()
+        webView.navigationDelegate = context.coordinator
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(isLoading: $isLoading)
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        @Binding var isLoading: Bool
+
+        init(isLoading: Binding<Bool>) {
+            _isLoading = isLoading
+        }
+
+        func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+            isLoading = true
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            isLoading = false
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            isLoading = false
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            isLoading = false
+        }
+    }
+}

--- a/PocketMesh/Views/Tools/OnlineMap/OnlineMapWebView.swift
+++ b/PocketMesh/Views/Tools/OnlineMap/OnlineMapWebView.swift
@@ -4,6 +4,7 @@ import WebKit
 struct OnlineMapWebView: UIViewRepresentable {
     let url: URL
     @Binding var isLoading: Bool
+    @Binding var loadError: Error?
 
     func makeUIView(context: Context) -> WKWebView {
         let webView = WKWebView()
@@ -15,30 +16,43 @@ struct OnlineMapWebView: UIViewRepresentable {
     func updateUIView(_ webView: WKWebView, context: Context) {}
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(isLoading: $isLoading)
+        Coordinator(isLoading: $isLoading, loadError: $loadError)
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate {
         @Binding var isLoading: Bool
+        @Binding var loadError: Error?
 
-        init(isLoading: Binding<Bool>) {
+        init(isLoading: Binding<Bool>, loadError: Binding<Error?>) {
             _isLoading = isLoading
+            _loadError = loadError
         }
 
         func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-            isLoading = true
+            Task { @MainActor in
+                isLoading = true
+                loadError = nil
+            }
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            isLoading = false
+            Task { @MainActor in
+                isLoading = false
+            }
         }
 
         func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-            isLoading = false
+            Task { @MainActor in
+                isLoading = false
+                loadError = error
+            }
         }
 
         func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-            isLoading = false
+            Task { @MainActor in
+                isLoading = false
+                loadError = error
+            }
         }
     }
 }

--- a/PocketMesh/Views/Tools/ToolsView.swift
+++ b/PocketMesh/Views/Tools/ToolsView.swift
@@ -9,6 +9,7 @@ struct ToolsView: View {
         case tracePath
         case lineOfSight
         case rxLog
+        case onlineMap
     }
 
     private enum SidebarDestination: Hashable {
@@ -34,6 +35,8 @@ struct ToolsView: View {
             "Trace Path"
         case .rxLog:
             "RX Log"
+        case .onlineMap:
+            "Online Map"
         case .lineOfSight, .none:
             "Tools"
         }
@@ -90,6 +93,14 @@ struct ToolsView: View {
                     } label: {
                         Label("RX Log", systemImage: "waveform.badge.magnifyingglass")
                     }
+
+                    NavigationLink {
+                        OnlineMapView()
+                            .navigationTitle("Online Map")
+                            .navigationBarTitleDisplayMode(.inline)
+                    } label: {
+                        Label("Online Map", systemImage: "globe")
+                    }
                 }
                 .navigationTitle("Tools")
                 .toolbar {
@@ -128,6 +139,14 @@ struct ToolsView: View {
                 } label: {
                     Label("RX Log", systemImage: "waveform.badge.magnifyingglass")
                 }
+
+                Button {
+                    selectedTool = .onlineMap
+                    isShowingLineOfSightPoints = false
+                    sidebarPath = NavigationPath()
+                } label: {
+                    Label("Online Map", systemImage: "globe")
+                }
             }
             .listStyle(.sidebar)
             .navigationTitle("Tools")
@@ -156,6 +175,8 @@ struct ToolsView: View {
             LineOfSightView(viewModel: lineOfSightViewModel, layoutMode: .map)
         case .rxLog:
             RxLogView()
+        case .onlineMap:
+            OnlineMapView()
         case .none:
             ContentUnavailableView("Select a tool", systemImage: "wrench.and.screwdriver")
         }


### PR DESCRIPTION
## Summary
- Adds a new "Online Map" tool in the Tools tab
- Displays an embedded web view of the MeshCore map (meshcore.co.uk/map.html)
- Includes network connectivity monitoring with offline placeholder message

## Test plan
- [ ] Open the Tools tab and verify "Online Map" appears with a globe icon
- [ ] Tap Online Map and verify the MeshCore map loads
- [ ] Test offline behavior by enabling airplane mode - should show "No Internet Connection" message
- [ ] Verify navigation works on both iPhone and iPad layouts