### PR TITLE
fix(connection): prevent reconnect sync hang

### DIFF
--- a/MeshCore/Tests/MeshCoreTests/Session/GetMessageTimeoutTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Session/GetMessageTimeoutTests.swift
@@ -1,0 +1,18 @@
+import Testing
+@testable import MeshCore
+
+@Suite("MeshCoreSession getMessage timeout")
+struct GetMessageTimeoutTests {
+    @Test("getMessage times out when no response arrives")
+    func getMessageTimesOutWhenNoResponseArrives() async {
+        let transport = MockTransport()
+        try? await transport.connect()
+
+        let configuration = SessionConfiguration(defaultTimeout: 0.02, clientIdentifier: "MeshCore-Tests")
+        let session = MeshCoreSession(transport: transport, configuration: configuration)
+
+        await #expect(throws: MeshCoreError.self) {
+            _ = try await session.getMessage()
+        }
+    }
+}

--- a/PocketMeshServices/Sources/PocketMeshServices/Protocols/MessagePollingServiceProtocol.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Protocols/MessagePollingServiceProtocol.swift
@@ -27,5 +27,5 @@ public protocol MessagePollingServiceProtocol: Actor {
 
     /// Wait for all pending message handlers to complete.
     /// Call this after pollAllMessages() to ensure all messages are fully processed.
-    func waitForPendingHandlers() async
+    func waitForPendingHandlers(timeout: Duration) async -> Bool
 }

--- a/PocketMeshServices/Tests/PocketMeshServicesTests/Mocks/MockMessagePollingService.swift
+++ b/PocketMeshServices/Tests/PocketMeshServicesTests/Mocks/MockMessagePollingService.swift
@@ -34,9 +34,9 @@ public actor MockMessagePollingService: MessagePollingServiceProtocol {
         }
     }
 
-    public func waitForPendingHandlers() async {
+    public func waitForPendingHandlers(timeout: Duration) async -> Bool {
         waitForPendingHandlersInvocations += 1
-        // In tests, handlers complete immediately
+        return true
     }
 
     // MARK: - Test Helpers

--- a/PocketMeshServices/Tests/PocketMeshServicesTests/SyncCoordinatorTests.swift
+++ b/PocketMeshServices/Tests/PocketMeshServicesTests/SyncCoordinatorTests.swift
@@ -354,8 +354,8 @@ actor OrderTrackingMessagePollingService: MessagePollingServiceProtocol {
         return 0
     }
 
-    func waitForPendingHandlers() async {
-        // No-op for tests
+    func waitForPendingHandlers(timeout: Duration) async -> Bool {
+        true
     }
 }
 


### PR DESCRIPTION
## Problem
After walking out of BLE range and returning, the app can get stuck showing the 'Connecting…' pill while messaging still works. In that state banner notifications stop, but badge counts continue updating.

## Fix
- Bound MeshCoreSession.getMessage so polling cannot wait indefinitely.
- Made MessagePollingService.waitForPendingHandlers time-bounded so notification suppression is always released.
- Treated initial sync failures as non-fatal across connection/reconnect paths so connection can still reach ready.

## Test
- swift test (MeshCore)
- swift test (PocketMeshServices)