### PR TITLE
fix(chats): rename "Private Message" placeholder to "Direct Message"

### DIFF
--- a/PocketMesh/Resources/Generated/L10n.swift
+++ b/PocketMesh/Resources/Generated/L10n.swift
@@ -345,7 +345,7 @@ public enum L10n {
         public static let typeFirst = L10n.tr("Chats", "chats.input.typeFirst", fallback: "Type a message first")
         public enum Placeholder {
           /// Location: ChatView.swift - Input bar placeholder for direct messages
-          public static let directMessage = L10n.tr("Chats", "chats.input.placeholder.directMessage", fallback: "Private Message")
+          public static let directMessage = L10n.tr("Chats", "chats.input.placeholder.directMessage", fallback: "Direct Message")
         }
       }
       public enum JoinFromMessage {

--- a/PocketMesh/Resources/Localization/en.lproj/Chats.strings
+++ b/PocketMesh/Resources/Localization/en.lproj/Chats.strings
@@ -170,7 +170,7 @@
 "chats.contactInfo.hasLocation" = "Has location";
 
 /* Location: ChatView.swift - Input bar placeholder for direct messages */
-"chats.input.placeholder.directMessage" = "Private Message";
+"chats.input.placeholder.directMessage" = "Direct Message";
 
 // MARK: - Channel Chat View
 


### PR DESCRIPTION
## Summary
- Changes the chat input placeholder text from "Private Message" to "Direct Message" to align with standard MeshCore ecosystem terminology

## Changes
- `Chats.strings`: Updated localization string `chats.input.placeholder.directMessage`
- `L10n.swift`: Regenerated via SwiftGen

## Test plan
- [x] Verified placeholder text displays "Direct Message" in the simulator on the direct message chat screen
- [x] `swiftlint lint` passes with no new warnings
- [x] SwiftGen regeneration successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)