### PR TITLE
feat: remove non-favorite nodes from danger zone

### DIFF
--- a/PocketMesh/Resources/Generated/L10n.swift
+++ b/PocketMesh/Resources/Generated/L10n.swift
@@ -2860,6 +2860,8 @@ public enum L10n {
       public static let forgetDevice = L10n.tr("Settings", "dangerZone.forgetDevice", fallback: "Forget Device")
       /// Section header for danger zone
       public static let header = L10n.tr("Settings", "dangerZone.header", fallback: "Danger Zone")
+      /// Label shown after successful removal
+      public static let removed = L10n.tr("Settings", "dangerZone.removed", fallback: "Nodes Removed")
       /// Button to remove non-favorite nodes
       public static let removeUnfavorited = L10n.tr("Settings", "dangerZone.removeUnfavorited", fallback: "Remove Non-Favorite Nodes")
       /// Text shown while removing unfavorited nodes
@@ -2886,8 +2888,10 @@ public enum L10n {
           public static let noneFound = L10n.tr("Settings", "dangerZone.alert.removeUnfavorited.noneFound", fallback: "No non-favorite nodes to remove.")
           /// Partial success message (%d = removed, %d = total)
           public static func partial(_ p1: Int, _ p2: Int) -> String {
-            return L10n.tr("Settings", "dangerZone.alert.removeUnfavorited.partial", p1, p2, fallback: "Removed %d of %d nodes. The connection was interrupted — the remaining nodes will be removed on the next attempt.")
+            return L10n.tr("Settings", "dangerZone.alert.removeUnfavorited.partial", p1, p2, fallback: "Removed %d of %d nodes. The connection was interrupted — tap the button again to retry removing the remaining nodes.")
           }
+          /// Alert title for removal result
+          public static let resultTitle = L10n.tr("Settings", "dangerZone.alert.removeUnfavorited.resultTitle", fallback: "Removal Result")
           /// Alert title for remove non-favorite confirmation
           public static let title = L10n.tr("Settings", "dangerZone.alert.removeUnfavorited.title", fallback: "Remove Non-Favorite Nodes")
         }

--- a/PocketMesh/Resources/Localization/de.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/de.lproj/Settings.strings
@@ -507,17 +507,23 @@
 /* Text shown while removing unfavorited nodes */
 "dangerZone.removing" = "Wird entfernt …";
 
+/* Label shown after successful removal */
+"dangerZone.removed" = "Knoten entfernt";
+
 /* Alert title for remove non-favorite confirmation */
 "dangerZone.alert.removeUnfavorited.title" = "Nicht-favorisierte Knoten entfernen";
 
 /* Button to confirm removal */
 "dangerZone.alert.removeUnfavorited.confirm" = "Knoten entfernen";
 
+/* Alert title for removal result */
+"dangerZone.alert.removeUnfavorited.resultTitle" = "Ergebnis der Entfernung";
+
 /* Alert message for remove unfavorited (%d = count) */
 "dangerZone.alert.removeUnfavorited.message" = "Dadurch werden %d nicht als Favorit markierte Knoten dauerhaft vom Gerät und der App gelöscht, einschließlich ihrer Nachrichten.";
 
 /* Partial success message (%d = removed, %d = total) */
-"dangerZone.alert.removeUnfavorited.partial" = "%d von %d Knoten entfernt. Die Verbindung wurde unterbrochen – die verbleibenden Knoten werden beim nächsten Versuch entfernt.";
+"dangerZone.alert.removeUnfavorited.partial" = "%d von %d Knoten entfernt. Die Verbindung wurde unterbrochen – tippen Sie erneut auf die Schaltfläche, um die verbleibenden Knoten zu entfernen.";
 
 /* Message when no non-favorite nodes to remove */
 "dangerZone.alert.removeUnfavorited.noneFound" = "Keine nicht-favorisierten Knoten zum Entfernen vorhanden.";

--- a/PocketMesh/Resources/Localization/en.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/en.lproj/Settings.strings
@@ -507,17 +507,23 @@
 /* Text shown while removing unfavorited nodes */
 "dangerZone.removing" = "Removing...";
 
+/* Label shown after successful removal */
+"dangerZone.removed" = "Nodes Removed";
+
 /* Alert title for remove non-favorite confirmation */
 "dangerZone.alert.removeUnfavorited.title" = "Remove Non-Favorite Nodes";
 
 /* Button to confirm removal */
 "dangerZone.alert.removeUnfavorited.confirm" = "Remove Nodes";
 
+/* Alert title for removal result */
+"dangerZone.alert.removeUnfavorited.resultTitle" = "Removal Result";
+
 /* Alert message for remove unfavorited (%d = count) */
 "dangerZone.alert.removeUnfavorited.message" = "This will permanently delete %d nodes not marked as favorite from the device and the app, along with their messages.";
 
 /* Partial success message (%d = removed, %d = total) */
-"dangerZone.alert.removeUnfavorited.partial" = "Removed %d of %d nodes. The connection was interrupted — the remaining nodes will be removed on the next attempt.";
+"dangerZone.alert.removeUnfavorited.partial" = "Removed %d of %d nodes. The connection was interrupted — tap the button again to retry removing the remaining nodes.";
 
 /* Message when no non-favorite nodes to remove */
 "dangerZone.alert.removeUnfavorited.noneFound" = "No non-favorite nodes to remove.";

--- a/PocketMesh/Resources/Localization/es.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/es.lproj/Settings.strings
@@ -507,17 +507,23 @@
 /* Text shown while removing unfavorited nodes */
 "dangerZone.removing" = "Eliminando…";
 
+/* Label shown after successful removal */
+"dangerZone.removed" = "Nodos eliminados";
+
 /* Alert title for remove non-favorite confirmation */
 "dangerZone.alert.removeUnfavorited.title" = "Eliminar nodos no favoritos";
 
 /* Button to confirm removal */
 "dangerZone.alert.removeUnfavorited.confirm" = "Eliminar nodos";
 
+/* Alert title for removal result */
+"dangerZone.alert.removeUnfavorited.resultTitle" = "Resultado de la eliminación";
+
 /* Alert message for remove unfavorited (%d = count) */
 "dangerZone.alert.removeUnfavorited.message" = "Esto eliminará permanentemente %d nodos no marcados como favoritos del dispositivo y la app, junto con sus mensajes.";
 
 /* Partial success message (%d = removed, %d = total) */
-"dangerZone.alert.removeUnfavorited.partial" = "Se eliminaron %d de %d nodos. La conexión se interrumpió; los nodos restantes se eliminarán en el próximo intento.";
+"dangerZone.alert.removeUnfavorited.partial" = "Se eliminaron %d de %d nodos. La conexión se interrumpió; toca el botón de nuevo para reintentar la eliminación de los nodos restantes.";
 
 /* Message when no non-favorite nodes to remove */
 "dangerZone.alert.removeUnfavorited.noneFound" = "No hay nodos no favoritos para eliminar.";

--- a/PocketMesh/Resources/Localization/fr.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/fr.lproj/Settings.strings
@@ -507,17 +507,23 @@
 /* Text shown while removing unfavorited nodes */
 "dangerZone.removing" = "Suppression…";
 
+/* Label shown after successful removal */
+"dangerZone.removed" = "Nœuds supprimés";
+
 /* Alert title for remove non-favorite confirmation */
 "dangerZone.alert.removeUnfavorited.title" = "Supprimer les nœuds non favoris";
 
 /* Button to confirm removal */
 "dangerZone.alert.removeUnfavorited.confirm" = "Supprimer les nœuds";
 
+/* Alert title for removal result */
+"dangerZone.alert.removeUnfavorited.resultTitle" = "Résultat de la suppression";
+
 /* Alert message for remove unfavorited (%d = count) */
 "dangerZone.alert.removeUnfavorited.message" = "Cela supprimera définitivement %d nœuds non marqués comme favoris de l'appareil et de l'app, ainsi que leurs messages.";
 
 /* Partial success message (%d = removed, %d = total) */
-"dangerZone.alert.removeUnfavorited.partial" = "%d nœuds sur %d supprimés. La connexion a été interrompue — les nœuds restants seront supprimés lors de la prochaine tentative.";
+"dangerZone.alert.removeUnfavorited.partial" = "%d nœuds sur %d supprimés. La connexion a été interrompue — appuyez à nouveau sur le bouton pour réessayer la suppression des nœuds restants.";
 
 /* Message when no non-favorite nodes to remove */
 "dangerZone.alert.removeUnfavorited.noneFound" = "Aucun nœud non favori à supprimer.";

--- a/PocketMesh/Resources/Localization/nl.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/nl.lproj/Settings.strings
@@ -507,17 +507,23 @@
 /* Text shown while removing unfavorited nodes */
 "dangerZone.removing" = "Verwijderen…";
 
+/* Label shown after successful removal */
+"dangerZone.removed" = "Knooppunten verwijderd";
+
 /* Alert title for remove non-favorite confirmation */
 "dangerZone.alert.removeUnfavorited.title" = "Niet-favoriete knooppunten verwijderen";
 
 /* Button to confirm removal */
 "dangerZone.alert.removeUnfavorited.confirm" = "Knooppunten verwijderen";
 
+/* Alert title for removal result */
+"dangerZone.alert.removeUnfavorited.resultTitle" = "Verwijderresultaat";
+
 /* Alert message for remove unfavorited (%d = count) */
 "dangerZone.alert.removeUnfavorited.message" = "Dit verwijdert permanent %d knooppunten die niet als favoriet zijn gemarkeerd van het apparaat en de app, inclusief hun berichten.";
 
 /* Partial success message (%d = removed, %d = total) */
-"dangerZone.alert.removeUnfavorited.partial" = "%d van %d knooppunten verwijderd. De verbinding werd onderbroken — de overige knooppunten worden bij de volgende poging verwijderd.";
+"dangerZone.alert.removeUnfavorited.partial" = "%d van %d knooppunten verwijderd. De verbinding werd onderbroken — tik opnieuw op de knop om de overige knooppunten te verwijderen.";
 
 /* Message when no non-favorite nodes to remove */
 "dangerZone.alert.removeUnfavorited.noneFound" = "Geen niet-favoriete knooppunten om te verwijderen.";

--- a/PocketMesh/Resources/Localization/pl.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/pl.lproj/Settings.strings
@@ -507,17 +507,23 @@
 /* Text shown while removing unfavorited nodes */
 "dangerZone.removing" = "Usuwanie…";
 
+/* Label shown after successful removal */
+"dangerZone.removed" = "Węzły usunięte";
+
 /* Alert title for remove non-favorite confirmation */
 "dangerZone.alert.removeUnfavorited.title" = "Usuń niefaworyzowane węzły";
 
 /* Button to confirm removal */
 "dangerZone.alert.removeUnfavorited.confirm" = "Usuń węzły";
 
+/* Alert title for removal result */
+"dangerZone.alert.removeUnfavorited.resultTitle" = "Wynik usuwania";
+
 /* Alert message for remove unfavorited (%d = count) */
 "dangerZone.alert.removeUnfavorited.message" = "Spowoduje to trwałe usunięcie %d węzłów nieoznaczonych jako ulubione z urządzenia i aplikacji, wraz z ich wiadomościami.";
 
 /* Partial success message (%d = removed, %d = total) */
-"dangerZone.alert.removeUnfavorited.partial" = "Usunięto %d z %d węzłów. Połączenie zostało przerwane — pozostałe węzły zostaną usunięte przy następnej próbie.";
+"dangerZone.alert.removeUnfavorited.partial" = "Usunięto %d z %d węzłów. Połączenie zostało przerwane — naciśnij przycisk ponownie, aby usunąć pozostałe węzły.";
 
 /* Message when no non-favorite nodes to remove */
 "dangerZone.alert.removeUnfavorited.noneFound" = "Brak niefaworyzowanych węzłów do usunięcia.";

--- a/PocketMesh/Resources/Localization/ru.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/ru.lproj/Settings.strings
@@ -507,17 +507,23 @@
 /* Text shown while removing unfavorited nodes */
 "dangerZone.removing" = "Удаление…";
 
+/* Label shown after successful removal */
+"dangerZone.removed" = "Узлы удалены";
+
 /* Alert title for remove non-favorite confirmation */
 "dangerZone.alert.removeUnfavorited.title" = "Удалить неизбранные узлы";
 
 /* Button to confirm removal */
 "dangerZone.alert.removeUnfavorited.confirm" = "Удалить узлы";
 
+/* Alert title for removal result */
+"dangerZone.alert.removeUnfavorited.resultTitle" = "Результат удаления";
+
 /* Alert message for remove unfavorited (%d = count) */
 "dangerZone.alert.removeUnfavorited.message" = "Это безвозвратно удалит %d узлов, не отмеченных как избранные, с устройства и из приложения, а также их сообщения.";
 
 /* Partial success message (%d = removed, %d = total) */
-"dangerZone.alert.removeUnfavorited.partial" = "Удалено %d из %d узлов. Соединение было прервано — оставшиеся узлы будут удалены при следующей попытке.";
+"dangerZone.alert.removeUnfavorited.partial" = "Удалено %d из %d узлов. Соединение было прервано — нажмите кнопку ещё раз, чтобы удалить оставшиеся узлы.";
 
 /* Message when no non-favorite nodes to remove */
 "dangerZone.alert.removeUnfavorited.noneFound" = "Нет неизбранных узлов для удаления.";

--- a/PocketMesh/Resources/Localization/uk.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/uk.lproj/Settings.strings
@@ -507,17 +507,23 @@
 /* Text shown while removing unfavorited nodes */
 "dangerZone.removing" = "Видалення…";
 
+/* Label shown after successful removal */
+"dangerZone.removed" = "Вузли видалено";
+
 /* Alert title for remove non-favorite confirmation */
 "dangerZone.alert.removeUnfavorited.title" = "Видалити необрані вузли";
 
 /* Button to confirm removal */
 "dangerZone.alert.removeUnfavorited.confirm" = "Видалити вузли";
 
+/* Alert title for removal result */
+"dangerZone.alert.removeUnfavorited.resultTitle" = "Результат видалення";
+
 /* Alert message for remove unfavorited (%d = count) */
 "dangerZone.alert.removeUnfavorited.message" = "Це назавжди видалить %d вузлів, не позначених як обрані, з пристрою та додатка, разом з їхніми повідомленнями.";
 
 /* Partial success message (%d = removed, %d = total) */
-"dangerZone.alert.removeUnfavorited.partial" = "Видалено %d з %d вузлів. З'єднання було перервано — решта вузлів буде видалена при наступній спробі.";
+"dangerZone.alert.removeUnfavorited.partial" = "Видалено %d з %d вузлів. З'єднання було перервано — натисніть кнопку ще раз, щоб видалити решту вузлів.";
 
 /* Message when no non-favorite nodes to remove */
 "dangerZone.alert.removeUnfavorited.noneFound" = "Немає необраних вузлів для видалення.";

--- a/PocketMesh/Resources/Localization/zh-Hans.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/zh-Hans.lproj/Settings.strings
@@ -493,17 +493,23 @@
 /* Text shown while removing unfavorited nodes */
 "dangerZone.removing" = "正在移除…";
 
+/* Label shown after successful removal */
+"dangerZone.removed" = "节点已移除";
+
 /* Alert title for remove non-favorite confirmation */
 "dangerZone.alert.removeUnfavorited.title" = "移除非收藏节点";
 
 /* Button to confirm removal */
 "dangerZone.alert.removeUnfavorited.confirm" = "移除节点";
 
+/* Alert title for removal result */
+"dangerZone.alert.removeUnfavorited.resultTitle" = "移除结果";
+
 /* Alert message for remove unfavorited (%d = count) */
 "dangerZone.alert.removeUnfavorited.message" = "这将从设备和应用中永久删除 %d 个未标记为收藏的节点及其消息。";
 
 /* Partial success message (%d = removed, %d = total) */
-"dangerZone.alert.removeUnfavorited.partial" = "已移除 %d 个节点（共 %d 个）。连接已中断——剩余节点将在下次尝试时移除。";
+"dangerZone.alert.removeUnfavorited.partial" = "已移除 %d 个节点（共 %d 个）。连接已中断——请再次点击按钮以移除剩余节点。";
 
 /* Message when no non-favorite nodes to remove */
 "dangerZone.alert.removeUnfavorited.noneFound" = "没有可移除的非收藏节点。";

--- a/PocketMeshServices/Sources/PocketMeshServices/Services/ContactService.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Services/ContactService.swift
@@ -232,6 +232,16 @@ public actor ContactService {
         }
     }
 
+    /// Remove a contact's local data and run the full cleanup chain without contacting the device.
+    /// Use when the device reports the contact doesn't exist but local data remains.
+    public func removeLocalContact(contactID: UUID, publicKey: Data) async throws {
+        try await dataStore.deleteMessagesForContact(contactID: contactID)
+        try await dataStore.deleteContact(id: contactID)
+        await cleanupHandler?(contactID, .deleted, publicKey)
+        await nodeDeletedHandler?()
+        await syncCoordinator?.notifyContactsChanged()
+    }
+
     // MARK: - Reset Path
 
     /// Reset the path for a contact (force rediscovery)


### PR DESCRIPTION
## Summary
- Adds a "Remove Non-Favorite Nodes" button to the danger zone settings section
- Deletes all nodes not marked as favorite from the device and app, including their messages
- Handles partial removal gracefully when the connection is interrupted
- Includes translations for all 9 locales (en, de, es, fr, nl, pl, ru, uk, zh-Hans)

## Test plan
- [x] Verify the "Remove Non-Favorite Nodes" button appears in Settings > Danger Zone
- [x] Tap the button and confirm the alert shows the correct node count
- [x] Confirm removal works and non-favorite nodes are deleted
- [x] Verify favorited nodes are preserved
- [x] Test with no non-favorite nodes present (should show "none found" message)
- [x] Verify translations render correctly in non-English locales