### PR TITLE
feat(discovery): add filtering, search, sort, and clear to DiscoverView

### DIFF
--- a/PocketMesh/Resources/Generated/L10n.swift
+++ b/PocketMesh/Resources/Generated/L10n.swift
@@ -722,10 +722,12 @@ public enum L10n {
           public static func invalidSize(_ p1: Int, _ p2: Int) -> String {
             return L10n.tr("Contacts", "contacts.add.error.invalidSize", p1, p2, fallback: "Public key must be %d bytes (%d hex characters)")
           }
-          /// Location: AddContactSheet.swift - Purpose: Node list full error
+          /// Location: AddContactSheet.swift, DiscoveryView.swift - Purpose: Node list full error with max count
           public static func nodeListFull(_ p1: Int) -> String {
             return L10n.tr("Contacts", "contacts.add.error.nodeListFull", p1, fallback: "Node list is full (max %d nodes)")
           }
+          /// Location: AddContactSheet.swift, DiscoveryView.swift - Purpose: Node list full error without max count
+          public static let nodeListFullSimple = L10n.tr("Contacts", "contacts.add.error.nodeListFullSimple", fallback: "Node list is full")
           /// Location: AddContactSheet.swift - Purpose: Not connected error
           public static let notConnected = L10n.tr("Contacts", "contacts.add.error.notConnected", fallback: "Not connected to device")
         }
@@ -893,17 +895,57 @@ public enum L10n {
       public enum Discovery {
         /// Location: DiscoveryView.swift - Purpose: Add button
         public static let add = L10n.tr("Contacts", "contacts.discovery.add", fallback: "Add")
+        /// Location: DiscoveryView.swift - Purpose: Clear all menu item
+        public static let clear = L10n.tr("Contacts", "contacts.discovery.clear", fallback: "Clear All")
+        /// Location: DiscoveryView.swift - Purpose: VoiceOver announcement after clearing
+        public static let clearedAllNodes = L10n.tr("Contacts", "contacts.discovery.clearedAllNodes", fallback: "All discovered nodes cleared")
+        /// Location: DiscoveryView.swift - Purpose: More menu accessibility label
+        public static let menu = L10n.tr("Contacts", "contacts.discovery.menu", fallback: "More")
+        /// Location: DiscoveryView.swift - Purpose: Swipe action to remove discovered node
+        public static let remove = L10n.tr("Contacts", "contacts.discovery.remove", fallback: "Remove")
+        /// Location: DiscoveryView.swift - Purpose: VoiceOver announcement when searching
+        public static let searchingAllTypes = L10n.tr("Contacts", "contacts.discovery.searchingAllTypes", fallback: "Searching all types")
+        /// Location: DiscoveryView.swift - Purpose: Search prompt
+        public static let searchPrompt = L10n.tr("Contacts", "contacts.discovery.searchPrompt", fallback: "Search discovered")
+        /// Location: DiscoveryView.swift - Purpose: Sort menu accessibility label
+        public static let sortMenu = L10n.tr("Contacts", "contacts.discovery.sortMenu", fallback: "Sort options")
+        /// Location: DiscoveryView.swift - Purpose: Sort menu accessibility hint
+        public static let sortMenuHint = L10n.tr("Contacts", "contacts.discovery.sortMenuHint", fallback: "Choose how to sort discovered nodes")
         /// Location: DiscoveryView.swift - Purpose: Navigation title
         public static let title = L10n.tr("Contacts", "contacts.discovery.title", fallback: "Discover")
+        public enum Clear {
+          /// Location: DiscoveryView.swift - Purpose: Clear confirmation button
+          public static let confirm = L10n.tr("Contacts", "contacts.discovery.clear.confirm", fallback: "Clear")
+          /// Location: DiscoveryView.swift - Purpose: Clear confirmation message
+          public static let message = L10n.tr("Contacts", "contacts.discovery.clear.message", fallback: "Discovered nodes will be removed from this list but can be rediscovered on the mesh network.")
+          /// Location: DiscoveryView.swift - Purpose: Clear confirmation title
+          public static let title = L10n.tr("Contacts", "contacts.discovery.clear.title", fallback: "Clear all discovered nodes?")
+        }
         public enum Empty {
           /// Location: DiscoveryView.swift - Purpose: Empty state description
           public static let description = L10n.tr("Contacts", "contacts.discovery.empty.description", fallback: "When Auto-Add Nodes is disabled, newly discovered nodes will appear here for you to add manually.")
           /// Location: DiscoveryView.swift - Purpose: Empty state title
           public static let title = L10n.tr("Contacts", "contacts.discovery.empty.title", fallback: "No Discovered Nodes")
+          public enum Search {
+            /// Location: DiscoveryView.swift - Purpose: Search empty state description
+            public static func description(_ p1: Any) -> String {
+              return L10n.tr("Contacts", "contacts.discovery.empty.search.description", String(describing: p1), fallback: "No discovered nodes match '%@'")
+            }
+            /// Location: DiscoveryView.swift - Purpose: Search empty state title
+            public static let title = L10n.tr("Contacts", "contacts.discovery.empty.search.title", fallback: "No Results")
+          }
         }
         public enum Error {
           /// Location: DiscoveryView.swift - Purpose: Services not available error
           public static let servicesUnavailable = L10n.tr("Contacts", "contacts.discovery.error.servicesUnavailable", fallback: "Services not available")
+        }
+        public enum Segment {
+          /// Location: DiscoveryView.swift - Purpose: Segment filter: All
+          public static let all = L10n.tr("Contacts", "contacts.discovery.segment.all", fallback: "All")
+          /// Location: DiscoveryView.swift - Purpose: Segment filter: Contacts
+          public static let contacts = L10n.tr("Contacts", "contacts.discovery.segment.contacts", fallback: "Contacts")
+          /// Location: DiscoveryView.swift - Purpose: Segment filter: Network
+          public static let network = L10n.tr("Contacts", "contacts.discovery.segment.network", fallback: "Network")
         }
       }
       public enum List {

--- a/PocketMesh/Resources/Localization/de.lproj/Contacts.strings
+++ b/PocketMesh/Resources/Localization/de.lproj/Contacts.strings
@@ -465,6 +465,54 @@
 /* Location: DiscoveryView.swift - Purpose: Services not available error */
 "contacts.discovery.error.servicesUnavailable" = "Dienste nicht verfügbar";
 
+/* Location: DiscoveryView.swift - Purpose: Segment filter - All */
+"contacts.discovery.segment.all" = "Alle";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter - Contacts */
+"contacts.discovery.segment.contacts" = "Kontakte";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter - Network */
+"contacts.discovery.segment.network" = "Netzwerk";
+
+/* Location: DiscoveryView.swift - Purpose: Search field placeholder */
+"contacts.discovery.searchPrompt" = "Entdeckte suchen";
+
+/* Location: DiscoveryView.swift - Purpose: More menu label */
+"contacts.discovery.menu" = "Mehr";
+
+/* Location: DiscoveryView.swift - Purpose: Clear all menu item */
+"contacts.discovery.clear" = "Alle löschen";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation title */
+"contacts.discovery.clear.title" = "Alle entdeckten Knoten löschen?";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation message */
+"contacts.discovery.clear.message" = "Entdeckte Knoten werden aus dieser Liste entfernt, können aber im Mesh-Netzwerk erneut entdeckt werden.";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation button */
+"contacts.discovery.clear.confirm" = "Löschen";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement when searching */
+"contacts.discovery.searchingAllTypes" = "Suche alle Typen";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility label */
+"contacts.discovery.sortMenu" = "Sortieroptionen";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility hint */
+"contacts.discovery.sortMenuHint" = "Wählen Sie die Sortierung für entdeckte Knoten";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement after clearing */
+"contacts.discovery.clearedAllNodes" = "Alle entdeckten Knoten gelöscht";
+
+/* Location: DiscoveryView.swift - Purpose: Swipe action to remove discovered node */
+"contacts.discovery.remove" = "Entfernen";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state title */
+"contacts.discovery.empty.search.title" = "Keine Ergebnisse";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state description */
+"contacts.discovery.empty.search.description" = "Keine entdeckten Knoten entsprechen '%@'";
+
 // MARK: - Path Editing Sheet
 
 /* Location: PathEditingSheet.swift - Purpose: Navigation title */

--- a/PocketMesh/Resources/Localization/en.lproj/Contacts.strings
+++ b/PocketMesh/Resources/Localization/en.lproj/Contacts.strings
@@ -396,8 +396,11 @@
 /* Location: AddContactSheet.swift - Purpose: Invalid public key size error */
 "contacts.add.error.invalidSize" = "Public key must be %d bytes (%d hex characters)";
 
-/* Location: AddContactSheet.swift - Purpose: Node list full error */
+/* Location: AddContactSheet.swift, DiscoveryView.swift - Purpose: Node list full error with max count */
 "contacts.add.error.nodeListFull" = "Node list is full (max %d nodes)";
+
+/* Location: AddContactSheet.swift, DiscoveryView.swift - Purpose: Node list full error without max count */
+"contacts.add.error.nodeListFullSimple" = "Node list is full";
 
 // MARK: - Contact QR Share Sheet
 
@@ -464,6 +467,54 @@
 
 /* Location: DiscoveryView.swift - Purpose: Services not available error */
 "contacts.discovery.error.servicesUnavailable" = "Services not available";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter: All */
+"contacts.discovery.segment.all" = "All";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter: Contacts */
+"contacts.discovery.segment.contacts" = "Contacts";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter: Network */
+"contacts.discovery.segment.network" = "Network";
+
+/* Location: DiscoveryView.swift - Purpose: Search prompt */
+"contacts.discovery.searchPrompt" = "Search discovered";
+
+/* Location: DiscoveryView.swift - Purpose: More menu accessibility label */
+"contacts.discovery.menu" = "More";
+
+/* Location: DiscoveryView.swift - Purpose: Clear all menu item */
+"contacts.discovery.clear" = "Clear All";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation title */
+"contacts.discovery.clear.title" = "Clear all discovered nodes?";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation message */
+"contacts.discovery.clear.message" = "Discovered nodes will be removed from this list but can be rediscovered on the mesh network.";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation button */
+"contacts.discovery.clear.confirm" = "Clear";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement when searching */
+"contacts.discovery.searchingAllTypes" = "Searching all types";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility label */
+"contacts.discovery.sortMenu" = "Sort options";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility hint */
+"contacts.discovery.sortMenuHint" = "Choose how to sort discovered nodes";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement after clearing */
+"contacts.discovery.clearedAllNodes" = "All discovered nodes cleared";
+
+/* Location: DiscoveryView.swift - Purpose: Swipe action to remove discovered node */
+"contacts.discovery.remove" = "Remove";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state title */
+"contacts.discovery.empty.search.title" = "No Results";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state description */
+"contacts.discovery.empty.search.description" = "No discovered nodes match '%@'";
 
 // MARK: - Path Editing Sheet
 

--- a/PocketMesh/Resources/Localization/es.lproj/Contacts.strings
+++ b/PocketMesh/Resources/Localization/es.lproj/Contacts.strings
@@ -465,6 +465,54 @@
 /* Location: DiscoveryView.swift - Purpose: Services not available error */
 "contacts.discovery.error.servicesUnavailable" = "Servicios no disponibles";
 
+/* Location: DiscoveryView.swift - Purpose: Segment filter - All */
+"contacts.discovery.segment.all" = "Todos";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter - Contacts */
+"contacts.discovery.segment.contacts" = "Contactos";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter - Network */
+"contacts.discovery.segment.network" = "Red";
+
+/* Location: DiscoveryView.swift - Purpose: Search field placeholder */
+"contacts.discovery.searchPrompt" = "Buscar descubiertos";
+
+/* Location: DiscoveryView.swift - Purpose: More menu label */
+"contacts.discovery.menu" = "Más";
+
+/* Location: DiscoveryView.swift - Purpose: Clear all menu item */
+"contacts.discovery.clear" = "Borrar todo";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation title */
+"contacts.discovery.clear.title" = "¿Borrar todos los nodos descubiertos?";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation message */
+"contacts.discovery.clear.message" = "Los nodos descubiertos se eliminarán de esta lista pero pueden volver a descubrirse en la red mesh.";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation button */
+"contacts.discovery.clear.confirm" = "Borrar";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement when searching */
+"contacts.discovery.searchingAllTypes" = "Buscando todos los tipos";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility label */
+"contacts.discovery.sortMenu" = "Opciones de orden";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility hint */
+"contacts.discovery.sortMenuHint" = "Elegir cómo ordenar los nodos descubiertos";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement after clearing */
+"contacts.discovery.clearedAllNodes" = "Todos los nodos descubiertos borrados";
+
+/* Location: DiscoveryView.swift - Purpose: Swipe action to remove discovered node */
+"contacts.discovery.remove" = "Eliminar";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state title */
+"contacts.discovery.empty.search.title" = "Sin resultados";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state description */
+"contacts.discovery.empty.search.description" = "Ningún nodo descubierto coincide con '%@'";
+
 // MARK: - Path Editing Sheet
 
 /* Location: PathEditingSheet.swift - Purpose: Navigation title */

--- a/PocketMesh/Resources/Localization/fr.lproj/Contacts.strings
+++ b/PocketMesh/Resources/Localization/fr.lproj/Contacts.strings
@@ -465,6 +465,54 @@
 /* Location: DiscoveryView.swift - Purpose: Services not available error */
 "contacts.discovery.error.servicesUnavailable" = "Services non disponibles";
 
+/* Location: DiscoveryView.swift - Purpose: Segment filter - All */
+"contacts.discovery.segment.all" = "Tous";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter - Contacts */
+"contacts.discovery.segment.contacts" = "Contacts";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter - Network */
+"contacts.discovery.segment.network" = "Réseau";
+
+/* Location: DiscoveryView.swift - Purpose: Search field placeholder */
+"contacts.discovery.searchPrompt" = "Rechercher découverts";
+
+/* Location: DiscoveryView.swift - Purpose: More menu label */
+"contacts.discovery.menu" = "Plus";
+
+/* Location: DiscoveryView.swift - Purpose: Clear all menu item */
+"contacts.discovery.clear" = "Tout effacer";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation title */
+"contacts.discovery.clear.title" = "Effacer tous les nœuds découverts ?";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation message */
+"contacts.discovery.clear.message" = "Les nœuds découverts seront supprimés de cette liste mais pourront être redécouverts sur le réseau mesh.";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation button */
+"contacts.discovery.clear.confirm" = "Effacer";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement when searching */
+"contacts.discovery.searchingAllTypes" = "Recherche de tous les types";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility label */
+"contacts.discovery.sortMenu" = "Options de tri";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility hint */
+"contacts.discovery.sortMenuHint" = "Choisir comment trier les nœuds découverts";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement after clearing */
+"contacts.discovery.clearedAllNodes" = "Tous les nœuds découverts effacés";
+
+/* Location: DiscoveryView.swift - Purpose: Swipe action to remove discovered node */
+"contacts.discovery.remove" = "Supprimer";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state title */
+"contacts.discovery.empty.search.title" = "Aucun résultat";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state description */
+"contacts.discovery.empty.search.description" = "Aucun nœud découvert ne correspond à '%@'";
+
 // MARK: - Path Editing Sheet
 
 /* Location: PathEditingSheet.swift - Purpose: Navigation title */

--- a/PocketMesh/Resources/Localization/nl.lproj/Contacts.strings
+++ b/PocketMesh/Resources/Localization/nl.lproj/Contacts.strings
@@ -465,6 +465,54 @@
 /* Location: DiscoveryView.swift - Purpose: Services not available error */
 "contacts.discovery.error.servicesUnavailable" = "Services niet beschikbaar";
 
+/* Location: DiscoveryView.swift - Purpose: Segment filter - All */
+"contacts.discovery.segment.all" = "Alle";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter - Contacts */
+"contacts.discovery.segment.contacts" = "Contacten";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter - Network */
+"contacts.discovery.segment.network" = "Netwerk";
+
+/* Location: DiscoveryView.swift - Purpose: Search field placeholder */
+"contacts.discovery.searchPrompt" = "Zoek ontdekte";
+
+/* Location: DiscoveryView.swift - Purpose: More menu label */
+"contacts.discovery.menu" = "Meer";
+
+/* Location: DiscoveryView.swift - Purpose: Clear all menu item */
+"contacts.discovery.clear" = "Alles wissen";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation title */
+"contacts.discovery.clear.title" = "Alle ontdekte knooppunten wissen?";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation message */
+"contacts.discovery.clear.message" = "Ontdekte knooppunten worden uit deze lijst verwijderd maar kunnen opnieuw worden ontdekt op het mesh-netwerk.";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation button */
+"contacts.discovery.clear.confirm" = "Wissen";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement when searching */
+"contacts.discovery.searchingAllTypes" = "Alle typen doorzoeken";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility label */
+"contacts.discovery.sortMenu" = "Sorteeropties";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility hint */
+"contacts.discovery.sortMenuHint" = "Kies hoe ontdekte knooppunten worden gesorteerd";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement after clearing */
+"contacts.discovery.clearedAllNodes" = "Alle ontdekte knooppunten gewist";
+
+/* Location: DiscoveryView.swift - Purpose: Swipe action to remove discovered node */
+"contacts.discovery.remove" = "Verwijderen";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state title */
+"contacts.discovery.empty.search.title" = "Geen resultaten";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state description */
+"contacts.discovery.empty.search.description" = "Geen ontdekte knooppunten komen overeen met '%@'";
+
 // MARK: - Path Editing Sheet
 
 /* Location: PathEditingSheet.swift - Purpose: Navigation title */

--- a/PocketMesh/Resources/Localization/pl.lproj/Contacts.strings
+++ b/PocketMesh/Resources/Localization/pl.lproj/Contacts.strings
@@ -465,6 +465,54 @@
 /* Location: DiscoveryView.swift - Purpose: Services not available error */
 "contacts.discovery.error.servicesUnavailable" = "Usługi niedostępne";
 
+/* Location: DiscoveryView.swift - Purpose: Segment filter - All */
+"contacts.discovery.segment.all" = "Wszystkie";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter - Contacts */
+"contacts.discovery.segment.contacts" = "Kontakty";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter - Network */
+"contacts.discovery.segment.network" = "Sieć";
+
+/* Location: DiscoveryView.swift - Purpose: Search field placeholder */
+"contacts.discovery.searchPrompt" = "Szukaj odkrytych";
+
+/* Location: DiscoveryView.swift - Purpose: More menu label */
+"contacts.discovery.menu" = "Więcej";
+
+/* Location: DiscoveryView.swift - Purpose: Clear all menu item */
+"contacts.discovery.clear" = "Wyczyść wszystko";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation title */
+"contacts.discovery.clear.title" = "Wyczyścić wszystkie odkryte węzły?";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation message */
+"contacts.discovery.clear.message" = "Odkryte węzły zostaną usunięte z tej listy, ale mogą zostać ponownie odkryte w sieci mesh.";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation button */
+"contacts.discovery.clear.confirm" = "Wyczyść";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement when searching */
+"contacts.discovery.searchingAllTypes" = "Wyszukiwanie wszystkich typów";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility label */
+"contacts.discovery.sortMenu" = "Opcje sortowania";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility hint */
+"contacts.discovery.sortMenuHint" = "Wybierz sposób sortowania odkrytych węzłów";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement after clearing */
+"contacts.discovery.clearedAllNodes" = "Wszystkie odkryte węzły wyczyszczone";
+
+/* Location: DiscoveryView.swift - Purpose: Swipe action to remove discovered node */
+"contacts.discovery.remove" = "Usuń";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state title */
+"contacts.discovery.empty.search.title" = "Brak wyników";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state description */
+"contacts.discovery.empty.search.description" = "Żaden odkryty węzeł nie pasuje do '%@'";
+
 // MARK: - Path Editing Sheet
 
 /* Location: PathEditingSheet.swift - Purpose: Navigation title */

--- a/PocketMesh/Resources/Localization/ru.lproj/Contacts.strings
+++ b/PocketMesh/Resources/Localization/ru.lproj/Contacts.strings
@@ -465,6 +465,54 @@
 /* Location: DiscoveryView.swift - Purpose: Services not available error */
 "contacts.discovery.error.servicesUnavailable" = "Сервисы недоступны";
 
+/* Location: DiscoveryView.swift - Purpose: Segment filter - All */
+"contacts.discovery.segment.all" = "Все";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter - Contacts */
+"contacts.discovery.segment.contacts" = "Контакты";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter - Network */
+"contacts.discovery.segment.network" = "Сеть";
+
+/* Location: DiscoveryView.swift - Purpose: Search field placeholder */
+"contacts.discovery.searchPrompt" = "Поиск обнаруженных";
+
+/* Location: DiscoveryView.swift - Purpose: More menu label */
+"contacts.discovery.menu" = "Ещё";
+
+/* Location: DiscoveryView.swift - Purpose: Clear all menu item */
+"contacts.discovery.clear" = "Очистить всё";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation title */
+"contacts.discovery.clear.title" = "Очистить все обнаруженные узлы?";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation message */
+"contacts.discovery.clear.message" = "Обнаруженные узлы будут удалены из этого списка, но могут быть обнаружены снова в mesh-сети.";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation button */
+"contacts.discovery.clear.confirm" = "Очистить";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement when searching */
+"contacts.discovery.searchingAllTypes" = "Поиск всех типов";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility label */
+"contacts.discovery.sortMenu" = "Параметры сортировки";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility hint */
+"contacts.discovery.sortMenuHint" = "Выберите способ сортировки обнаруженных узлов";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement after clearing */
+"contacts.discovery.clearedAllNodes" = "Все обнаруженные узлы очищены";
+
+/* Location: DiscoveryView.swift - Purpose: Swipe action to remove discovered node */
+"contacts.discovery.remove" = "Удалить";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state title */
+"contacts.discovery.empty.search.title" = "Нет результатов";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state description */
+"contacts.discovery.empty.search.description" = "Ни один обнаруженный узел не соответствует '%@'";
+
 // MARK: - Path Editing Sheet
 
 /* Location: PathEditingSheet.swift - Purpose: Navigation title */

--- a/PocketMesh/Resources/Localization/uk.lproj/Contacts.strings
+++ b/PocketMesh/Resources/Localization/uk.lproj/Contacts.strings
@@ -465,6 +465,54 @@
 /* Location: DiscoveryView.swift - Purpose: Services not available error */
 "contacts.discovery.error.servicesUnavailable" = "Сервіси недоступні";
 
+/* Location: DiscoveryView.swift - Purpose: Segment filter - All */
+"contacts.discovery.segment.all" = "Усі";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter - Contacts */
+"contacts.discovery.segment.contacts" = "Контакти";
+
+/* Location: DiscoveryView.swift - Purpose: Segment filter - Network */
+"contacts.discovery.segment.network" = "Мережа";
+
+/* Location: DiscoveryView.swift - Purpose: Search field placeholder */
+"contacts.discovery.searchPrompt" = "Шукати виявлені";
+
+/* Location: DiscoveryView.swift - Purpose: More menu label */
+"contacts.discovery.menu" = "Більше";
+
+/* Location: DiscoveryView.swift - Purpose: Clear all menu item */
+"contacts.discovery.clear" = "Очистити все";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation title */
+"contacts.discovery.clear.title" = "Очистити всі виявлені вузли?";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation message */
+"contacts.discovery.clear.message" = "Виявлені вузли будуть видалені з цього списку, але можуть бути виявлені знову в mesh-мережі.";
+
+/* Location: DiscoveryView.swift - Purpose: Clear confirmation button */
+"contacts.discovery.clear.confirm" = "Очистити";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement when searching */
+"contacts.discovery.searchingAllTypes" = "Пошук усіх типів";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility label */
+"contacts.discovery.sortMenu" = "Параметри сортування";
+
+/* Location: DiscoveryView.swift - Purpose: Sort menu accessibility hint */
+"contacts.discovery.sortMenuHint" = "Виберіть спосіб сортування виявлених вузлів";
+
+/* Location: DiscoveryView.swift - Purpose: VoiceOver announcement after clearing */
+"contacts.discovery.clearedAllNodes" = "Усі виявлені вузли очищено";
+
+/* Location: DiscoveryView.swift - Purpose: Swipe action to remove discovered node */
+"contacts.discovery.remove" = "Видалити";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state title */
+"contacts.discovery.empty.search.title" = "Немає результатів";
+
+/* Location: DiscoveryView.swift - Purpose: Search empty state description */
+"contacts.discovery.empty.search.description" = "Жоден виявлений вузол не відповідає '%@'";
+
 // MARK: - Path Editing Sheet
 
 /* Location: PathEditingSheet.swift - Purpose: Navigation title */

--- a/PocketMesh/Views/Contacts/DiscoveryViewModel.swift
+++ b/PocketMesh/Views/Contacts/DiscoveryViewModel.swift
@@ -1,0 +1,166 @@
+import CoreLocation
+import SwiftUI
+import PocketMeshServices
+
+/// Segment for the discovery picker
+enum DiscoverSegment: String, CaseIterable {
+    case all
+    case contacts
+    case network
+
+    var localizedTitle: String {
+        switch self {
+        case .all: L10n.Contacts.Contacts.Discovery.Segment.all
+        case .contacts: L10n.Contacts.Contacts.Discovery.Segment.contacts
+        case .network: L10n.Contacts.Contacts.Discovery.Segment.network
+        }
+    }
+}
+
+/// ViewModel for discovery view
+@Observable
+@MainActor
+final class DiscoveryViewModel {
+
+    // MARK: - Properties
+
+    /// Discovered contacts from the mesh network
+    var discoveredContacts: [ContactDTO] = []
+
+    /// Loading state
+    var isLoading = false
+
+    /// Whether data has been loaded at least once (prevents empty state flash)
+    var hasLoadedOnce = false
+
+    /// Error message to display
+    var errorMessage: String?
+
+    // MARK: - Dependencies
+
+    private var dataStore: DataStore?
+
+    // MARK: - Initialization
+
+    init() {}
+
+    /// Configure with services from AppState
+    func configure(appState: AppState) {
+        self.dataStore = appState.offlineDataStore
+    }
+
+    /// Configure with services (for testing)
+    func configure(dataStore: DataStore) {
+        self.dataStore = dataStore
+    }
+
+    // MARK: - Load Contacts
+
+    func loadDiscoveredContacts(deviceID: UUID) async {
+        guard let dataStore else { return }
+
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            discoveredContacts = try await dataStore.fetchDiscoveredContacts(deviceID: deviceID)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        hasLoadedOnce = true
+        isLoading = false
+    }
+
+    // MARK: - Delete
+
+    func deleteDiscoveredContact(_ contact: ContactDTO) async {
+        guard let dataStore else { return }
+
+        // Remove from UI immediately
+        discoveredContacts.removeAll { $0.id == contact.id }
+
+        do {
+            try await dataStore.deleteContact(id: contact.id)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func clearAllDiscoveredContacts(deviceID: UUID) async {
+        guard let dataStore else { return }
+
+        do {
+            try await dataStore.clearDiscoveredContacts(deviceID: deviceID)
+            discoveredContacts = []
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Filtering
+
+    func filteredContacts(
+        searchText: String,
+        segment: DiscoverSegment,
+        sortOrder: NodeSortOrder,
+        userLocation: CLLocation?
+    ) -> [ContactDTO] {
+        var result = discoveredContacts
+
+        if searchText.isEmpty {
+            switch segment {
+            case .all:
+                break
+            case .contacts:
+                result = result.filter { $0.type == .chat }
+            case .network:
+                result = result.filter { $0.type == .repeater || $0.type == .room }
+            }
+        } else {
+            result = result.filter { contact in
+                contact.displayName.localizedStandardContains(searchText)
+            }
+        }
+
+        return sorted(result, by: sortOrder, userLocation: userLocation)
+    }
+
+    // MARK: - Sorting
+
+    private func sorted(
+        _ contacts: [ContactDTO],
+        by order: NodeSortOrder,
+        userLocation: CLLocation?
+    ) -> [ContactDTO] {
+        switch order {
+        case .lastHeard:
+            return contacts.sorted { $0.lastAdvertTimestamp > $1.lastAdvertTimestamp }
+        case .name:
+            return contacts.sorted {
+                $0.displayName.localizedCompare($1.displayName) == .orderedAscending
+            }
+        case .distance:
+            guard let userLocation else {
+                return sorted(contacts, by: .name, userLocation: nil)
+            }
+            return contacts.sorted { lhs, rhs in
+                let lhsHasLocation = lhs.hasLocation
+                let rhsHasLocation = rhs.hasLocation
+
+                if lhsHasLocation != rhsHasLocation {
+                    return lhsHasLocation
+                }
+
+                guard lhsHasLocation && rhsHasLocation else {
+                    return lhs.displayName.localizedCompare(rhs.displayName) == .orderedAscending
+                }
+
+                let lhsLocation = CLLocation(latitude: lhs.latitude, longitude: lhs.longitude)
+                let rhsLocation = CLLocation(latitude: rhs.latitude, longitude: rhs.longitude)
+
+                return lhsLocation.distance(from: userLocation) < rhsLocation.distance(from: userLocation)
+            }
+        }
+    }
+}

--- a/PocketMeshServices/Sources/PocketMeshServices/Protocols/PersistenceStoreProtocol.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Protocols/PersistenceStoreProtocol.swift
@@ -147,6 +147,9 @@ public protocol PersistenceStoreProtocol: Actor {
     /// Mark a discovered contact as confirmed
     func confirmContact(id: UUID) async throws
 
+    /// Clear all discovered (unadded) contacts for a device
+    func clearDiscoveredContacts(deviceID: UUID) async throws
+
     // MARK: - Channel Operations
 
     /// Fetch all channels for a device

--- a/PocketMeshServices/Sources/PocketMeshServices/Services/PersistenceStore.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Services/PersistenceStore.swift
@@ -503,6 +503,19 @@ public actor PersistenceStore: PersistenceStoreProtocol {
         }
     }
 
+    /// Clear all discovered (unadded) contacts for a device
+    public func clearDiscoveredContacts(deviceID: UUID) throws {
+        let targetDeviceID = deviceID
+        let predicate = #Predicate<Contact> { contact in
+            contact.deviceID == targetDeviceID && contact.isDiscovered == true
+        }
+        let contacts = try modelContext.fetch(FetchDescriptor(predicate: predicate))
+        for contact in contacts {
+            modelContext.delete(contact)
+        }
+        try modelContext.save()
+    }
+
     /// Update contact's last message info (nil clears the date, removing from conversations list)
     public func updateContactLastMessage(contactID: UUID, date: Date?) throws {
         let targetID = contactID

--- a/PocketMeshServices/Tests/PocketMeshServicesTests/Mocks/MockPersistenceStore.swift
+++ b/PocketMeshServices/Tests/PocketMeshServicesTests/Mocks/MockPersistenceStore.swift
@@ -699,6 +699,18 @@ public actor MockPersistenceStore: PersistenceStoreProtocol {
         }
     }
 
+    public func clearDiscoveredContacts(deviceID: UUID) async throws {
+        if let error = stubbedDeleteContactError {
+            throw error
+        }
+        let keysToRemove = contacts.values
+            .filter { $0.deviceID == deviceID && $0.isDiscovered }
+            .map(\.id)
+        for key in keysToRemove {
+            contacts.removeValue(forKey: key)
+        }
+    }
+
     // MARK: - Channel Operations
 
     public func fetchChannels(deviceID: UUID) async throws -> [ChannelDTO] {


### PR DESCRIPTION
## Summary

Enhance DiscoverView with the following capabilities:

- **Segment filter** (All/Contacts/Network) to filter by contact type
- **Search field** with locale-aware filtering by display name (always visible)
- **Sort menu** (Last Heard/Name/Distance) with AppStorage persistence
- **Clear All** button in triple-dot menu with confirmation dialog
- **Swipe to remove** individual discovered nodes
- **Timestamp display** showing when each node was last heard
- **Location display** with distance when available
- Dedicated `DiscoveryViewModel` with centralized state management
- VoiceOver accessibility announcements for key actions
- GlassButtonModifier for iOS 26 Liquid Glass styling
- Search empty state with localized "No Results" message
- Full localization for all 8 supported languages

Also adds `clearDiscoveredContacts` method to PersistenceStore for safely removing discovered (unadded) contacts from the database.

## Test plan

- [x] Verify segment picker filters correctly (All shows everything, Contacts shows chat types, Network shows repeaters/rooms)
- [x] Verify search filters by display name across all segments
- [ ] Verify sort options persist and work correctly
- [x] Verify Clear All shows confirmation and removes all discovered nodes
- [x] Verify swipe-to-remove works on individual nodes
- [x] Verify timestamp and location info display correctly
- [x] Verify empty states show appropriately
- [ ] Test VoiceOver announcements

Fixes #165 