### PR TITLE
feat(live-activity): add Lock Screen and Dynamic Island Live Activity

### DIFF
--- a/PocketMesh/Info-Debug.plist
+++ b/PocketMesh/Info-Debug.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAccessorySetupBluetoothNames</key>
@@ -80,6 +80,17 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>pocketmesh</string>
+			</array>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/PocketMesh/Info.plist
+++ b/PocketMesh/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAccessorySetupBluetoothNames</key>
@@ -83,5 +83,16 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>pocketmesh</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/PocketMesh/PocketMeshApp.swift
+++ b/PocketMesh/PocketMeshApp.swift
@@ -42,6 +42,10 @@ struct PocketMeshApp: App {
 
                     await runInitialForegroundReconciliationIfNeeded()
                 }
+                .onOpenURL { _ in
+                    // pocketmesh://status — tapped from Live Activity
+                    // Opening the app is sufficient; future: navigate based on url.host
+                }
                 .onChange(of: scenePhase) { oldPhase, newPhase in
                     handleScenePhaseChange(from: oldPhase, to: newPhase)
                 }

--- a/PocketMesh/Resources/Generated/L10n.swift
+++ b/PocketMesh/Resources/Generated/L10n.swift
@@ -3303,6 +3303,16 @@ public enum L10n {
       /// Toggle label for link previews
       public static let toggle = L10n.tr("Settings", "linkPreviews.toggle", fallback: "Link Previews")
     }
+    public enum LiveActivity {
+      /// Label for the Live Status toggle in App Settings
+      public static let title = L10n.tr("Settings", "liveActivity.title", fallback: "Live Status")
+      public enum Tip {
+        /// Message for the Live Activity tip
+        public static let message = L10n.tr("Settings", "liveActivity.tip.message", fallback: "Your connection, battery, and messages stay visible — even without opening the app.")
+        /// Title for the Live Activity tip shown after first connection
+        public static let title = L10n.tr("Settings", "liveActivity.tip.title", fallback: "Radio status at a glance")
+      }
+    }
     public enum Location {
       /// Toggle label for auto-update location
       public static let autoUpdate = L10n.tr("Settings", "location.autoUpdate", fallback: "Auto-Update Location")

--- a/PocketMesh/Resources/Localization/de.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/de.lproj/Settings.strings
@@ -1127,3 +1127,15 @@
 
 /* Location: SettingsView.swift - Purpose: Section footer explaining language setting */
 "language.footer" = "Ändere die App-Sprache in den Systemeinstellungen.";
+
+
+// MARK: - Live Activity
+
+/* Label for the Live Status toggle in App Settings */
+"liveActivity.title" = "Live-Status";
+
+/* Title for the Live Activity tip shown after first connection */
+"liveActivity.tip.title" = "Funkstatus auf einen Blick";
+
+/* Message for the Live Activity tip */
+"liveActivity.tip.message" = "Verbindung, Akku und Nachrichten bleiben sichtbar — auch ohne die App zu öffnen.";

--- a/PocketMesh/Resources/Localization/en.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/en.lproj/Settings.strings
@@ -1132,3 +1132,15 @@
 
 /* Location: SettingsView.swift - Purpose: Section footer explaining language setting */
 "language.footer" = "Change the app language in System Settings.";
+
+
+// MARK: - Live Activity
+
+/* Label for the Live Status toggle in App Settings */
+"liveActivity.title" = "Live Status";
+
+/* Title for the Live Activity tip shown after first connection */
+"liveActivity.tip.title" = "Radio status at a glance";
+
+/* Message for the Live Activity tip */
+"liveActivity.tip.message" = "Your connection, battery, and messages stay visible — even without opening the app.";

--- a/PocketMesh/Resources/Localization/es.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/es.lproj/Settings.strings
@@ -1127,3 +1127,15 @@
 
 /* Location: SettingsView.swift - Purpose: Section footer explaining language setting */
 "language.footer" = "Cambia el idioma de la app en Ajustes del sistema.";
+
+
+// MARK: - Live Activity
+
+/* Label for the Live Status toggle in App Settings */
+"liveActivity.title" = "Estado en vivo";
+
+/* Title for the Live Activity tip shown after first connection */
+"liveActivity.tip.title" = "Estado de la radio de un vistazo";
+
+/* Message for the Live Activity tip */
+"liveActivity.tip.message" = "Tu conexión, batería y mensajes se mantienen visibles, incluso sin abrir la app.";

--- a/PocketMesh/Resources/Localization/fr.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/fr.lproj/Settings.strings
@@ -1127,3 +1127,15 @@
 
 /* Location: SettingsView.swift - Purpose: Section footer explaining language setting */
 "language.footer" = "Modifiez la langue de l'app dans les Réglages système.";
+
+
+// MARK: - Live Activity
+
+/* Label for the Live Status toggle in App Settings */
+"liveActivity.title" = "Statut en direct";
+
+/* Title for the Live Activity tip shown after first connection */
+"liveActivity.tip.title" = "État radio en un coup d'œil";
+
+/* Message for the Live Activity tip */
+"liveActivity.tip.message" = "Votre connexion, batterie et messages restent visibles — même sans ouvrir l'app.";

--- a/PocketMesh/Resources/Localization/nl.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/nl.lproj/Settings.strings
@@ -1127,3 +1127,15 @@
 
 /* Location: SettingsView.swift - Purpose: Section footer explaining language setting */
 "language.footer" = "Wijzig de taal van de app in Systeeminstellingen.";
+
+
+// MARK: - Live Activity
+
+/* Label for the Live Status toggle in App Settings */
+"liveActivity.title" = "Livestatus";
+
+/* Title for the Live Activity tip shown after first connection */
+"liveActivity.tip.title" = "Radiostatus in één oogopslag";
+
+/* Message for the Live Activity tip */
+"liveActivity.tip.message" = "Je verbinding, batterij en berichten blijven zichtbaar — ook zonder de app te openen.";

--- a/PocketMesh/Resources/Localization/pl.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/pl.lproj/Settings.strings
@@ -1127,3 +1127,15 @@
 
 /* Location: SettingsView.swift - Purpose: Section footer explaining language setting */
 "language.footer" = "Zmień język aplikacji w Ustawieniach systemowych.";
+
+
+// MARK: - Live Activity
+
+/* Label for the Live Status toggle in App Settings */
+"liveActivity.title" = "Status na żywo";
+
+/* Title for the Live Activity tip shown after first connection */
+"liveActivity.tip.title" = "Stan radia w jednym rzucie oka";
+
+/* Message for the Live Activity tip */
+"liveActivity.tip.message" = "Połączenie, bateria i wiadomości są widoczne — nawet bez otwierania aplikacji.";

--- a/PocketMesh/Resources/Localization/ru.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/ru.lproj/Settings.strings
@@ -1127,3 +1127,15 @@
 
 /* Location: SettingsView.swift - Purpose: Section footer explaining language setting */
 "language.footer" = "Измените язык приложения в Настройках системы.";
+
+
+// MARK: - Live Activity
+
+/* Label for the Live Status toggle in App Settings */
+"liveActivity.title" = "Статус в реальном времени";
+
+/* Title for the Live Activity tip shown after first connection */
+"liveActivity.tip.title" = "Состояние радио с первого взгляда";
+
+/* Message for the Live Activity tip */
+"liveActivity.tip.message" = "Подключение, батарея и сообщения остаются видимыми — даже без открытия приложения.";

--- a/PocketMesh/Resources/Localization/uk.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/uk.lproj/Settings.strings
@@ -1127,3 +1127,15 @@
 
 /* Location: SettingsView.swift - Purpose: Section footer explaining language setting */
 "language.footer" = "Змініть мову застосунку в Системних налаштуваннях.";
+
+
+// MARK: - Live Activity
+
+/* Label for the Live Status toggle in App Settings */
+"liveActivity.title" = "Стан наживо";
+
+/* Title for the Live Activity tip shown after first connection */
+"liveActivity.tip.title" = "Стан радіо з першого погляду";
+
+/* Message for the Live Activity tip */
+"liveActivity.tip.message" = "Ваше з'єднання, батарея та повідомлення залишаються видимими — навіть без відкриття застосунку.";

--- a/PocketMesh/Resources/Localization/zh-Hans.lproj/Settings.strings
+++ b/PocketMesh/Resources/Localization/zh-Hans.lproj/Settings.strings
@@ -1100,3 +1100,15 @@
 
 /* Location: SettingsView.swift - Purpose: Section footer explaining language setting */
 "language.footer" = "在系统设置中更改应用语言。";
+
+
+// MARK: - Live Activity
+
+/* Label for the Live Status toggle in App Settings */
+"liveActivity.title" = "实时状态";
+
+/* Title for the Live Activity tip shown after first connection */
+"liveActivity.tip.title" = "一目了然的电台状态";
+
+/* Message for the Live Activity tip */
+"liveActivity.tip.message" = "即使不打开应用，您的连接、电池和消息也清晰可见。";

--- a/PocketMesh/State/AppState.swift
+++ b/PocketMesh/State/AppState.swift
@@ -81,6 +81,9 @@ public final class AppState {
     /// Battery monitoring (polling, thresholds, low-battery notifications)
     let batteryMonitor = BatteryMonitor()
 
+    /// Live Activity lifecycle (start/update/stop on Lock Screen and Dynamic Island)
+    let liveActivityManager = LiveActivityManager()
+
     /// Task chain that serializes BLE lifecycle transitions across scene-phase changes.
     /// Do not cancel this task externally -- cancelling breaks the serialization
     /// guarantee because Task<Void, Never>.value returns immediately on cancellation.
@@ -184,8 +187,10 @@ public final class AppState {
 
     /// Initialize on app launch
     func initialize() async {
-        // activate() will trigger onConnectionReady callback if connection succeeds
-        // Notification delegate is set in wireServicesIfConnected() when services become available
+        // Recover any existing Live Activity before activate() so that onConnectionReady
+        // (which fires during activate) finds currentActivity populated and can update it.
+        await liveActivityManager.recoverExistingActivity()
+        liveActivityManager.startObservingEnablement()
         await connectionManager.activate()
         // Check if disconnected pill should show (for fresh launch after termination)
         connectionUI.updateDisconnectedPillState(
@@ -209,6 +214,7 @@ public final class AppState {
             cliToolViewModel?.reset()
             batteryMonitor.stop()
             batteryMonitor.clearThresholds()
+            await liveActivityManager.handleConnectionLost()
             return
         }
 
@@ -236,6 +242,7 @@ public final class AppState {
         wireSettingsEventStream(services: services)
         await wireDeviceUpdateCallbacks(services: services)
         await wireMessageBroadcasting(services: services)
+        await wireLiveActivityCallbacks(services: services)
 
         // Increment version to trigger UI refresh in views observing this
         servicesVersion += 1
@@ -277,6 +284,11 @@ public final class AppState {
             },
             onConversationsChanged: { @MainActor [weak self] in
                 self?.conversationsVersion += 1
+                Task { @MainActor [weak self] in
+                    guard let self, let services = self.services else { return }
+                    let total = await self.totalUnreadCount(from: services)
+                    await self.liveActivityManager.handleUnreadCountChanged(unreadCount: total)
+                }
             }
         )
     }
@@ -349,11 +361,50 @@ public final class AppState {
             services,
             onConversationsChanged: { [weak self] in
                 self?.conversationsVersion += 1
+                Task { @MainActor [weak self] in
+                    guard let self, let services = self.services else { return }
+                    let total = await self.totalUnreadCount(from: services)
+                    await self.liveActivityManager.handleUnreadCountChanged(unreadCount: total)
+                }
             },
             onReactionReceived: { [weak self] messageID in
                 await self?.handleReactionNotification(messageID: messageID)
             }
         )
+    }
+
+    /// Wire Live Activity callbacks for RX freshness, battery, and connection lifecycle.
+    private func wireLiveActivityCallbacks(services: ServiceContainer) async {
+        await services.rxLogService.setPacketReceivedHandler { [weak self] in
+            Task { @MainActor [weak self] in
+                await self?.liveActivityManager.handlePacketReceived()
+            }
+        }
+
+        batteryMonitor.onBatteryChanged = { [weak self] battery in
+            Task { @MainActor [weak self] in
+                await self?.liveActivityManager.handleBatteryChanged(battery: battery)
+            }
+        }
+
+        let device = connectedDevice
+        let ocvArray = batteryMonitor.activeBatteryOCVArray(for: device)
+        let unreadCount = await totalUnreadCount(from: services)
+
+        if let device {
+            await liveActivityManager.handleConnectionReady(
+                device: device,
+                ocvArray: ocvArray,
+                unreadCount: unreadCount
+            )
+        }
+    }
+
+    private func totalUnreadCount(from services: ServiceContainer) async -> Int {
+        guard let deviceID = currentDeviceID else { return 0 }
+        let counts = (try? await services.dataStore.getTotalUnreadCounts(deviceID: deviceID))
+            ?? (contacts: 0, channels: 0, rooms: 0)
+        return counts.contacts + counts.channels + counts.rooms
     }
 
     // MARK: - Stale Node Cleanup

--- a/PocketMesh/State/BatteryMonitor.swift
+++ b/PocketMesh/State/BatteryMonitor.swift
@@ -25,6 +25,9 @@ public final class BatteryMonitor {
     /// Battery warning threshold levels (percentage)
     private let batteryWarningThresholds = [20, 10, 5]
 
+    /// Called when battery info is updated, for Live Activity
+    var onBatteryChanged: ((_ battery: BatteryInfo) -> Void)?
+
     /// The active OCV array for the connected device
     func activeBatteryOCVArray(for device: DeviceDTO?) -> [Int] {
         device?.activeOCVArray ?? OCVPreset.liIon.ocvArray
@@ -38,6 +41,9 @@ public final class BatteryMonitor {
 
         do {
             deviceBattery = try await settingsService.getBattery()
+            if let battery = deviceBattery {
+                onBatteryChanged?(battery)
+            }
             await checkBatteryThresholds(device: device, services: services)
         } catch {
             deviceBattery = nil
@@ -52,6 +58,9 @@ public final class BatteryMonitor {
 
             do {
                 self.deviceBattery = try await services.settingsService.getBattery()
+                if let battery = self.deviceBattery {
+                    self.onBatteryChanged?(battery)
+                }
             } catch {
                 self.logger.debug("Deferred battery bootstrap failed: \(error.localizedDescription, privacy: .public)")
                 self.deviceBattery = nil
@@ -86,6 +95,9 @@ public final class BatteryMonitor {
 
         do {
             deviceBattery = try await settingsService.getBattery()
+            if let battery = deviceBattery {
+                onBatteryChanged?(battery)
+            }
         } catch {
             return
         }

--- a/PocketMesh/State/LiveActivityManager.swift
+++ b/PocketMesh/State/LiveActivityManager.swift
@@ -1,0 +1,202 @@
+@preconcurrency import ActivityKit
+import Foundation
+import MeshCore
+import OSLog
+import PocketMeshServices
+
+@Observable
+@MainActor
+public final class LiveActivityManager {
+
+    static let enabledKey = "liveActivityEnabled"
+
+    private let logger = Logger(subsystem: "com.pocketmesh", category: "LiveActivityManager")
+
+    private var currentActivity: Activity<MeshStatusAttributes>?
+    private var disconnectTimer: Task<Void, Never>?
+    private var enablementTask: Task<Void, Never>?
+    private var ocvArray: [Int] = []
+
+    var isEnabled: Bool {
+        UserDefaults.standard.object(forKey: Self.enabledKey) as? Bool ?? true
+    }
+
+    // MARK: - Lifecycle
+
+    func startObservingEnablement() {
+        enablementTask?.cancel()
+        enablementTask = Task { [weak self] in
+            for await enabled in ActivityAuthorizationInfo().activityEnablementUpdates {
+                guard let self else { break }
+                if !enabled {
+                    await self.endActivity()
+                }
+            }
+        }
+    }
+
+    func handleConnectionReady(
+        device: DeviceDTO,
+        ocvArray: [Int],
+        unreadCount: Int
+    ) async {
+        self.ocvArray = ocvArray
+
+        // If reconnecting to same device within grace period, restore connected state
+        if let activity = currentActivity,
+           activity.attributes.deviceName == device.nodeName {
+            disconnectTimer?.cancel()
+            disconnectTimer = nil
+            await updateActivity(
+                isConnected: true,
+                battery: .some(nil),
+                lastRXDate: .some(nil),
+                unreadCount: unreadCount,
+                disconnectedDate: .some(nil)
+            )
+            return
+        }
+
+        // If reconnecting to a different device, end the old activity first
+        if currentActivity != nil {
+            await endActivity()
+        }
+
+        await startActivity(
+            device: device,
+            unreadCount: unreadCount
+        )
+    }
+
+    func handleConnectionLost() async {
+        guard currentActivity != nil else { return }
+
+        await updateActivity(
+            isConnected: false,
+            battery: .some(nil),
+            lastRXDate: .some(nil),
+            unreadCount: 0,
+            disconnectedDate: .some(.now)
+        )
+
+        disconnectTimer?.cancel()
+        disconnectTimer = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(300))
+            guard !Task.isCancelled else { return }
+            await self?.endActivity()
+        }
+    }
+
+    func handlePacketReceived() async {
+        await updateActivity(lastRXDate: .some(.now))
+    }
+
+    func handleBatteryChanged(battery: BatteryInfo) async {
+        let percent = battery.percentage(using: ocvArray)
+        await updateActivity(battery: .some(percent))
+    }
+
+    func handleUnreadCountChanged(unreadCount: Int) async {
+        await updateActivity(unreadCount: unreadCount)
+    }
+
+    func setEnabled(_ enabled: Bool) async {
+        UserDefaults.standard.set(enabled, forKey: Self.enabledKey)
+        if !enabled {
+            await endActivity()
+        }
+    }
+
+    // MARK: - App relaunch recovery
+
+    func recoverExistingActivity() async {
+        currentActivity = Activity<MeshStatusAttributes>.activities.first
+
+        guard let activity = currentActivity,
+              !activity.content.state.isConnected,
+              let disconnectedDate = activity.content.state.disconnectedDate else {
+            return
+        }
+
+        let elapsed = Date.now.timeIntervalSince(disconnectedDate)
+        let remaining = 300 - elapsed
+
+        if remaining > 0 {
+            disconnectTimer = Task { [weak self] in
+                try? await Task.sleep(for: .seconds(remaining))
+                guard !Task.isCancelled else { return }
+                await self?.endActivity()
+            }
+        } else {
+            await endActivity()
+        }
+    }
+
+    // MARK: - Private
+
+    private func startActivity(
+        device: DeviceDTO,
+        unreadCount: Int
+    ) async {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled,
+              isEnabled,
+              !DemoModeManager.shared.isEnabled,
+              Activity<MeshStatusAttributes>.activities.isEmpty else {
+            return
+        }
+
+        let attributes = MeshStatusAttributes(deviceName: device.nodeName)
+        let state = MeshStatusAttributes.ContentState(
+            isConnected: true,
+            batteryPercent: nil,
+            lastRXDate: nil,
+            unreadCount: unreadCount,
+            disconnectedDate: nil
+        )
+        let staleDate = Calendar.current.date(byAdding: .minute, value: 5, to: .now)
+        let content = ActivityContent(state: state, staleDate: staleDate)
+
+        do {
+            currentActivity = try Activity.request(
+                attributes: attributes,
+                content: content,
+                pushType: nil
+            )
+            LiveActivityTip.radioConnected.sendDonation()
+            logger.info("Started Live Activity for \(device.nodeName, privacy: .public)")
+        } catch {
+            logger.error("Failed to start Live Activity: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Updates the Live Activity state. Pass `nil` to keep the current value, `.some(value)` to override.
+    private func updateActivity(
+        isConnected: Bool? = nil,
+        battery: Int?? = nil,
+        lastRXDate: Date?? = nil,
+        unreadCount: Int? = nil,
+        disconnectedDate: Date?? = nil
+    ) async {
+        guard let current = currentActivity?.content.state else { return }
+        let state = MeshStatusAttributes.ContentState(
+            isConnected: isConnected ?? current.isConnected,
+            batteryPercent: battery ?? current.batteryPercent,
+            lastRXDate: lastRXDate ?? current.lastRXDate,
+            unreadCount: unreadCount ?? current.unreadCount,
+            disconnectedDate: disconnectedDate ?? current.disconnectedDate
+        )
+        let staleDate = Calendar.current.date(byAdding: .minute, value: 5, to: .now)
+        let content = ActivityContent(state: state, staleDate: staleDate)
+        await currentActivity?.update(content)
+    }
+
+    func endActivity() async {
+        disconnectTimer?.cancel()
+        disconnectTimer = nil
+        for activity in Activity<MeshStatusAttributes>.activities {
+            await activity.end(nil, dismissalPolicy: .immediate)
+        }
+        currentActivity = nil
+        logger.info("Ended Live Activity")
+    }
+}

--- a/PocketMesh/Tips/LiveActivityTip.swift
+++ b/PocketMesh/Tips/LiveActivityTip.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+import TipKit
+
+/// Tip shown after a Live Activity starts for the first time
+struct LiveActivityTip: Tip {
+    static let radioConnected = Tips.Event(id: "radioConnected")
+
+    var title: Text {
+        Text(L10n.Settings.LiveActivity.Tip.title)
+    }
+
+    var message: Text? {
+        Text(L10n.Settings.LiveActivity.Tip.message)
+    }
+
+    var image: Image? {
+        Image(systemName: "antenna.radiowaves.left.and.right.fill")
+    }
+
+    var options: [TipOption] {
+        [Tips.MaxDisplayCount(1)]
+    }
+
+    var rules: [Rule] {
+        #Rule(Self.radioConnected) { $0.donations.count >= 1 }
+    }
+}

--- a/PocketMesh/Views/Settings/SettingsView.swift
+++ b/PocketMesh/Views/Settings/SettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PocketMeshServices
+import TipKit
 
 /// Main settings screen — navigation-link rows for device settings, always-visible app settings
 struct SettingsView: View {
@@ -36,6 +37,7 @@ private struct SettingsListContent: View {
     @Environment(\.appState) private var appState
     @Binding var showingDeviceSelection: Bool
     let demoModeManager: DemoModeManager
+    private let liveActivityTip = LiveActivityTip()
 
     var body: some View {
         List {
@@ -69,6 +71,25 @@ private struct SettingsListContent: View {
                         detail: currentLanguageDisplayName
                     )
                 }
+
+                HStack {
+                    TintedLabel(L10n.Settings.LiveActivity.title, systemImage: "antenna.radiowaves.left.and.right")
+                    Spacer()
+                    Toggle("", isOn: Binding(
+                        get: { appState.liveActivityManager.isEnabled },
+                        set: { newValue in
+                            Task {
+                                await appState.liveActivityManager.setEnabled(newValue)
+                                if newValue, appState.connectionState == .ready || appState.connectionState == .connected {
+                                    await appState.wireServicesIfConnected()
+                                }
+                            }
+                        }
+                    ))
+                    .labelsHidden()
+                }
+                .accessibilityElement(children: .combine)
+                .popoverTip(liveActivityTip)
             } header: {
                 Text(L10n.Settings.AppSettings.header)
             } footer: {

--- a/PocketMeshServices/Sources/PocketMeshServices/Services/RxLogService.swift
+++ b/PocketMeshServices/Sources/PocketMeshServices/Services/RxLogService.swift
@@ -23,6 +23,9 @@ public actor RxLogService {
     // Stream for UI updates
     private var streamContinuation: AsyncStream<RxLogEntryDTO>.Continuation?
 
+    /// Called when any RF packet is received, for Live Activity freshness tracking
+    private var onPacketReceived: (@Sendable @MainActor () -> Void)?
+
     // Event monitoring
     private var eventMonitorTask: Task<Void, Never>?
 
@@ -40,6 +43,11 @@ public actor RxLogService {
     /// Sets the HeardRepeatsService for processing channel message repeats.
     public func setHeardRepeatsService(_ service: HeardRepeatsService) {
         self.heardRepeatsService = service
+    }
+
+    /// Sets the callback invoked when any RF packet is received.
+    public func setPacketReceivedHandler(_ handler: (@Sendable @MainActor () -> Void)?) {
+        onPacketReceived = handler
     }
 
     /// Whether a heard repeats service has been wired via `setHeardRepeatsService`.
@@ -298,6 +306,10 @@ public actor RxLogService {
 
         // Emit to stream
         streamContinuation?.yield(dto)
+
+        if let onPacketReceived {
+            await onPacketReceived()
+        }
 
         // Process for heard repeats (inline await provides natural backpressure,
         // preventing unbounded Task accumulation under high RX volume)

--- a/PocketMeshWidgets/Info.plist
+++ b/PocketMeshWidgets/Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/PocketMeshWidgets/MeshStatusLiveActivity.swift
+++ b/PocketMeshWidgets/MeshStatusLiveActivity.swift
@@ -1,0 +1,72 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+struct MeshStatusLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: MeshStatusAttributes.self) { context in
+            LockScreenView(context: context)
+                .activityBackgroundTint(
+                    context.state.isConnected ? .green.opacity(0.15) : .orange.opacity(0.2)
+                )
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    HStack {
+                        Image(systemName: context.state.antennaIconName)
+                            .accessibilityHidden(true)
+                        Text(context.attributes.deviceName)
+                            .bold()
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                    .accessibilityElement(children: .combine)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    BatteryLabel(percent: context.state.batteryPercent)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    if context.state.isConnected {
+                        RXFreshnessLabel(lastRXDate: context.state.lastRXDate)
+                    } else {
+                        Text("Disconnected")
+                            .foregroundStyle(.orange)
+                            .font(.caption)
+                    }
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    if context.state.isConnected, context.state.unreadCount > 0 {
+                        HStack {
+                            Image(systemName: "envelope.badge")
+                                .accessibilityHidden(true)
+                            Text("\(context.state.unreadCount) unread")
+                                .contentTransition(.numericText())
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .accessibilityElement(children: .combine)
+                    }
+
+                    if !context.state.isConnected, let date = context.state.disconnectedDate {
+                        Text(date, style: .relative)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } compactLeading: {
+                Image(systemName: context.state.antennaIconName)
+            } compactTrailing: {
+                if context.state.isConnected, let lastRX = context.state.lastRXDate {
+                    Text(lastRX, style: .relative)
+                        .monospacedDigit()
+                        .fixedSize()
+                } else {
+                    Text("—")
+                }
+            } minimal: {
+                Image(systemName: context.state.antennaIconName)
+            }
+            .widgetURL(URL(string: "pocketmesh://status"))
+        }
+    }
+}

--- a/PocketMeshWidgets/PocketMeshWidgetsBundle.swift
+++ b/PocketMeshWidgets/PocketMeshWidgetsBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct PocketMeshWidgetsBundle: WidgetBundle {
+    var body: some Widget {
+        MeshStatusLiveActivity()
+    }
+}

--- a/PocketMeshWidgets/Resources/de.lproj/Localizable.strings
+++ b/PocketMeshWidgets/Resources/de.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* Widget localization — German */
+
+"Disconnected" = "Getrennt";
+"Disconnected %@ ago" = "Getrennt seit %@";
+"Last received %@ ago" = "Zuletzt empfangen vor %@";
+"No data received" = "Keine Daten empfangen";
+"Battery %lld percent" = "Akku %lld Prozent";

--- a/PocketMeshWidgets/Resources/de.lproj/Localizable.stringsdict
+++ b/PocketMeshWidgets/Resources/de.lproj/Localizable.stringsdict
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>%lld unread</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld ungelesen</string>
+			<key>other</key>
+			<string>%lld ungelesen</string>
+		</dict>
+	</dict>
+	<key>%lld unread messages</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld ungelesene Nachricht</string>
+			<key>other</key>
+			<string>%lld ungelesene Nachrichten</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/PocketMeshWidgets/Resources/en.lproj/Localizable.strings
+++ b/PocketMeshWidgets/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,16 @@
+/* Widget localization — English (base) */
+
+/* Connection status shown when radio is disconnected */
+"Disconnected" = "Disconnected";
+
+/* Accessibility: disconnected duration on Lock Screen */
+"Disconnected %@ ago" = "Disconnected %@ ago";
+
+/* Accessibility: last packet received relative time */
+"Last received %@ ago" = "Last received %@ ago";
+
+/* Accessibility: no packets received yet */
+"No data received" = "No data received";
+
+/* Accessibility: battery level */
+"Battery %lld percent" = "Battery %lld percent";

--- a/PocketMeshWidgets/Resources/en.lproj/Localizable.stringsdict
+++ b/PocketMeshWidgets/Resources/en.lproj/Localizable.stringsdict
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>%lld unread</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld unread</string>
+			<key>other</key>
+			<string>%lld unread</string>
+		</dict>
+	</dict>
+	<key>%lld unread messages</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld unread message</string>
+			<key>other</key>
+			<string>%lld unread messages</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/PocketMeshWidgets/Resources/es.lproj/Localizable.strings
+++ b/PocketMeshWidgets/Resources/es.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* Widget localization — Spanish */
+
+"Disconnected" = "Desconectado";
+"Disconnected %@ ago" = "Desconectado hace %@";
+"Last received %@ ago" = "Último recibido hace %@";
+"No data received" = "Sin datos recibidos";
+"Battery %lld percent" = "Batería %lld por ciento";

--- a/PocketMeshWidgets/Resources/es.lproj/Localizable.stringsdict
+++ b/PocketMeshWidgets/Resources/es.lproj/Localizable.stringsdict
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>%lld unread</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld sin leer</string>
+			<key>other</key>
+			<string>%lld sin leer</string>
+		</dict>
+	</dict>
+	<key>%lld unread messages</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld mensaje sin leer</string>
+			<key>other</key>
+			<string>%lld mensajes sin leer</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/PocketMeshWidgets/Resources/fr.lproj/Localizable.strings
+++ b/PocketMeshWidgets/Resources/fr.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* Widget localization — French */
+
+"Disconnected" = "Déconnecté";
+"Disconnected %@ ago" = "Déconnecté depuis %@";
+"Last received %@ ago" = "Dernier reçu il y a %@";
+"No data received" = "Aucune donnée reçue";
+"Battery %lld percent" = "Batterie %lld pour cent";

--- a/PocketMeshWidgets/Resources/fr.lproj/Localizable.stringsdict
+++ b/PocketMeshWidgets/Resources/fr.lproj/Localizable.stringsdict
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>%lld unread</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld non lu</string>
+			<key>other</key>
+			<string>%lld non lus</string>
+		</dict>
+	</dict>
+	<key>%lld unread messages</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld message non lu</string>
+			<key>other</key>
+			<string>%lld messages non lus</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/PocketMeshWidgets/Resources/nl.lproj/Localizable.strings
+++ b/PocketMeshWidgets/Resources/nl.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* Widget localization — Dutch */
+
+"Disconnected" = "Niet verbonden";
+"Disconnected %@ ago" = "Niet verbonden sinds %@";
+"Last received %@ ago" = "Laatst ontvangen %@ geleden";
+"No data received" = "Geen gegevens ontvangen";
+"Battery %lld percent" = "Batterij %lld procent";

--- a/PocketMeshWidgets/Resources/nl.lproj/Localizable.stringsdict
+++ b/PocketMeshWidgets/Resources/nl.lproj/Localizable.stringsdict
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>%lld unread</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld ongelezen</string>
+			<key>other</key>
+			<string>%lld ongelezen</string>
+		</dict>
+	</dict>
+	<key>%lld unread messages</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld ongelezen bericht</string>
+			<key>other</key>
+			<string>%lld ongelezen berichten</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/PocketMeshWidgets/Resources/pl.lproj/Localizable.strings
+++ b/PocketMeshWidgets/Resources/pl.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* Widget localization — Polish */
+
+"Disconnected" = "Rozłączono";
+"Disconnected %@ ago" = "Rozłączono %@ temu";
+"Last received %@ ago" = "Ostatnio odebrano %@ temu";
+"No data received" = "Brak odebranych danych";
+"Battery %lld percent" = "Bateria %lld procent";

--- a/PocketMeshWidgets/Resources/pl.lproj/Localizable.stringsdict
+++ b/PocketMeshWidgets/Resources/pl.lproj/Localizable.stringsdict
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>%lld unread</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld nieprzeczytana</string>
+			<key>few</key>
+			<string>%lld nieprzeczytane</string>
+			<key>many</key>
+			<string>%lld nieprzeczytanych</string>
+			<key>other</key>
+			<string>%lld nieprzeczytanych</string>
+		</dict>
+	</dict>
+	<key>%lld unread messages</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld nieprzeczytana wiadomość</string>
+			<key>few</key>
+			<string>%lld nieprzeczytane wiadomości</string>
+			<key>many</key>
+			<string>%lld nieprzeczytanych wiadomości</string>
+			<key>other</key>
+			<string>%lld nieprzeczytanych wiadomości</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/PocketMeshWidgets/Resources/ru.lproj/Localizable.strings
+++ b/PocketMeshWidgets/Resources/ru.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* Widget localization — Russian */
+
+"Disconnected" = "Отключено";
+"Disconnected %@ ago" = "Отключено %@ назад";
+"Last received %@ ago" = "Последний приём %@ назад";
+"No data received" = "Нет полученных данных";
+"Battery %lld percent" = "Батарея %lld процентов";

--- a/PocketMeshWidgets/Resources/ru.lproj/Localizable.stringsdict
+++ b/PocketMeshWidgets/Resources/ru.lproj/Localizable.stringsdict
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>%lld unread</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld непрочитанное</string>
+			<key>few</key>
+			<string>%lld непрочитанных</string>
+			<key>many</key>
+			<string>%lld непрочитанных</string>
+			<key>other</key>
+			<string>%lld непрочитанных</string>
+		</dict>
+	</dict>
+	<key>%lld unread messages</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld непрочитанное сообщение</string>
+			<key>few</key>
+			<string>%lld непрочитанных сообщения</string>
+			<key>many</key>
+			<string>%lld непрочитанных сообщений</string>
+			<key>other</key>
+			<string>%lld непрочитанных сообщений</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/PocketMeshWidgets/Resources/uk.lproj/Localizable.strings
+++ b/PocketMeshWidgets/Resources/uk.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* Widget localization — Ukrainian */
+
+"Disconnected" = "Від'єднано";
+"Disconnected %@ ago" = "Від'єднано %@ тому";
+"Last received %@ ago" = "Останній прийом %@ тому";
+"No data received" = "Немає отриманих даних";
+"Battery %lld percent" = "Батарея %lld відсотків";

--- a/PocketMeshWidgets/Resources/uk.lproj/Localizable.stringsdict
+++ b/PocketMeshWidgets/Resources/uk.lproj/Localizable.stringsdict
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>%lld unread</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld непрочитане</string>
+			<key>few</key>
+			<string>%lld непрочитаних</string>
+			<key>many</key>
+			<string>%lld непрочитаних</string>
+			<key>other</key>
+			<string>%lld непрочитаних</string>
+		</dict>
+	</dict>
+	<key>%lld unread messages</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>one</key>
+			<string>%lld непрочитане повідомлення</string>
+			<key>few</key>
+			<string>%lld непрочитаних повідомлення</string>
+			<key>many</key>
+			<string>%lld непрочитаних повідомлень</string>
+			<key>other</key>
+			<string>%lld непрочитаних повідомлень</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/PocketMeshWidgets/Resources/zh-Hans.lproj/Localizable.strings
+++ b/PocketMeshWidgets/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+/* Widget localization — Simplified Chinese */
+
+"Disconnected" = "已断开";
+"Disconnected %@ ago" = "已断开 %@";
+"Last received %@ ago" = "%@前最后接收";
+"No data received" = "未收到数据";
+"Battery %lld percent" = "电量 %lld%%";

--- a/PocketMeshWidgets/Resources/zh-Hans.lproj/Localizable.stringsdict
+++ b/PocketMeshWidgets/Resources/zh-Hans.lproj/Localizable.stringsdict
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>%lld unread</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>other</key>
+			<string>%lld 条未读</string>
+		</dict>
+	</dict>
+	<key>%lld unread messages</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>lld</string>
+			<key>other</key>
+			<string>%lld 条未读消息</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/PocketMeshWidgets/Views/LockScreenView.swift
+++ b/PocketMeshWidgets/Views/LockScreenView.swift
@@ -1,0 +1,104 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+struct LockScreenView: View {
+    let context: ActivityViewContext<MeshStatusAttributes>
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Image(systemName: context.state.antennaIconName)
+                    .accessibilityHidden(true)
+
+                Text(context.attributes.deviceName)
+                    .bold()
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer()
+
+                if context.state.isConnected {
+                    RXFreshnessLabel(lastRXDate: context.state.lastRXDate)
+                } else {
+                    Text("Disconnected")
+                        .foregroundStyle(.orange)
+                }
+
+                BatteryLabel(percent: context.state.batteryPercent)
+            }
+
+            if context.state.isConnected, context.state.unreadCount > 0 {
+                HStack {
+                    Spacer()
+                    Image(systemName: "envelope.badge")
+                        .accessibilityHidden(true)
+                    Text("\(context.state.unreadCount) unread")
+                        .contentTransition(.numericText())
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("\(context.state.unreadCount) unread messages")
+            }
+
+            if !context.state.isConnected, let disconnectedDate = context.state.disconnectedDate {
+                HStack {
+                    Spacer()
+                    Text(disconnectedDate, style: .relative)
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                }
+                .accessibilityLabel("Disconnected \(Text(disconnectedDate, style: .relative)) ago")
+            }
+        }
+        .padding()
+        .accessibilityElement(children: .combine)
+        .widgetURL(URL(string: "pocketmesh://status"))
+    }
+}
+
+// MARK: - Subviews
+
+struct RXFreshnessLabel: View {
+    let lastRXDate: Date?
+
+    var body: some View {
+        HStack(spacing: 2) {
+            Image(systemName: "arrow.down")
+                .font(.caption2)
+                .accessibilityHidden(true)
+            if let lastRXDate {
+                Text(lastRXDate, style: .relative)
+                    .monospacedDigit()
+            } else {
+                Text("—")
+            }
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(lastRXDate.map { "Last received \(Text($0, style: .relative)) ago" } ?? "No data received")
+    }
+}
+
+struct BatteryLabel: View {
+    let percent: Int?
+
+    var body: some View {
+        if let percent {
+            Image(systemName: batteryIconName(for: percent))
+                .accessibilityLabel("Battery \(percent) percent")
+        }
+    }
+
+    private func batteryIconName(for percent: Int) -> String {
+        switch percent {
+        case 88...100: "battery.100"
+        case 63..<88: "battery.75"
+        case 38..<63: "battery.50"
+        case 13..<38: "battery.25"
+        default: "battery.0"
+        }
+    }
+}

--- a/Shared/MeshStatusAttributes.swift
+++ b/Shared/MeshStatusAttributes.swift
@@ -1,0 +1,20 @@
+import ActivityKit
+import Foundation
+
+struct MeshStatusAttributes: ActivityAttributes, Sendable {
+    let deviceName: String
+
+    struct ContentState: Codable, Hashable, Sendable {
+        var isConnected: Bool
+        var batteryPercent: Int?
+        var lastRXDate: Date?
+        var unreadCount: Int
+        var disconnectedDate: Date?
+
+        var antennaIconName: String {
+            isConnected
+                ? "antenna.radiowaves.left.and.right"
+                : "antenna.radiowaves.left.and.right.slash"
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -31,9 +31,11 @@ targets:
         excludes:
           - "**/*.md"
       - path: AppIcon.icon
+      - path: Shared
     dependencies:
       - package: PocketMeshServices
       - package: Emojibase
+      - target: PocketMeshWidgets
     preBuildScripts:
       - name: SwiftGen
         script: |
@@ -64,6 +66,7 @@ targets:
         CURRENT_PROJECT_VERSION: 1
         VERSIONING_SYSTEM: apple-generic
         TARGETED_DEVICE_FAMILY: "1,2"
+        NSSupportsLiveActivities: true
         UIBackgroundModes:
           - bluetooth-central
         NSBluetoothAlwaysUsageDescription: "PocketMesh uses Bluetooth to maintain connections with MeshCore radios, even in the background, so you can send and receive messages without opening the app."
@@ -112,12 +115,33 @@ targets:
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/PocketMesh.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PocketMesh"
         BUNDLE_LOADER: "$(TEST_HOST)"
 
+  PocketMeshWidgets:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: PocketMeshWidgets
+      - path: Shared
+    settings:
+      base:
+        MARKETING_VERSION: 0.10.0
+        CURRENT_PROJECT_VERSION: 1
+        VERSIONING_SYSTEM: apple-generic
+        TARGETED_DEVICE_FAMILY: "1,2"
+      configs:
+        Debug:
+          INFOPLIST_FILE: PocketMeshWidgets/Info.plist
+          PRODUCT_BUNDLE_IDENTIFIER: io.pocketmesh.app.debug.widgets
+        Release:
+          INFOPLIST_FILE: PocketMeshWidgets/Info.plist
+          PRODUCT_BUNDLE_IDENTIFIER: io.pocketmesh.app.widgets
+
 schemes:
   PocketMesh:
     build:
       targets:
         PocketMesh: all
         PocketMeshTests: [test]
+        PocketMeshWidgets: [run]
     run:
       config: Debug
     test:


### PR DESCRIPTION
## Summary
- Add `PocketMeshWidgets` extension target with Lock Screen and Dynamic Island Live Activity views
- Implement `LiveActivityManager` with start/update/stop lifecycle, wired into `AppState`, `BatteryMonitor`, and `RxLogService` callbacks
- Add `pocketmesh://` URL scheme handler for Live Activity deep links
- Add Live Status toggle and `LiveActivityTip` in Settings
- Localize all widget and settings strings across 9 languages

## Test plan
- [x] Build and run on iOS 18.1+ simulator/device
- [x] Verify Live Activity appears on Lock Screen when connected to mesh
- [x] Verify Dynamic Island compact/expanded views display correctly
- [ ] Verify activity updates with node count, packet count, and battery level
- [x] Verify tapping the Live Activity deep links back into the app
- [ ] Verify Settings toggle starts/stops the Live Activity
- [ ] Verify LiveActivityTip appears on first connection
- [x] Verify localized strings render correctly in non-English locales