### PR TITLE
Fix SelfInfo frame length validation

### DIFF
--- a/MeshCore/Sources/MeshCore/Protocol/Parsers.swift
+++ b/MeshCore/Sources/MeshCore/Protocol/Parsers.swift
@@ -7,8 +7,7 @@ import os
 enum PacketSize {
     /// Full contact structure size.
     static let contact = 147
-    /// Minimum size for self info response before optional device name bytes.
-    /// Format: fixed fields through radio SF/CR = 57 bytes.
+    /// Minimum size for self info response.
     static let selfInfoMinimum = 57
     /// Minimum size for message sent confirmation.
     static let messageSentMinimum = 9
@@ -203,7 +202,7 @@ public enum Parsers {
 
     /// Parser for local device configuration info.
     enum SelfInfo {
-        /// Parses self info response (55+ bytes).
+        /// Parses self info response (57+ bytes).
         ///
         /// - Parameter data: Raw self info data.
         /// - Returns: A `.selfInfo` event or `.parseFailure`.

--- a/MeshCore/Sources/MeshCore/Protocol/Parsers.swift
+++ b/MeshCore/Sources/MeshCore/Protocol/Parsers.swift
@@ -7,8 +7,9 @@ import os
 enum PacketSize {
     /// Full contact structure size.
     static let contact = 147
-    /// Minimum size for self info response.
-    static let selfInfoMinimum = 55
+    /// Minimum size for self info response before optional device name bytes.
+    /// Format: fixed fields through radio SF/CR = 57 bytes.
+    static let selfInfoMinimum = 57
     /// Minimum size for message sent confirmation.
     static let messageSentMinimum = 9
     /// Minimum size for version 1 contact messages.

--- a/MeshCore/Tests/MeshCoreTests/Validation/RoundTripTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Validation/RoundTripTests.swift
@@ -170,6 +170,66 @@ struct RoundTripTests {
         #expect(info.name == "NegPwr")
     }
 
+    @Test("SelfInfo parses minimum-length payload without device name")
+    func selfInfoMinimumLengthPayload() {
+        var data = Data()
+        data.append(0x01)  // advType
+        data.append(UInt8(bitPattern: Int8(20)))  // txPower
+        data.append(UInt8(bitPattern: Int8(30)))  // maxTxPower
+        data.append(Data(repeating: 0xAA, count: 32))  // publicKey
+        data.append(contentsOf: withUnsafeBytes(of: Int32(0).littleEndian) { Data($0) })  // lat
+        data.append(contentsOf: withUnsafeBytes(of: Int32(0).littleEndian) { Data($0) })  // lon
+        data.append(0x02)  // multiAcks
+        data.append(0x01)  // advLocPolicy
+        data.append(0x00)  // telemetryMode
+        data.append(0x01)  // manualAdd
+        data.append(contentsOf: withUnsafeBytes(of: UInt32(915_000).littleEndian) { Data($0) })  // radioFreq
+        data.append(contentsOf: withUnsafeBytes(of: UInt32(250_000).littleEndian) { Data($0) })  // radioBW
+        data.append(0x0A)  // radioSF
+        data.append(0x05)  // radioCR
+
+        #expect(data.count == 57)
+
+        let event = Parsers.SelfInfo.parse(data)
+
+        guard case .selfInfo(let info) = event else {
+            Issue.record("Expected .selfInfo event, got \(event)")
+            return
+        }
+
+        #expect(info.radioSpreadingFactor == 0x0A)
+        #expect(info.radioCodingRate == 0x05)
+        #expect(info.name.isEmpty)
+    }
+
+    @Test("SelfInfo rejects truncated fixed-width payload")
+    func selfInfoRejectsTruncatedPayload() {
+        var data = Data()
+        data.append(0x01)  // advType
+        data.append(UInt8(bitPattern: Int8(20)))  // txPower
+        data.append(UInt8(bitPattern: Int8(30)))  // maxTxPower
+        data.append(Data(repeating: 0xAA, count: 32))  // publicKey
+        data.append(contentsOf: withUnsafeBytes(of: Int32(0).littleEndian) { Data($0) })  // lat
+        data.append(contentsOf: withUnsafeBytes(of: Int32(0).littleEndian) { Data($0) })  // lon
+        data.append(0x02)  // multiAcks
+        data.append(0x01)  // advLocPolicy
+        data.append(0x00)  // telemetryMode
+        data.append(0x01)  // manualAdd
+        data.append(contentsOf: withUnsafeBytes(of: UInt32(915_000).littleEndian) { Data($0) })  // radioFreq
+        data.append(contentsOf: withUnsafeBytes(of: UInt32(250_000).littleEndian) { Data($0) })  // radioBW
+
+        #expect(data.count == 55)
+
+        let event = Parsers.SelfInfo.parse(data)
+
+        guard case .parseFailure(_, let reason) = event else {
+            Issue.record("Expected .parseFailure event, got \(event)")
+            return
+        }
+
+        #expect(reason.contains("SelfInfo response too short"))
+    }
+
     // MARK: - Message Round-Trip
 
     @Test("ContactMessage v3 round trip")


### PR DESCRIPTION
## Summary
- raise `PacketSize.selfInfoMinimum` from 55 to 57 bytes
- add coverage for the minimum valid fixed-width `SelfInfo` payload and for truncated payload rejection

## Why this is the correct fix
The current MeshCore firmware documentation describes `PACKET_SELF_INFO` as:
- byte 0: packet type
- bytes 1-57: fixed-width fields through radio spreading factor and coding rate
- bytes 58+: optional device name

References:
- https://github.com/meshcore-dev/MeshCore
- https://github.com/meshcore-dev/MeshCore/tree/main/docs
- `docs/companion_protocol.md` (`PACKET_SELF_INFO`)

`PacketParser` drops the response code before parsing, so the parser should require a minimum payload length of 57 bytes, not 55. With the old boundary, malformed frames missing `radioSF`/`radioCR` could still pass the initial size check and then be parsed incorrectly.

This change tightens validation to match the documented fixed-width frame while preserving valid firmware behavior, including payloads with no trailing device name.

## Testing
Automated:
- `cd MeshCore && swift test`
- Result: 262 tests passed in 23 suites
- Added tests cover:
  - valid 57-byte `SelfInfo` payload with no device name
  - invalid truncated 55-byte `SelfInfo` payload rejected with parse failure

Manual on device:
- launched the app on an iPhone 16 Pro over USB from Xcode
- paired and connected successfully to a MeshCore device
- confirmed normal session startup, `selfInfo` reception, sync, and repeater interaction all still work

Relevant log proof from the successful on-device run:
```text
Received event: selfInfo(MeshCore.SelfInfo(... name: "RKE2847"))
MeshCore session started
Received event: deviceInfo(MeshCore.DeviceCapabilities(firmwareVersion: 10, ... version: "v1.14.0-9f1a3ea" ...))
Full sync complete
Connection complete - device ready
[CMD] <- REPEATER CLI_RESP from=88fcce4bf302 resp="v1.14.0-9f1a3ea (Build: 06-Mar-2026)"
```

That gives both sides of the validation: the new parser still accepts real firmware frames on hardware, and the new tests prove truncated frames are rejected.