### PR TITLE
Validate packet inputs and fail closed on malformed responses

### DIFF
--- a/MeshCore/Sources/MeshCore/Protocol/PacketBuilder.swift
+++ b/MeshCore/Sources/MeshCore/Protocol/PacketBuilder.swift
@@ -37,6 +37,15 @@ public enum PacketBuilder: Sendable {
 
     /// Size of a public key in bytes.
     static let publicKeySize = 32
+    static let rawDataMaxPathBytes = 64
+    static let rawDataMaxPayloadBytes = 184
+
+    private static func encodePublicKey(_ publicKey: Data) -> Data {
+        if publicKey.count >= publicKeySize {
+            return publicKey.prefix(publicKeySize)
+        }
+        return publicKey + Data(repeating: 0, count: publicKeySize - publicKey.count)
+    }
 
     // MARK: - Device Commands
 
@@ -790,7 +799,7 @@ public enum PacketBuilder: Sendable {
     /// - Offset 1 (1 byte): Reserved `0x00`
     /// - Offset 2 (1 byte): Mode value (0, 1, or 2)
     public static func setPathHashMode(_ mode: UInt8) -> Data {
-        Data([CommandCode.setPathHashMode.rawValue, 0x00, mode])
+        Data([CommandCode.setPathHashMode.rawValue, 0x00, min(mode, 2)])
     }
 
     /// Builds a factoryReset command to wipe all settings and data from the device.
@@ -864,10 +873,10 @@ public enum PacketBuilder: Sendable {
     /// - Offset 2+N (M bytes): Payload
     public static func sendRawData(path: Data, payload: Data) -> Data {
         var data = Data([CommandCode.sendRawData.rawValue])
-        let clampedPath = path.prefix(255)
+        let clampedPath = path.prefix(rawDataMaxPathBytes)
         data.append(UInt8(clampedPath.count))
         data.append(clampedPath)
-        data.append(payload)
+        data.append(payload.prefix(rawDataMaxPayloadBytes))
         return data
     }
 
@@ -881,7 +890,7 @@ public enum PacketBuilder: Sendable {
     /// - Offset 1 (32 bytes): Full public key
     public static func hasConnection(publicKey: Data) -> Data {
         var data = Data([CommandCode.hasConnection.rawValue])
-        data.append(publicKey.prefix(publicKeySize))
+        data.append(encodePublicKey(publicKey))
         return data
     }
 
@@ -895,7 +904,7 @@ public enum PacketBuilder: Sendable {
     /// - Offset 1 (32 bytes): Full public key
     public static func getContactByKey(publicKey: Data) -> Data {
         var data = Data([CommandCode.getContactByKey.rawValue])
-        data.append(publicKey.prefix(publicKeySize))
+        data.append(encodePublicKey(publicKey))
         return data
     }
 
@@ -910,7 +919,7 @@ public enum PacketBuilder: Sendable {
     /// - Offset 2 (32 bytes): Full public key
     public static func getAdvertPath(publicKey: Data) -> Data {
         var data = Data([CommandCode.getAdvertPath.rawValue, 0x00])
-        data.append(publicKey.prefix(publicKeySize))
+        data.append(encodePublicKey(publicKey))
         return data
     }
 

--- a/MeshCore/Sources/MeshCore/Protocol/PacketParser.swift
+++ b/MeshCore/Sources/MeshCore/Protocol/PacketParser.swift
@@ -102,6 +102,12 @@ extension PacketParser {
                     reason: "Battery response too short: \(payload.count) < \(PacketSize.batteryMinimum)"
                 )
             }
+            if payload.count > PacketSize.batteryMinimum && payload.count < PacketSize.batteryExtended {
+                return .parseFailure(
+                    data: payload,
+                    reason: "Battery response has partial extended payload: \(payload.count) < \(PacketSize.batteryExtended)"
+                )
+            }
             let level = Int(payload.readUInt16LE(at: 0))
             var usedKB: Int?
             var totalKB: Int?

--- a/MeshCore/Sources/MeshCore/Protocol/Parsers.swift
+++ b/MeshCore/Sources/MeshCore/Protocol/Parsers.swift
@@ -150,6 +150,7 @@ public enum Parsers {
         let type = ContactType(rawValue: data[offset]) ?? .chat; offset += 1
         let flags = ContactFlags(rawValue: data[offset]); offset += 1
         let pathLen = data[offset]; offset += 1
+        guard pathLen == 0xFF || decodePathLen(pathLen) != nil else { return nil }
         let actualPathLen = (pathLen == 0xFF) ? 0 : (decodePathLen(pathLen)?.byteLength ?? 0)
         // Read full 64-byte path field, but only use first actualPathLen bytes
         let pathBytes = Data(data[offset..<offset+64])
@@ -188,6 +189,15 @@ public enum Parsers {
         /// - Parameter data: Raw contact data.
         /// - Returns: A `.contact` event or `.parseFailure`.
         static func parse(_ data: Data) -> MeshEvent {
+            if data.count >= PacketSize.contact {
+                let pathLen = data[34]
+                if pathLen != 0xFF && decodePathLen(pathLen) == nil {
+                    return .parseFailure(
+                        data: data,
+                        reason: "Contact response uses reserved path length encoding: 0x\(String(format: "%02X", pathLen))"
+                    )
+                }
+            }
             guard let contact = parseContactData(data) else {
                 return .parseFailure(
                     data: data,
@@ -296,6 +306,13 @@ public enum Parsers {
             var model: String?
             var version: String?
 
+            if fwVer >= 3 && data.count < PacketSize.deviceInfoV3Full {
+                return .parseFailure(
+                    data: data,
+                    reason: "DeviceInfo v\(fwVer) response too short: \(data.count) < \(PacketSize.deviceInfoV3Full)"
+                )
+            }
+
             // v3+ format: fwBuild=12, model=40, version=20 bytes
             if fwVer >= 3 && data.count >= PacketSize.deviceInfoV3Full {
                 maxContacts = Int(data[offset]) * 2  /// Stored as count/2 in firmware.
@@ -320,14 +337,26 @@ public enum Parsers {
 
             // v9+: client_repeat byte after version string
             var clientRepeat = false
-            if fwVer >= 9 && data.count > offset {
+            if fwVer >= 9 {
+                guard data.count > offset else {
+                    return .parseFailure(
+                        data: data,
+                        reason: "DeviceInfo v\(fwVer) missing client_repeat byte"
+                    )
+                }
                 clientRepeat = data[offset] != 0
                 offset += 1
             }
 
             // v10+: path_hash_mode byte after client_repeat
             var pathHashMode: UInt8 = 0
-            if fwVer >= 10 && data.count > offset {
+            if fwVer >= 10 {
+                guard data.count > offset else {
+                    return .parseFailure(
+                        data: data,
+                        reason: "DeviceInfo v\(fwVer) missing pathHashMode byte"
+                    )
+                }
                 pathHashMode = data[offset]
             }
 
@@ -391,7 +420,13 @@ public enum Parsers {
             let timestamp = Date(timeIntervalSince1970: TimeInterval(data.readUInt32LE(at: offset))); offset += 4
 
             var signature: Data?
-            if txtType == 2 && data.count >= offset + 4 {
+            if txtType == 2 {
+                guard data.count >= offset + 4 else {
+                    return .parseFailure(
+                        data: data,
+                        reason: "ContactMessage signature truncated: \(data.count) < \(offset + 4)"
+                    )
+                }
                 signature = Data(data[offset..<offset+4]); offset += 4
             }
 
@@ -1324,7 +1359,19 @@ public enum Parsers {
 
             let timestamp = data.readUInt32LE(at: 0)
             let pathLen = data[4]
-            let byteLen = decodePathLen(pathLen)?.byteLength ?? 0
+            guard let decoded = decodePathLen(pathLen) else {
+                return .parseFailure(
+                    data: data,
+                    reason: "AdvertPathResponse uses reserved path length encoding: 0x\(String(format: "%02X", pathLen))"
+                )
+            }
+            let byteLen = decoded.byteLength
+            guard data.count >= 5 + byteLen else {
+                return .parseFailure(
+                    data: data,
+                    reason: "AdvertPathResponse path truncated: \(data.count) < \(5 + byteLen)"
+                )
+            }
             let path = Data(data.dropFirst(5).prefix(byteLen))
 
             return .advertPathResponse(MeshCore.AdvertPathResponse(

--- a/MeshCore/Sources/MeshCore/Session/MeshCoreSession.swift
+++ b/MeshCore/Sources/MeshCore/Session/MeshCoreSession.swift
@@ -720,6 +720,7 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Throws: ``MeshCoreError/timeout`` if the device doesn't respond.
     ///           ``MeshCoreError/deviceError(code:)`` if the device returns an error.
     public func getContact(publicKey: Data) async throws -> MeshContact? {
+        try requireFullPublicKey(publicKey, operation: "getContact")
         let data = PacketBuilder.getContactByKey(publicKey: publicKey)
         return try await sendAndWait(data) { event in
             switch event {
@@ -873,8 +874,9 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Throws: ``MeshCoreError/timeout`` if no response within the timeout period.
     ///           ``MeshCoreError/invalidResponse`` if an unexpected response is received.
     public func requestStatus(from publicKey: Data) async throws -> StatusResponse {
+        try requireFullPublicKey(publicKey, operation: "requestStatus")
         // Serialize binary requests to prevent messageSent race conditions
-        try await binaryRequestSerializer.withSerialization { [self] in
+        return try await binaryRequestSerializer.withSerialization { [self] in
             try await performStatusRequest(from: publicKey)
         }
     }
@@ -998,6 +1000,7 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Returns: Information about the sent message.
     /// - Throws: ``MeshCoreError/timeout`` if the device doesn't respond.
     public func sendKeepAlive(to publicKey: Data, syncSince: UInt32) async throws -> MessageSentInfo {
+        try requireFullPublicKey(publicKey, operation: "sendKeepAlive")
         var syncSinceLE = syncSince.littleEndian
         let payload = withUnsafeBytes(of: &syncSinceLE) { Data($0) }
         let data = PacketBuilder.binaryRequest(to: publicKey, type: .keepAlive, payload: payload)
@@ -1386,6 +1389,7 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Parameter publicKey: The full 32-byte public key of the contact.
     /// - Throws: ``MeshCoreError/timeout`` or ``MeshCoreError/deviceError(code:)`` on failure.
     public func resetPath(publicKey: Data) async throws {
+        try requireFullPublicKey(publicKey, operation: "resetPath")
         try await sendSimpleCommand(PacketBuilder.resetPath(publicKey: publicKey))
     }
 
@@ -1394,6 +1398,7 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Parameter publicKey: The full 32-byte public key of the contact to remove.
     /// - Throws: ``MeshCoreError/timeout`` or ``MeshCoreError/deviceError(code:)`` on failure.
     public func removeContact(publicKey: Data) async throws {
+        try requireFullPublicKey(publicKey, operation: "removeContact")
         try await sendSimpleCommand(PacketBuilder.removeContact(publicKey: publicKey))
     }
 
@@ -1405,6 +1410,7 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Parameter publicKey: The full 32-byte public key of the contact to share.
     /// - Throws: ``MeshCoreError/timeout`` or ``MeshCoreError/deviceError(code:)`` on failure.
     public func shareContact(publicKey: Data) async throws {
+        try requireFullPublicKey(publicKey, operation: "shareContact")
         try await sendSimpleCommand(PacketBuilder.shareContact(publicKey: publicKey))
     }
 
@@ -1414,7 +1420,10 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Returns: A URI string encoding the contact information.
     /// - Throws: ``MeshCoreError/timeout`` if the device doesn't respond.
     public func exportContact(publicKey: Data? = nil) async throws -> String {
-        try await sendAndWait(PacketBuilder.exportContact(publicKey: publicKey)) { event in
+        if let publicKey {
+            try requireFullPublicKey(publicKey, operation: "exportContact")
+        }
+        return try await sendAndWait(PacketBuilder.exportContact(publicKey: publicKey)) { event in
             if case .contactURI(let uri) = event { return uri }
             return nil
         }
@@ -1819,6 +1828,9 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Parameter mode: Hash mode (0=1-byte, 1=2-byte, 2=3-byte hashes).
     /// - Throws: ``MeshCoreError/timeout`` or ``MeshCoreError/deviceError(code:)`` on failure.
     public func setPathHashMode(_ mode: UInt8) async throws {
+        guard mode <= 2 else {
+            throw MeshCoreError.invalidInput("Path hash mode must be 0, 1, or 2")
+        }
         try await sendSimpleCommand(PacketBuilder.setPathHashMode(mode))
     }
 
@@ -1870,8 +1882,9 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Throws: ``MeshCoreError/timeout`` if no response within timeout period.
     ///           ``MeshCoreError/invalidResponse`` if unexpected response received.
     public func requestTelemetry(from publicKey: Data) async throws -> TelemetryResponse {
+        try requireFullPublicKey(publicKey, operation: "requestTelemetry")
         // Serialize binary requests to prevent messageSent race conditions
-        try await binaryRequestSerializer.withSerialization { [self] in
+        return try await binaryRequestSerializer.withSerialization { [self] in
             try await performTelemetryRequest(from: publicKey)
         }
     }
@@ -1990,7 +2003,8 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Returns: MMA response containing aggregated statistics.
     /// - Throws: ``MeshCoreError/timeout`` if no response within timeout period.
     public func requestMMA(from publicKey: Data, start: Date, end: Date) async throws -> MMAResponse {
-        try await binaryRequestSerializer.withSerialization { [self] in
+        try requireFullPublicKey(publicKey, operation: "requestMMA")
+        return try await binaryRequestSerializer.withSerialization { [self] in
             try await performMMARequest(from: publicKey, start: start, end: end)
         }
     }
@@ -2073,7 +2087,8 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Returns: ACL response containing authorized public keys.
     /// - Throws: ``MeshCoreError/timeout`` if no response within timeout period.
     public func requestACL(from publicKey: Data) async throws -> ACLResponse {
-        try await binaryRequestSerializer.withSerialization { [self] in
+        try requireFullPublicKey(publicKey, operation: "requestACL")
+        return try await binaryRequestSerializer.withSerialization { [self] in
             try await performACLRequest(from: publicKey)
         }
     }
@@ -2579,6 +2594,12 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
             await pendingRequests.complete(tag: code, with: event)
         default:
             break
+        }
+    }
+
+    private func requireFullPublicKey(_ publicKey: Data, operation: String) throws {
+        guard publicKey.count == PacketBuilder.publicKeySize else {
+            throw MeshCoreError.invalidInput("Full \(PacketBuilder.publicKeySize)-byte public key required for \(operation)")
         }
     }
 }

--- a/MeshCore/Tests/MeshCoreTests/Protocol/NewCommandsTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Protocol/NewCommandsTests.swift
@@ -25,6 +25,18 @@ struct NewCommandsTests {
         #expect(packet.count == 3, "command + pathLen + payload")
     }
 
+    @Test("sendRawData clamps to firmware limits")
+    func sendRawDataClampsToFirmwareLimits() {
+        let path = Data(repeating: 0x11, count: 80)
+        let payload = Data(repeating: 0x22, count: 220)
+
+        let packet = PacketBuilder.sendRawData(path: path, payload: payload)
+
+        #expect(packet[1] == 64, "Path length should clamp to firmware 64-byte limit")
+        #expect(Data(packet[2..<66]) == Data(repeating: 0x11, count: 64), "Path bytes should be truncated to 64 bytes")
+        #expect(Data(packet[66...]) == Data(repeating: 0x22, count: 184), "Payload should be truncated to firmware 184-byte limit")
+    }
+
     @Test("hasConnection format")
     func hasConnectionFormat() {
         let pubkey = Data(repeating: 0xAA, count: 32)
@@ -34,6 +46,17 @@ struct NewCommandsTests {
         #expect(packet.count == 33, "1 + 32 bytes")
         #expect(packet[0] == 0x1C, "Command code")
         #expect(Data(packet[1...]) == pubkey, "Public key")
+    }
+
+    @Test("hasConnection pads short public key to protocol width")
+    func hasConnectionPadsShortPublicKey() {
+        let pubkey = Data(repeating: 0xAA, count: 31)
+
+        let packet = PacketBuilder.hasConnection(publicKey: pubkey)
+
+        #expect(packet.count == 33, "Packet should still contain a full 32-byte key field")
+        #expect(Data(packet[1..<32]) == Data(repeating: 0xAA, count: 31))
+        #expect(packet[32] == 0x00, "Short public keys should be zero-padded at the builder layer")
     }
 
     @Test("getContactByKey format")
@@ -47,6 +70,17 @@ struct NewCommandsTests {
         #expect(Data(packet[1...]) == pubkey, "Public key")
     }
 
+    @Test("getContactByKey pads short public key to protocol width")
+    func getContactByKeyPadsShortPublicKey() {
+        let pubkey = Data(repeating: 0xBB, count: 31)
+
+        let packet = PacketBuilder.getContactByKey(publicKey: pubkey)
+
+        #expect(packet.count == 33, "Packet should still contain a full 32-byte key field")
+        #expect(Data(packet[1..<32]) == Data(repeating: 0xBB, count: 31))
+        #expect(packet[32] == 0x00)
+    }
+
     @Test("getAdvertPath format")
     func getAdvertPathFormat() {
         let pubkey = Data(repeating: 0xCC, count: 32)
@@ -57,6 +91,17 @@ struct NewCommandsTests {
         #expect(packet[0] == 0x2A, "Command code")
         #expect(packet[1] == 0x00, "Reserved byte")
         #expect(Data(packet[2...]) == pubkey, "Public key")
+    }
+
+    @Test("getAdvertPath pads short public key to protocol width")
+    func getAdvertPathPadsShortPublicKey() {
+        let pubkey = Data(repeating: 0xCC, count: 31)
+
+        let packet = PacketBuilder.getAdvertPath(publicKey: pubkey)
+
+        #expect(packet.count == 34, "Packet should still contain reserved byte plus a full 32-byte key field")
+        #expect(Data(packet[2..<33]) == Data(repeating: 0xCC, count: 31))
+        #expect(packet[33] == 0x00)
     }
 
     @Test("getTuningParams format")
@@ -81,5 +126,13 @@ struct NewCommandsTests {
         #expect(packet[0] == 0x3D, "Command code should be setPathHashMode (0x3D)")
         #expect(packet[1] == 0x00, "Reserved byte at offset 1 should be 0x00")
         #expect(packet[2] == mode, "Mode byte at offset 2 should be \(mode) (\(label))")
+    }
+
+    @Test("setPathHashMode clamps reserved values to max supported mode")
+    func setPathHashModeClampsReservedValues() {
+        let packet = PacketBuilder.setPathHashMode(3)
+
+        #expect(packet.count == 3)
+        #expect(packet[2] == 2, "Reserved path hash modes should clamp to the max supported mode")
     }
 }

--- a/MeshCore/Tests/MeshCoreTests/Session/ConnectionStateTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Session/ConnectionStateTests.swift
@@ -60,6 +60,51 @@ struct ConnectionStateTests {
         await session.stop()
     }
 
+    @Test("getContact rejects short public key before sending")
+    func getContactRejectsShortPublicKey() async {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "Test")
+        )
+
+        await #expect(throws: MeshCoreError.self) {
+            _ = try await session.getContact(publicKey: Data(repeating: 0xAA, count: 31))
+        }
+
+        #expect(await transport.sentData.isEmpty)
+    }
+
+    @Test("requestStatus rejects short public key before sending")
+    func requestStatusRejectsShortPublicKey() async {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "Test")
+        )
+
+        await #expect(throws: MeshCoreError.self) {
+            _ = try await session.requestStatus(from: Data(repeating: 0xBB, count: 31))
+        }
+
+        #expect(await transport.sentData.isEmpty)
+    }
+
+    @Test("setPathHashMode rejects reserved mode before sending")
+    func setPathHashModeRejectsReservedMode() async {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "Test")
+        )
+
+        await #expect(throws: MeshCoreError.self) {
+            try await session.setPathHashMode(3)
+        }
+
+        #expect(await transport.sentData.isEmpty)
+    }
+
     private func makeSelfInfoPacket(name: String = "TestNode") -> Data {
         var payload = Data()
         payload.append(0)

--- a/MeshCore/Tests/MeshCoreTests/Validation/NewResponseParsingTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Validation/NewResponseParsingTests.swift
@@ -54,6 +54,23 @@ struct NewResponseParsingTests {
         }
     }
 
+    @Test("advertPathResponse rejects reserved path length encoding")
+    func advertPathResponseRejectsReservedPathLengthEncoding() {
+        var payload = Data()
+        payload.appendLittleEndian(UInt32(1704067200))
+        payload.append(0xC1)  // mode 3 (reserved), hop count 1
+        payload.append(0x11)
+
+        let event = Parsers.AdvertPathResponse.parse(payload)
+
+        guard case .parseFailure(_, let reason) = event else {
+            Issue.record("Expected parseFailure for reserved path length, got \(event)")
+            return
+        }
+
+        #expect(reason.contains("reserved path length encoding"))
+    }
+
     @Test("tuningParamsResponse parse")
     func tuningParamsResponseParse() {
         var payload = Data()

--- a/MeshCore/Tests/MeshCoreTests/Validation/ProtocolBugFixTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Validation/ProtocolBugFixTests.swift
@@ -213,6 +213,22 @@ struct ProtocolBugFixTests {
         #expect(status.receiveErrors == 0, "receiveErrors should default to 0 when not present")
     }
 
+    @Test("battery response rejects partial extended payload")
+    func batteryResponseRejectsPartialExtendedPayload() {
+        var packet = Data([ResponseCode.battery.rawValue])
+        packet.append(contentsOf: [0xE8, 0x03])  // 1000 mV
+        packet.append(contentsOf: [0x01, 0x02, 0x03])  // partial extended fields only
+
+        let event = PacketParser.parse(packet)
+
+        guard case .parseFailure(_, let reason) = event else {
+            Issue.record("Expected .parseFailure event, got \(event)")
+            return
+        }
+
+        #expect(reason.contains("partial extended payload"))
+    }
+
     @Test("statusResponse parseFromBinaryResponse 52 bytes parses rxAirtime")
     func statusResponseParseFromBinaryResponse52BytesParsesRxAirtime() {
         // 52 bytes: has rxAirtime but no receiveErrors

--- a/MeshCore/Tests/MeshCoreTests/Validation/RoundTripTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Validation/RoundTripTests.swift
@@ -59,6 +59,24 @@ struct RoundTripTests {
         #expect(abs(contact.longitude - (-122.4194)) <= 0.0001)
     }
 
+    @Test("Contact rejects reserved path length encoding")
+    func contactRejectsReservedPathLengthEncoding() {
+        var data = Data(repeating: 0, count: 147)
+        data.replaceSubrange(0..<32, with: Data(repeating: 0xAA, count: 32))
+        data[32] = 1
+        data[33] = 0
+        data[34] = 0xC1  // mode 3 (reserved), hop count 1
+
+        let event = Parsers.Contact.parse(data)
+
+        guard case .parseFailure(_, let reason) = event else {
+            Issue.record("Expected .parseFailure event, got \(event)")
+            return
+        }
+
+        #expect(reason.contains("reserved path length encoding"))
+    }
+
     // MARK: - SelfInfo Round-Trip
 
     @Test("SelfInfo round trip")
@@ -263,6 +281,27 @@ struct RoundTripTests {
         #expect(msg.pathLength == pathLen)
         #expect(msg.textType == txtType)
         #expect(msg.text == "Hello World")
+    }
+
+    @Test("ContactMessage rejects truncated signature payload")
+    func contactMessageRejectsTruncatedSignaturePayload() {
+        var data = Data()
+        data.append(UInt8(bitPattern: Int8(0)))
+        data.append(contentsOf: withUnsafeBytes(of: UInt16(0).littleEndian) { Data($0) })
+        data.append(Data([0x01, 0x23, 0x45, 0x67, 0x89, 0xAB]))
+        data.append(0x00)
+        data.append(0x02)  // signed text
+        data.append(contentsOf: withUnsafeBytes(of: UInt32(1704067200).littleEndian) { Data($0) })
+        data.append(Data([0xDE, 0xAD, 0xBE]))  // only 3 signature bytes, no text payload
+
+        let event = Parsers.ContactMessage.parse(data, version: .v3)
+
+        guard case .parseFailure(_, let reason) = event else {
+            Issue.record("Expected .parseFailure event, got \(event)")
+            return
+        }
+
+        #expect(reason.contains("signature truncated"))
     }
 
     @Test("ChannelMessage v3 round trip")
@@ -678,6 +717,28 @@ struct RoundTripTests {
         #expect(caps.blePin == blePin)
         #expect(caps.clientRepeat, "client_repeat should be true")
         #expect(caps.pathHashMode == 2, "pathHashMode should be 2 (3-byte hashes)")
+    }
+
+    @Test("DeviceInfo v10 rejects truncated payload before pathHashMode")
+    func deviceInfoV10RejectsTruncatedPayloadBeforePathHashMode() {
+        var data = Data()
+        data.append(10)  // fwVer
+        data.append(50)  // maxContacts
+        data.append(8)   // maxChannels
+        let blePin: UInt32 = 654321
+        data.append(contentsOf: withUnsafeBytes(of: blePin.littleEndian) { Data($0) })
+        data.append(Data(repeating: 0, count: 12 + 40 + 20))
+        data.append(1)   // client_repeat present
+        #expect(data.count == 80, "v10 payload missing pathHashMode byte should be truncated")
+
+        let event = Parsers.DeviceInfo.parse(data)
+
+        guard case .parseFailure(_, let reason) = event else {
+            Issue.record("Expected .parseFailure event, got \(event)")
+            return
+        }
+
+        #expect(reason.contains("missing pathHashMode byte"))
     }
 
     @Test("DeviceInfo v9 defaults pathHashMode to 0")


### PR DESCRIPTION
## Summary
- clamp `PacketBuilder.sendRawData` to current firmware path and payload limits
- keep public-key command packets fixed-width for `hasConnection`, `getContactByKey`, and `getAdvertPath`
- reject invalid public API inputs before sending for full-key request APIs and `setPathHashMode`
- fail closed on malformed battery, contact, advert-path, device-info, and signed contact-message responses
- add regression coverage in existing upstream test files only

## Rationale
This change tightens validation at the correct protocol boundaries.

At the low-level packet-construction layer, callers should not be able to build malformed command frames that firmware will reject or misinterpret. That is why the builder now enforces the current raw-data limits and always emits fixed-width public-key fields for commands whose wire format requires 32 bytes.

At the public session API layer, methods that already document a full 32-byte public key now reject invalid input up front with `MeshCoreError.invalidInput` instead of silently padding or truncating user input and sending a request anyway. `setPathHashMode(_:)` similarly rejects reserved mode values before sending.

On the receive side, malformed responses should fail closed rather than being partially parsed into invented or defaulted state. This PR makes that explicit for:
- partial extended battery payloads
- reserved path-length encodings in contact and advert-path responses
- truncated v10 device-info payloads missing required versioned fields
- truncated signed contact-message payloads

## Firmware Validation
I validated these client-side constraints against current `meshcore` firmware `main` behavior:
- `MAX_PATH_SIZE` is `64` and `MAX_PACKET_PAYLOAD` is `184` in `src/MeshCore.h`
- `docs/packet_format.md` documents path as up to `64` bytes and payload as up to `184` bytes
- `docs/packet_format.md` and `src/Packet.cpp` treat path-length mode `0b11` / `3` as reserved or unsupported
- firmware command and packet structures use fixed-width `PUB_KEY_SIZE == 32` byte public-key fields

That means the builder clamping and fixed-width encoding are matching the current firmware contract, not inventing a client-only policy.

## Why these layers
- `PacketBuilder` is the shared construction boundary for protocol-shaped packets
- `MeshCoreSession` is the right place for caller-facing input validation and clean errors
- `PacketParser` / `Parsers` are the right place to reject malformed incoming wire data

That split avoids pushing protocol-specific validation into the transport or send layer while still giving higher-level callers better errors.

## Validation
- `swift test --package-path MeshCore`

Result:
- `280` tests passed

## Test coverage added
- builder regression tests for raw-data clamping, fixed-width public-key encoding, and path-hash-mode clamping
- session tests that invalid short-key inputs and reserved path-hash-mode values are rejected before any send occurs
- parser tests for malformed battery, contact, advert-path, device-info, and signed contact-message payloads
