### PR TITLE
Reduce RX log prune work on the ingest path

### DIFF
--- a/MC1Services/Sources/MC1Services/Services/PersistenceStore+Diagnostics.swift
+++ b/MC1Services/Sources/MC1Services/Services/PersistenceStore+Diagnostics.swift
@@ -129,6 +129,7 @@ extension PersistenceStore {
         )
         modelContext.insert(entry)
         try modelContext.save()
+        rxLogEntryCountsByDevice[dto.deviceID, default: 0] += 1
     }
 
     /// Fetch RX log entries for a device, most recent first.
@@ -152,10 +153,17 @@ extension PersistenceStore {
         return try modelContext.fetchCount(descriptor)
     }
 
-    /// Delete oldest entries if count exceeds limit.
-    public func pruneRxLogEntries(deviceID: UUID, keepCount: Int = 1000) throws {
-        let count = try countRxLogEntries(deviceID: deviceID)
-        guard count > keepCount else { return }
+    /// Delete oldest entries once the log materially exceeds the retention cap.
+    ///
+    /// This avoids repeated count/fetch/delete maintenance on every RX packet while keeping
+    /// retention bounded to `keepCount + pruneThreshold` entries between prune passes.
+    public func pruneRxLogEntries(
+        deviceID: UUID,
+        keepCount: Int = 1000,
+        pruneThreshold: Int = 100
+    ) throws {
+        let count = try cachedRxLogEntryCount(deviceID: deviceID)
+        guard count > keepCount + pruneThreshold else { return }
 
         let deleteCount = count - keepCount
         let targetDeviceID = deviceID
@@ -171,6 +179,7 @@ extension PersistenceStore {
             modelContext.delete(entry)
         }
         try modelContext.save()
+        rxLogEntryCountsByDevice[deviceID] = keepCount
     }
 
     /// Clear all RX log entries for a device.
@@ -184,6 +193,17 @@ extension PersistenceStore {
             modelContext.delete(entry)
         }
         try modelContext.save()
+        rxLogEntryCountsByDevice[deviceID] = 0
+    }
+
+    private func cachedRxLogEntryCount(deviceID: UUID) throws -> Int {
+        if let cached = rxLogEntryCountsByDevice[deviceID] {
+            return cached
+        }
+
+        let count = try countRxLogEntries(deviceID: deviceID)
+        rxLogEntryCountsByDevice[deviceID] = count
+        return count
     }
 
     /// Find RxLogEntry matching an incoming message for path correlation.

--- a/MC1Services/Sources/MC1Services/Services/PersistenceStore.swift
+++ b/MC1Services/Sources/MC1Services/Services/PersistenceStore.swift
@@ -36,6 +36,7 @@ extension PersistenceStoreError: LocalizedError {
 /// Provides per-device data isolation and thread-safe access.
 @ModelActor
 public actor PersistenceStore: PersistenceStoreProtocol {
+    var rxLogEntryCountsByDevice: [UUID: Int] = [:]
 
     /// Shared schema for MeshCore One models
     public static let schema = Schema([

--- a/MC1Services/Tests/MC1ServicesTests/PersistenceStoreTests.swift
+++ b/MC1Services/Tests/MC1ServicesTests/PersistenceStoreTests.swift
@@ -1044,6 +1044,62 @@ struct PersistenceStoreTests {
         #expect(entries.first?.senderTimestamp == 1703123456)
     }
 
+    @Test("RX log prune is deferred until threshold is exceeded")
+    func rxLogPruneDefersUntilThresholdExceeded() async throws {
+        let store = try await createTestStore()
+        let device = createTestDevice()
+        try await store.saveDevice(device)
+
+        for index in 0..<1_100 {
+            let dto = createTestRxLogEntryDTO(
+                deviceID: device.id,
+                senderTimestamp: UInt32(index)
+            )
+            try await store.saveRxLogEntry(dto)
+            try await store.pruneRxLogEntries(deviceID: device.id)
+        }
+
+        let entriesBeforeThreshold = try await store.fetchRxLogEntries(deviceID: device.id, limit: 1_200)
+        #expect(entriesBeforeThreshold.count == 1_100)
+
+        let thresholdEntry = createTestRxLogEntryDTO(
+            deviceID: device.id,
+            senderTimestamp: UInt32(1_100)
+        )
+        try await store.saveRxLogEntry(thresholdEntry)
+        try await store.pruneRxLogEntries(deviceID: device.id)
+
+        let entriesAfterThreshold = try await store.fetchRxLogEntries(deviceID: device.id, limit: 1_200)
+        #expect(entriesAfterThreshold.count == 1_000)
+        #expect(entriesAfterThreshold.first?.senderTimestamp == 1_100)
+        #expect(entriesAfterThreshold.last?.senderTimestamp == 101)
+    }
+
+    @Test("Clearing RX log resets cached count for future pruning")
+    func clearRxLogResetsCachedCount() async throws {
+        let store = try await createTestStore()
+        let device = createTestDevice()
+        try await store.saveDevice(device)
+
+        for index in 0..<1_101 {
+            let dto = createTestRxLogEntryDTO(
+                deviceID: device.id,
+                senderTimestamp: UInt32(index)
+            )
+            try await store.saveRxLogEntry(dto)
+        }
+        try await store.pruneRxLogEntries(deviceID: device.id)
+        try await store.clearRxLogEntries(deviceID: device.id)
+
+        let replacement = createTestRxLogEntryDTO(deviceID: device.id, senderTimestamp: 42)
+        try await store.saveRxLogEntry(replacement)
+        try await store.pruneRxLogEntries(deviceID: device.id)
+
+        let entries = try await store.fetchRxLogEntries(deviceID: device.id)
+        #expect(entries.count == 1)
+        #expect(entries.first?.senderTimestamp == 42)
+    }
+
     // MARK: - Mute Tests
 
     @Test("Set contact muted")


### PR DESCRIPTION
## Summary
- make RX log pruning threshold-based instead of doing full retention maintenance on every packet
- cache per-device RX log counts inside `PersistenceStore`
- add persistence tests covering deferred prune behavior and cache reset after clearing logs

## Why this is the correct fix
`RxLogService` currently saves every incoming packet and immediately calls `pruneRxLogEntries(deviceID:)`. The old implementation always did a full count query and, once over the cap, an oldest-first fetch/delete/save cycle. That puts database maintenance directly on the RX ingest path.

This change keeps the retention policy but removes the repeated heavy work from the steady state:
- each saved RX entry increments an in-memory per-device count cache
- pruning only runs once the log grows past `keepCount + pruneThreshold`
- when prune runs, it trims back to `keepCount` and resets the cached count to match
- clearing RX logs also resets the cache so future pruning remains correct

This is the right tradeoff for this code path because:
- retention remains bounded
- the hot path becomes `save + cheap counter update` instead of `save + count query + possible delete pass`
- prune frequency drops from every packet to roughly every 100 packets beyond the cap
- the behavior is still deterministic and local to `PersistenceStore`, so the rest of the app does not need to change

## Testing
### Automated
- `cd MC1Services && swift test`

Added tests in `PersistenceStoreTests` for:
- prune is deferred until the configured threshold is exceeded
- pruning trims back to `keepCount`
- clearing RX logs resets the cached count correctly

### Manual on iPhone 16 Pro
Ran the app on an iPhone 16 Pro, connected successfully to the MeshCore device, completed reconnect/session startup, full sync, and processed post-sync `rxLogData` events without regression.

Relevant log excerpts from the device run after this change:

```text
Full sync complete
Resuming message notifications (sync complete)
[Sync] Starting auto-fetch for device 1346332E
Auto-fetch started for device 1346332E-84A5-338C-00C4-989AD123ED54
...
Received event: rxLogData(MeshCore.ParsedRxLogData(... payloadType: MeshCore.PayloadType.trace ...))
Received event: traceData(...)
Received trace data: tag=3286845316, hops=2
...
Received event: rxLogData(MeshCore.ParsedRxLogData(... payloadType: MeshCore.PayloadType.trace ...))
Received event: traceData(...)
Received trace data: tag=56972050, hops=2
```

This run is not a high-volume stress test, so it does not directly demonstrate reduced prune frequency in logs, but it does confirm that the retention-path change does not regress normal device operation or RX log handling.
