### PR TITLE
Coalesce message auto-fetch polling

### DIFF
--- a/MeshCore/Sources/MeshCore/Session/MeshCoreSession.swift
+++ b/MeshCore/Sources/MeshCore/Session/MeshCoreSession.swift
@@ -97,7 +97,11 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     private var isRunning = false
     private var receiveTask: Task<Void, Never>?
     private var autoMessageFetchTask: Task<Void, Never>?
+    private var autoMessageDrainTask: Task<Void, Never>?
     private var isAutoFetchingMessages = false
+    private var autoMessageDrainRequested = false
+    private var isGetMessageInFlight = false
+    private var getMessageWaiters: [CheckedContinuation<MessageResult, Error>] = []
 
     // MARK: - Connection State
 
@@ -352,8 +356,11 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// Call this to disable the automatic fetching started by ``startAutoMessageFetching()``.
     public func stopAutoMessageFetching() {
         isAutoFetchingMessages = false
+        autoMessageDrainRequested = false
         autoMessageFetchTask?.cancel()
         autoMessageFetchTask = nil
+        autoMessageDrainTask?.cancel()
+        autoMessageDrainTask = nil
     }
 
     private func autoMessageFetchLoop() async {
@@ -361,15 +368,35 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
             guard isAutoFetchingMessages else { break }
 
             if case .messagesWaiting = event {
-                do {
-                    while isAutoFetchingMessages {
-                        let result = try await getMessage()
-                        if case .noMoreMessages = result { break }
-                        try await Task.sleep(for: .milliseconds(100))
-                    }
-                } catch {
-                    logger.debug("Auto message fetch error: \(error.localizedDescription)")
+                requestAutoMessageDrain()
+            }
+        }
+    }
+
+    private func requestAutoMessageDrain() {
+        autoMessageDrainRequested = true
+
+        guard autoMessageDrainTask == nil else { return }
+        autoMessageDrainTask = Task { [weak self] in
+            guard let self else { return }
+            await self.runAutoMessageDrainLoop()
+        }
+    }
+
+    private func runAutoMessageDrainLoop() async {
+        defer { autoMessageDrainTask = nil }
+
+        while isAutoFetchingMessages, autoMessageDrainRequested, !Task.isCancelled {
+            autoMessageDrainRequested = false
+
+            do {
+                while isAutoFetchingMessages, !Task.isCancelled {
+                    let result = try await getMessage()
+                    if case .noMoreMessages = result { break }
+                    try await Task.sleep(for: .milliseconds(100))
                 }
+            } catch {
+                logger.debug("Auto message fetch error: \(error.localizedDescription)")
             }
         }
     }
@@ -1535,6 +1562,26 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     ///            or indication that no more messages are waiting.
     /// - Throws: ``MeshCoreError`` if the fetch fails.
     public func getMessage(timeout: TimeInterval? = nil) async throws -> MessageResult {
+        if isGetMessageInFlight {
+            return try await withCheckedThrowingContinuation { continuation in
+                getMessageWaiters.append(continuation)
+            }
+        }
+
+        isGetMessageInFlight = true
+        defer { isGetMessageInFlight = false }
+
+        do {
+            let result = try await performGetMessage(timeout: timeout)
+            finishGetMessageWaiters(with: .success(result))
+            return result
+        } catch {
+            finishGetMessageWaiters(with: .failure(error))
+            throw error
+        }
+    }
+
+    private func performGetMessage(timeout: TimeInterval? = nil) async throws -> MessageResult {
         let timeoutSeconds = timeout ?? configuration.defaultTimeout
 
         let stream = await dispatcher.subscribe { event in
@@ -1585,6 +1632,20 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
             }
 
             return result
+        }
+    }
+
+    private func finishGetMessageWaiters(with result: Result<MessageResult, Error>) {
+        let waiters = getMessageWaiters
+        getMessageWaiters.removeAll(keepingCapacity: false)
+
+        for waiter in waiters {
+            switch result {
+            case .success(let messageResult):
+                waiter.resume(returning: messageResult)
+            case .failure(let error):
+                waiter.resume(throwing: error)
+            }
         }
     }
 

--- a/MeshCore/Tests/MeshCoreTests/Session/AutoMessageFetchTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Session/AutoMessageFetchTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Testing
+@testable import MeshCore
+
+@Suite("MeshCoreSession auto message fetch")
+struct AutoMessageFetchTests {
+    @Test("concurrent getMessage calls share one wire request")
+    func concurrentGetMessageSingleFlight() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+        try await startSession(session, transport: transport)
+
+        let firstTask = Task { try await session.getMessage(timeout: 0.2) }
+        let secondTask = Task { try await session.getMessage(timeout: 0.2) }
+
+        try await waitUntil("getMessage command should be sent once") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(Data([ResponseCode.noMoreMessages.rawValue]))
+
+        let first = try await firstTask.value
+        let second = try await secondTask.value
+
+        assertNoMoreMessages(first)
+        assertNoMoreMessages(second)
+        #expect(await transport.sentData.count == 1)
+    }
+
+    @Test("auto-fetch coalesces repeated messagesWaiting notifications")
+    func autoFetchCoalescesRepeatedMessagesWaiting() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+        try await startSession(session, transport: transport)
+        await session.startAutoMessageFetching()
+
+        let waitingPacket = Data([ResponseCode.messagesWaiting.rawValue])
+        await transport.simulateReceive(waitingPacket)
+        await transport.simulateReceive(waitingPacket)
+        await transport.simulateReceive(waitingPacket)
+
+        try await waitUntil("first drain poll should be sent") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(Data([ResponseCode.noMoreMessages.rawValue]))
+        try? await Task.sleep(for: .milliseconds(50))
+
+        let sentCount = await transport.sentData.count
+        #expect(sentCount >= 1)
+        #expect(sentCount <= 2)
+
+        if sentCount == 2 {
+            await transport.simulateReceive(Data([ResponseCode.noMoreMessages.rawValue]))
+            try? await Task.sleep(for: .milliseconds(20))
+            #expect(await transport.sentData.count == 2)
+        }
+
+        await session.stopAutoMessageFetching()
+    }
+
+    @Test("manual getMessage shares in-flight auto-fetch poll")
+    func manualGetMessageSharesAutoFetchPoll() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+        try await startSession(session, transport: transport)
+        await session.startAutoMessageFetching()
+
+        await transport.simulateReceive(Data([ResponseCode.messagesWaiting.rawValue]))
+
+        try await waitUntil("auto-fetch should issue the first poll") {
+            await transport.sentData.count == 1
+        }
+
+        let manualPoll = Task { try await session.getMessage(timeout: 0.2) }
+        try? await Task.sleep(for: .milliseconds(20))
+
+        #expect(await transport.sentData.count == 1)
+
+        await transport.simulateReceive(Data([ResponseCode.noMoreMessages.rawValue]))
+
+        let result = try await manualPoll.value
+        assertNoMoreMessages(result)
+        #expect(await transport.sentData.count == 1)
+        await session.stopAutoMessageFetching()
+    }
+
+    private func startSession(_ session: MeshCoreSession, transport: MockTransport) async throws {
+        let startTask = Task { try await session.start() }
+
+        try await waitUntil("appStart command should be sent") {
+            await transport.sentData.count >= 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+        await transport.clearSentData()
+    }
+
+    private func waitUntil(
+        _ description: String,
+        timeout: Duration = .milliseconds(300),
+        pollInterval: Duration = .milliseconds(10),
+        condition: @escaping @Sendable () async -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+
+        while clock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: pollInterval)
+        }
+
+        Issue.record("Timed out waiting: \(description)")
+        throw MeshCoreError.timeout
+    }
+
+    private func makeSelfInfoPacket() -> Data {
+        var payload = Data([ResponseCode.selfInfo.rawValue])
+        payload.append(0x01)  // advType
+        payload.append(UInt8(bitPattern: Int8(20)))  // txPower
+        payload.append(UInt8(bitPattern: Int8(22)))  // maxTxPower
+        payload.append(Data(repeating: 0xAA, count: 32))  // publicKey
+        payload.append(contentsOf: withUnsafeBytes(of: Int32(0).littleEndian) { Data($0) })  // lat
+        payload.append(contentsOf: withUnsafeBytes(of: Int32(0).littleEndian) { Data($0) })  // lon
+        payload.append(0x00)  // multiAcks
+        payload.append(0x00)  // adv policy
+        payload.append(0x00)  // telemetry mode
+        payload.append(0x01)  // manual add
+        payload.append(contentsOf: withUnsafeBytes(of: UInt32(910_525).littleEndian) { Data($0) })  // freq
+        payload.append(contentsOf: withUnsafeBytes(of: UInt32(62_500).littleEndian) { Data($0) })  // bw
+        payload.append(0x07)  // sf
+        payload.append(0x05)  // cr
+        payload.append("TestNode".data(using: .utf8)!)
+        return payload
+    }
+
+    private func assertNoMoreMessages(_ result: MessageResult) {
+        guard case .noMoreMessages = result else {
+            Issue.record("Expected .noMoreMessages, got \(result)")
+            return
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make `MeshCoreSession.getMessage()` single-flight so overlapping callers share one wire request
- coalesce repeated `messagesWaiting` notifications into a single auto-fetch drain task
- cancel in-flight auto-fetch work cleanly when stopping message polling
- add focused tests for concurrent `getMessage()`, coalesced auto-fetch wakeups, and sharing between manual and auto-fetch polling

## Why this is the correct fix
The previously observed on-device failure mode was repeated `CMD_GET_MESSAGE` traffic after message/CLI activity, followed by long runs of `noMoreMessages`. That pattern can happen when multiple callers or repeated `messagesWaiting` events each start their own drain loop.

This change fixes the coordination point instead of adding timing hacks:
- only one `getMessage()` request is allowed on the wire at a time
- repeated `messagesWaiting` while a drain is active are collapsed into at most one follow-up drain pass
- manual and automatic message fetch paths share the same in-flight request

That preserves correctness while removing the redundant BLE chatter that was degrading responsiveness and battery behavior.

## Testing
### Automated
- `cd MeshCore && swift test`
- Result: 263 tests passed in 24 suites

### On-device validation
Launched the app on an iPhone 16 Pro, connected to the MeshCore device over BLE, and verified successful reconnect/session startup, sync, and interaction.

Relevant log evidence from the iPhone run:
- iOS auto-reconnect completed and the MeshCore session rebuilt successfully
- message sync performed a single poll and stopped cleanly:
  - `[Sync] State → .syncing(.messages)`
  - `[BLE] send: 1 bytes`
  - `Received event: noMoreMessages`
  - `[Sync] Phase end: messages - 0 polled`
- after `Resuming message notifications (sync complete)` and `[Sync] Starting auto-fetch for device 1346332E`, the earlier repeated `getMessage` / `noMoreMessages` loop was no longer present in the follow-on logs
- the session remained healthy after that point, including successful trace traffic:
  - `Received event: traceData(...)`
  - `Received trace data: tag=1302212448, hops=2`
