### PR TITLE
Stabilize BLE session reconnect handling

### DIFF
--- a/MC1Services/Sources/MC1Services/ConnectionManager+BLE.swift
+++ b/MC1Services/Sources/MC1Services/ConnectionManager+BLE.swift
@@ -244,6 +244,11 @@ extension ConnectionManager {
         guard connectionIntent.wantsConnection,
               let deviceID = lastConnectedDeviceID else { return }
 
+        if activeReconnectDeviceID == deviceID {
+            logger.info("[BLE] Skipping foreground reconnect: reconnect/session rebuild already in progress for \(deviceID.uuidString.prefix(8))")
+            return
+        }
+
         // Check actual BLE state - if connected at BLE level, no action needed
         let bleConnected = await stateMachine.isConnected
         if bleConnected {

--- a/MC1Services/Sources/MC1Services/ConnectionManager+BLE.swift
+++ b/MC1Services/Sources/MC1Services/ConnectionManager+BLE.swift
@@ -85,11 +85,15 @@ extension ConnectionManager {
             return false
         }
 
+        // Adoption is only valid from an idle BLE state machine. If restoration or another
+        // discovery chain is already in progress, let that flow own the reconnect.
+        let blePhase = await stateMachine.currentPhaseName
+        guard blePhase == "idle" else { return false }
+
         // Avoid doing teardown/UI transitions when there is no system-level link.
         guard await stateMachine.isDeviceConnectedToSystem(deviceID) else { return false }
 
         let bleState = await stateMachine.centralManagerStateName
-        let blePhase = await stateMachine.currentPhaseName
         let blePeripheralState = await stateMachine.currentPeripheralState ?? "none"
         logger.warning(
             "[BLE] \(context): device appears system-connected while disconnected; attempting adoption - " +

--- a/MC1Services/Sources/MC1Services/ConnectionManager+Lifecycle.swift
+++ b/MC1Services/Sources/MC1Services/ConnectionManager+Lifecycle.swift
@@ -2,6 +2,13 @@ import Foundation
 import MeshCore
 
 extension ConnectionManager {
+    var activeConnectionAttemptDeviceID: UUID? {
+        connectingDeviceID ?? sessionRebuildDeviceID ?? reconnectionCoordinator.reconnectingDeviceID
+    }
+
+    var activeReconnectDeviceID: UUID? {
+        sessionRebuildDeviceID ?? reconnectionCoordinator.reconnectingDeviceID
+    }
 
     // MARK: - App Lifecycle
 
@@ -264,9 +271,17 @@ extension ConnectionManager {
             throw BLEError.connectionFailed("Connection blocked by circuit breaker (cooling down)")
         }
 
+        if activeReconnectDeviceID == deviceID {
+            connectionIntent = .wantsConnection(forceFullSync: forceFullSync)
+            persistIntent()
+            reconnectionCoordinator.restartTimeout(deviceID: deviceID)
+            logger.info("[BLE] Reconnect already in progress for \(deviceID.uuidString.prefix(8)), deferring duplicate connect request")
+            return
+        }
+
         // Prevent concurrent connection attempts
         if connectionState == .connecting {
-            let currentDeviceID = connectingDeviceID ?? reconnectionCoordinator.reconnectingDeviceID
+            let currentDeviceID = activeConnectionAttemptDeviceID
 
             if currentDeviceID == deviceID {
                 if connectingDeviceID == nil {

--- a/MC1Services/Sources/MC1Services/ConnectionManager+Session.swift
+++ b/MC1Services/Sources/MC1Services/ConnectionManager+Session.swift
@@ -60,7 +60,7 @@ extension ConnectionManager: BLEReconnectionDelegate {
         self.session = newSession
 
         do {
-            try await newSession.start()
+            try await newSession.start(reconnectingAttempt: 1)
         } catch {
             logger.warning("[BLE] rebuildSession: session.start() failed: \(error.localizedDescription)")
             throw error

--- a/MC1Services/Sources/MC1Services/ConnectionManager+Session.swift
+++ b/MC1Services/Sources/MC1Services/ConnectionManager+Session.swift
@@ -51,6 +51,12 @@ extension ConnectionManager: BLEReconnectionDelegate {
     func rebuildSession(deviceID: UUID) async throws {
         logger.info("[BLE] Rebuilding session for auto-reconnect: \(deviceID.uuidString.prefix(8))")
         let expectedGeneration = reconnectionCoordinator.reconnectGeneration
+        sessionRebuildDeviceID = deviceID
+        defer {
+            if sessionRebuildDeviceID == deviceID {
+                sessionRebuildDeviceID = nil
+            }
+        }
 
         // Stop any existing session to prevent multiple receive loops racing for transport data
         await session?.stop()

--- a/MC1Services/Sources/MC1Services/ConnectionManager.swift
+++ b/MC1Services/Sources/MC1Services/ConnectionManager.swift
@@ -653,6 +653,16 @@ public final class ConnectionManager {
                           self.connectionState == .disconnected,
                           let deviceID = self.lastConnectedDeviceID else { return }
 
+                    let blePhase = await self.stateMachine.currentPhaseName
+                    let bleConnectedDeviceID = await self.stateMachine.connectedDeviceID
+                    if blePhase != "idle" || bleConnectedDeviceID == deviceID {
+                        self.logger.info(
+                            "[BLE] Bluetooth powered on: BLE already owns reconnect flow for \(deviceID.uuidString.prefix(8)) " +
+                            "(phase: \(blePhase), bleConnectedDevice: \(bleConnectedDeviceID?.uuidString.prefix(8) ?? "none"))"
+                        )
+                        return
+                    }
+
                     if self.activeReconnectDeviceID == deviceID {
                         self.logger.info("[BLE] Bluetooth powered on: reconnect/session rebuild already in progress for \(deviceID.uuidString.prefix(8))")
                         return

--- a/MC1Services/Sources/MC1Services/ConnectionManager.swift
+++ b/MC1Services/Sources/MC1Services/ConnectionManager.swift
@@ -219,6 +219,10 @@ public final class ConnectionManager {
     /// Nil during auto-reconnect (tracked by reconnectionCoordinator.reconnectingDeviceID instead).
     var connectingDeviceID: UUID?
 
+    /// The device whose MeshCore session is currently being rebuilt after a BLE auto-reconnect.
+    /// Used to suppress duplicate reconnect attempts while session startup is still in flight.
+    var sessionRebuildDeviceID: UUID?
+
     // MARK: - Callbacks
 
     /// Called when connection is ready and services are available.
@@ -649,6 +653,11 @@ public final class ConnectionManager {
                           self.connectionState == .disconnected,
                           let deviceID = self.lastConnectedDeviceID else { return }
 
+                    if self.activeReconnectDeviceID == deviceID {
+                        self.logger.info("[BLE] Bluetooth powered on: reconnect/session rebuild already in progress for \(deviceID.uuidString.prefix(8))")
+                        return
+                    }
+
                     self.logger.info("[BLE] Bluetooth powered on: attempting reconnection to \(deviceID.uuidString.prefix(8))")
                     try? await self.connect(to: deviceID)
                 }
@@ -857,7 +866,8 @@ public final class ConnectionManager {
         connectionState: ConnectionState? = nil,
         currentTransportType: TransportType?? = nil,
         connectionIntent: ConnectionIntent? = nil,
-        connectingDeviceID: UUID?? = nil
+        connectingDeviceID: UUID?? = nil,
+        sessionRebuildDeviceID: UUID?? = nil
     ) {
         suppressInvariantChecks = true
         defer { suppressInvariantChecks = false }
@@ -873,6 +883,9 @@ public final class ConnectionManager {
         }
         if let deviceID = connectingDeviceID {
             self.connectingDeviceID = deviceID
+        }
+        if let deviceID = sessionRebuildDeviceID {
+            self.sessionRebuildDeviceID = deviceID
         }
     }
     #endif

--- a/MC1Services/Tests/MC1ServicesTests/ConnectionManagerBLEHealthTests.swift
+++ b/MC1Services/Tests/MC1ServicesTests/ConnectionManagerBLEHealthTests.swift
@@ -101,6 +101,28 @@ struct ConnectionManagerBLEHealthTests {
         #expect(manager.connectionState == .connecting)
     }
 
+    @Test("skips reconnect while session rebuild is in progress")
+    func skipsWhenSessionRebuildInProgress() async throws {
+        let (manager, mock) = try ConnectionManager.createForTesting()
+        let deviceID = UUID()
+
+        await mock.setStubbedIsConnected(false)
+        await mock.setStubbedIsAutoReconnecting(false)
+
+        manager.setTestState(
+            connectionState: .disconnected,
+            currentTransportType: .bluetooth,
+            connectionIntent: .wantsConnection(),
+            sessionRebuildDeviceID: deviceID
+        )
+        manager.testLastConnectedDeviceID = deviceID
+
+        await manager.checkBLEConnectionHealth()
+
+        #expect(manager.connectionState == .disconnected)
+        #expect(manager.sessionRebuildDeviceID == deviceID)
+    }
+
     @Test("health check skips reconnection when Bluetooth is powered off")
     func healthCheckSkipsReconnectionWhenPoweredOff() async throws {
         let (manager, mock) = try ConnectionManager.createForTesting()

--- a/MC1Services/Tests/MC1ServicesTests/ConnectionManagerBLEHealthTests.swift
+++ b/MC1Services/Tests/MC1ServicesTests/ConnectionManagerBLEHealthTests.swift
@@ -123,6 +123,29 @@ struct ConnectionManagerBLEHealthTests {
         #expect(manager.sessionRebuildDeviceID == deviceID)
     }
 
+    @Test("health check does not attempt adoption while BLE restoration is already in progress")
+    func healthCheckSkipsAdoptionDuringRestoration() async throws {
+        let (manager, mock) = try ConnectionManager.createForTesting()
+        let deviceID = UUID()
+
+        await mock.setStubbedIsConnected(false)
+        await mock.setStubbedIsAutoReconnecting(false)
+        await mock.setStubbedCurrentPhaseName("restoringState")
+        await mock.setStubbedIsDeviceConnectedToSystem(true)
+
+        manager.setTestState(
+            connectionState: .disconnected,
+            currentTransportType: .bluetooth,
+            connectionIntent: .wantsConnection()
+        )
+        manager.testLastConnectedDeviceID = deviceID
+
+        await manager.checkBLEConnectionHealth()
+
+        let adoptionCalls = await mock.startAdoptingSystemConnectedPeripheralCalls
+        #expect(adoptionCalls.isEmpty)
+    }
+
     @Test("health check skips reconnection when Bluetooth is powered off")
     func healthCheckSkipsReconnectionWhenPoweredOff() async throws {
         let (manager, mock) = try ConnectionManager.createForTesting()

--- a/MC1Services/Tests/MC1ServicesTests/ConnectionManagerSessionTests.swift
+++ b/MC1Services/Tests/MC1ServicesTests/ConnectionManagerSessionTests.swift
@@ -67,6 +67,37 @@ struct ConnectionManagerSessionTests {
         #expect(result)
     }
 
+    @Test("activeConnectionAttemptDeviceID prefers session rebuild device")
+    func activeConnectionAttemptDeviceIDPrefersSessionRebuildDevice() throws {
+        let (manager, _) = try ConnectionManager.createForTesting()
+        let deviceID = UUID()
+
+        manager.setTestState(sessionRebuildDeviceID: deviceID)
+
+        #expect(manager.activeConnectionAttemptDeviceID == deviceID)
+        #expect(manager.activeReconnectDeviceID == deviceID)
+    }
+
+    @Test("connect to same device returns early while session rebuild is in progress")
+    func connectToSameDeviceReturnsEarlyDuringSessionRebuild() async throws {
+        let (manager, _) = try ConnectionManager.createForTesting()
+        let deviceID = UUID()
+
+        manager.testLastConnectedDeviceID = deviceID
+        manager.setTestState(
+            connectionState: .disconnected,
+            currentTransportType: .bluetooth,
+            connectionIntent: .wantsConnection(),
+            sessionRebuildDeviceID: deviceID
+        )
+
+        try await manager.connect(to: deviceID)
+
+        #expect(manager.connectionState == .disconnected)
+        #expect(manager.sessionRebuildDeviceID == deviceID)
+        #expect(manager.connectionIntent == .wantsConnection())
+    }
+
     // MARK: - handleReconnectionFailure Tests
 
     @Test("handleReconnectionFailure clears state and sets disconnected")

--- a/MC1Services/Tests/MC1ServicesTests/Mocks/MockBLEStateMachine.swift
+++ b/MC1Services/Tests/MC1ServicesTests/Mocks/MockBLEStateMachine.swift
@@ -194,4 +194,12 @@ extension MockBLEStateMachine {
     func setStubbedDidStartAdoptingSystemConnectedPeripheral(_ value: Bool) {
         stubbedDidStartAdoptingSystemConnectedPeripheral = value
     }
+
+    func setStubbedCurrentPhaseName(_ value: String) {
+        stubbedCurrentPhaseName = value
+    }
+
+    func setStubbedConnectedDeviceID(_ value: UUID?) {
+        stubbedConnectedDeviceID = value
+    }
 }

--- a/MeshCore/Sources/MeshCore/Session/MeshCoreSession.swift
+++ b/MeshCore/Sources/MeshCore/Session/MeshCoreSession.swift
@@ -130,6 +130,7 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     }
 
     private func updateConnectionState(_ state: ConnectionState) {
+        logger.info("Session connection state -> \(String(describing: state))")
         _connectionState = state
         for continuation in connectionStateContinuations.values {
             continuation.yield(state)
@@ -169,9 +170,11 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// The session becomes ready for use after this method returns successfully.
     /// Subscribe to events via ``events()`` to receive incoming messages and notifications.
     ///
+    /// - Parameter reconnectingAttempt: When non-nil, publishes `.reconnecting(attempt:)`
+    ///   instead of `.connecting` before establishing the transport/session.
     /// - Throws: ``MeshTransportError`` if the transport connection fails.
     ///           ``MeshCoreError/timeout`` if the device doesn't respond to appStart.
-    public func start() async throws {
+    public func start(reconnectingAttempt: Int? = nil) async throws {
         // Guard against being called multiple times
         if isRunning {
             logger.warning("Session already running - skipping redundant start()")
@@ -179,7 +182,11 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
         }
 
         logger.info("Starting MeshCore session...")
-        updateConnectionState(.connecting)
+        if let reconnectingAttempt {
+            updateConnectionState(.reconnecting(attempt: max(1, reconnectingAttempt)))
+        } else {
+            updateConnectionState(.connecting)
+        }
         logger.info("Connecting via transport...")
         do {
             try await transport.connect()

--- a/MeshCore/Tests/MeshCoreTests/Session/ConnectionStateTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Session/ConnectionStateTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import MeshCore
+
+@Suite("MeshCoreSession connection state")
+struct ConnectionStateTests {
+    @Test("initial start emits connecting then connected")
+    func initialStartEmitsConnectingThenConnected() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "Test")
+        )
+
+        var iterator = await session.connectionState.makeAsyncIterator()
+        #expect(await iterator.next() == .disconnected)
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should have sent appStart") {
+            await transport.sentData.count >= 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        #expect(await iterator.next() == .connecting)
+        #expect(await iterator.next() == .connected)
+
+        await session.stop()
+    }
+
+    @Test("reconnect start emits reconnecting then connected")
+    func reconnectStartEmitsReconnectingThenConnected() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "Test")
+        )
+
+        var iterator = await session.connectionState.makeAsyncIterator()
+        #expect(await iterator.next() == .disconnected)
+
+        let startTask = Task {
+            try await session.start(reconnectingAttempt: 1)
+        }
+
+        try await waitUntil("transport should have sent appStart") {
+            await transport.sentData.count >= 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        #expect(await iterator.next() == .reconnecting(attempt: 1))
+        #expect(await iterator.next() == .connected)
+
+        await session.stop()
+    }
+
+    private func makeSelfInfoPacket(name: String = "TestNode") -> Data {
+        var payload = Data()
+        payload.append(0)
+        payload.append(0)
+        payload.append(0)
+        payload.append(Data(repeating: 0x01, count: 32))
+        payload.append(contentsOf: withUnsafeBytes(of: Int32(0).littleEndian) { Array($0) })
+        payload.append(contentsOf: withUnsafeBytes(of: Int32(0).littleEndian) { Array($0) })
+        payload.append(0)
+        payload.append(0)
+        payload.append(0)
+        payload.append(0)
+        payload.append(contentsOf: withUnsafeBytes(of: UInt32(915_000).littleEndian) { Array($0) })
+        payload.append(contentsOf: withUnsafeBytes(of: UInt32(125_000).littleEndian) { Array($0) })
+        payload.append(7)
+        payload.append(5)
+        payload.append(contentsOf: name.utf8)
+
+        var packet = Data([ResponseCode.selfInfo.rawValue])
+        packet.append(payload)
+        return packet
+    }
+}


### PR DESCRIPTION
## Summary
- emit `MeshCoreSession.ConnectionState.reconnecting(attempt:)` during session rebuilds
- add permanent session connection-state logging for reconnect observability
- prevent duplicate reconnect/adoption paths from interrupting a valid iOS BLE restoration flow

## Why this is correct
`MeshCoreSession` exposed a public `.reconnecting` state but never emitted it during real reconnects. In practice, iOS BLE state restoration and app-level reconnect code were also racing each other during recovery, which caused a valid auto-reconnect to be torn down by a second connect/adoption path.

This change makes the public API match the actual reconnect lifecycle and makes reconnect ownership single-flight during restoration:
- first/manual connects still emit `.connecting`
- session rebuilds after BLE restoration now emit `.reconnecting(attempt: 1)`
- adoption is limited to idle BLE state so it cannot interfere with restoration/discovery already in progress
- powered-on reconnect handling now defers when the BLE state machine already owns reconnect flow for the same device
- duplicate same-device reconnect requests are ignored while reconnect/session rebuild is already in flight

That behavior matches the observed on-device lifecycle:
- BLE restores a connected peripheral
- iOS auto-reconnect completes
- `ConnectionManager` rebuilds the MeshCore session on the already-connected transport
- the session emits `.reconnecting(attempt: 1)` and returns to `.connected`

## Testing
### Automated
- `cd MeshCore && swift test`
- `cd MC1Services && swift test`

Added/updated tests cover:
- fresh connect emits `.connecting -> .connected`
- reconnect rebuild emits `.reconnecting(attempt: 1) -> .connected`
- `getMessage()` single-flight/coalesced auto-fetch behavior remains covered from the earlier branch work
- health checks skip reconnect/adoption while session rebuild or BLE restoration is already in progress
- same-device reconnect requests are ignored while session rebuild owns the flow

### Manual on iPhone 16 Pro
Launched the app on an iPhone 16 Pro, connected to a MeshCore device over BLE, and exercised reconnect by power-cycling the device. The app successfully:
- restored the BLE peripheral
- rebuilt the MeshCore session
- completed sync
- resumed normal operation

Relevant log proof from the successful reconnect path:

```text
[BLE] State restoration callback: 1346332E, state: connected
[BLE] iOS auto-reconnect complete: 1346332E
[BLE] handleReconnectionComplete: device=1346332E
[BLE] Rebuilding session for auto-reconnect: 1346332E
Starting MeshCore session...
Session connection state -> reconnecting(attempt: 1)
Connecting via transport...
Already connected to device: 1346332E-84A5-338C-00C4-989AD123ED54
Session connection state -> connected
Received event: selfInfo(...)
MeshCore session started
Received event: deviceInfo(...)
Full sync complete
[BLE] iOS auto-reconnect: session ready, device: 1346332E
```

I also verified that later disconnect/reconnect behavior matched the manual test conditions: when the radio was turned off for around 5 seconds, reconnect recovered quickly; when it was left off for around 20 seconds, the app eventually fell back to disconnected UI and later recovered via watchdog reconnect. That behavior is consistent with deliberate device power loss rather than the earlier app-side reconnect race.
