### PR TITLE
fix(meshcore): serialize companion commands

### DIFF
--- a/MeshCore/Sources/MeshCore/Session/MeshCoreSession.swift
+++ b/MeshCore/Sources/MeshCore/Session/MeshCoreSession.swift
@@ -83,6 +83,7 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     private let clock: any Clock<Duration>
     private let dispatcher = EventDispatcher()
     private let pendingRequests = PendingRequests()
+    private let companionCommandSerializer = CompanionCommandSerializer()
     private let binaryRequestSerializer = BinaryRequestSerializer()
 
     // State
@@ -475,37 +476,39 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
         matching predicate: @escaping @Sendable (MeshEvent) -> T?,
         timeout: TimeInterval? = nil
     ) async throws -> T {
-        let effectiveTimeout = timeout ?? configuration.defaultTimeout
+        try await companionCommandSerializer.withSerialization { [self] in
+            let effectiveTimeout = timeout ?? configuration.defaultTimeout
 
-        // Subscribe BEFORE sending to avoid race condition
-        let events = await dispatcher.subscribe()
+            // Subscribe BEFORE sending to avoid race condition
+            let events = await dispatcher.subscribe()
 
-        // Send after subscribing
-        try await transport.send(data)
+            // Send after subscribing
+            try await transport.send(data)
 
-        // Now wait for matching event
-        return try await withThrowingTaskGroup(of: T?.self) { group in
-            group.addTask {
-                for await event in events {
-                    if Task.isCancelled { return nil }
-                    if let result = predicate(event) {
-                        return result
+            // Now wait for matching event
+            return try await withThrowingTaskGroup(of: T?.self) { group in
+                group.addTask {
+                    for await event in events {
+                        if Task.isCancelled { return nil }
+                        if let result = predicate(event) {
+                            return result
+                        }
                     }
+                    return nil
                 }
-                return nil
-            }
 
-            group.addTask { [clock = self.clock] in
-                try await clock.sleep(for: .seconds(effectiveTimeout))
-                return nil
-            }
+                group.addTask { [clock = self.clock] in
+                    try await clock.sleep(for: .seconds(effectiveTimeout))
+                    return nil
+                }
 
-            if let result = try await group.next() ?? nil {
+                if let result = try await group.next() ?? nil {
+                    group.cancelAll()
+                    return result
+                }
                 group.cancelAll()
-                return result
+                throw MeshCoreError.timeout
             }
-            group.cancelAll()
-            throw MeshCoreError.timeout
         }
     }
 
@@ -523,41 +526,43 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
         matching successPredicate: @escaping @Sendable (MeshEvent) -> T?,
         timeout: TimeInterval? = nil
     ) async throws -> T {
-        let effectiveTimeout = timeout ?? configuration.defaultTimeout
+        try await companionCommandSerializer.withSerialization { [self] in
+            let effectiveTimeout = timeout ?? configuration.defaultTimeout
 
-        // Subscribe BEFORE sending to avoid race condition
-        let events = await dispatcher.subscribe()
+            // Subscribe BEFORE sending to avoid race condition
+            let events = await dispatcher.subscribe()
 
-        // Send after subscribing
-        try await transport.send(data)
+            // Send after subscribing
+            try await transport.send(data)
 
-        // Now wait for matching event
-        return try await withThrowingTaskGroup(of: T?.self) { group in
-            group.addTask {
-                for await event in events {
-                    if Task.isCancelled { return nil }
-                    // Check for error response first
-                    if case .error(let code) = event {
-                        throw MeshCoreError.deviceError(code: code ?? 0)
+            // Now wait for matching event
+            return try await withThrowingTaskGroup(of: T?.self) { group in
+                group.addTask {
+                    for await event in events {
+                        if Task.isCancelled { return nil }
+                        // Check for error response first
+                        if case .error(let code) = event {
+                            throw MeshCoreError.deviceError(code: code ?? 0)
+                        }
+                        if let result = successPredicate(event) {
+                            return result
+                        }
                     }
-                    if let result = successPredicate(event) {
-                        return result
-                    }
+                    return nil
                 }
-                return nil
-            }
 
-            group.addTask { [clock = self.clock] in
-                try await clock.sleep(for: .seconds(effectiveTimeout))
-                return nil
-            }
+                group.addTask { [clock = self.clock] in
+                    try await clock.sleep(for: .seconds(effectiveTimeout))
+                    return nil
+                }
 
-            if let result = try await group.next() ?? nil {
+                if let result = try await group.next() ?? nil {
+                    group.cancelAll()
+                    return result
+                }
                 group.cancelAll()
-                return result
+                throw MeshCoreError.timeout
             }
-            group.cancelAll()
-            throw MeshCoreError.timeout
         }
     }
 
@@ -615,57 +620,59 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Throws: ``MeshCoreError/timeout`` if the device doesn't respond.
     ///           ``MeshCoreError/deviceError(code:)`` if the device returns an error.
     public func getContacts(since lastModified: Date? = nil) async throws -> [MeshContact] {
-        let data = PacketBuilder.getContacts(since: lastModified)
-        let events = await dispatcher.subscribe()
-        try await transport.send(data)
+        let (contacts, modifiedDate): ([MeshContact], Date?) = try await companionCommandSerializer.withSerialization { [self] in
+            let data = PacketBuilder.getContacts(since: lastModified)
+            let events = await dispatcher.subscribe()
+            try await transport.send(data)
 
-        // Manual timeout pattern (not withTimeout) because:
-        // 1. Uses injected clock for testability
-        // 2. Throws MeshCoreError.timeout for consistency with other session methods
-        // 3. Defers contactManager mutations until after the task group
-        //    to avoid actor-isolation issues in the @Sendable closure.
-        let (contacts, modifiedDate): ([MeshContact], Date?) = try await withThrowingTaskGroup(
-            of: ([MeshContact], Date?).self
-        ) { group in
-            group.addTask {
-                var receivedContacts: [MeshContact] = []
-                var finalModifiedDate: Date?
+            // Manual timeout pattern (not withTimeout) because:
+            // 1. Uses injected clock for testability
+            // 2. Throws MeshCoreError.timeout for consistency with other session methods
+            // 3. Defers contactManager mutations until after the task group
+            //    to avoid actor-isolation issues in the @Sendable closure.
+            return try await withThrowingTaskGroup(
+                of: ([MeshContact], Date?).self
+            ) { group in
+                group.addTask {
+                    var receivedContacts: [MeshContact] = []
+                    var finalModifiedDate: Date?
 
-                for await event in events {
-                    if Task.isCancelled {
-                        throw CancellationError()
+                    for await event in events {
+                        if Task.isCancelled {
+                            throw CancellationError()
+                        }
+
+                        switch event {
+                        case .contactsStart(let count):
+                            receivedContacts.reserveCapacity(count)
+                        case .contact(let contact):
+                            receivedContacts.append(contact)
+                        case .contactsEnd(let modifiedDate):
+                            finalModifiedDate = modifiedDate
+                            return (receivedContacts, finalModifiedDate)
+                        case .error(let code):
+                            throw MeshCoreError.deviceError(code: code ?? 0)
+                        default:
+                            continue
+                        }
                     }
 
-                    switch event {
-                    case .contactsStart(let count):
-                        receivedContacts.reserveCapacity(count)
-                    case .contact(let contact):
-                        receivedContacts.append(contact)
-                    case .contactsEnd(let modifiedDate):
-                        finalModifiedDate = modifiedDate
-                        return (receivedContacts, finalModifiedDate)
-                    case .error(let code):
-                        throw MeshCoreError.deviceError(code: code ?? 0)
-                    default:
-                        continue
-                    }
+                    throw MeshCoreError.timeout
                 }
 
-                throw MeshCoreError.timeout
+                group.addTask { [clock = self.clock] in
+                    try await clock.sleep(for: .seconds(60))
+                    throw MeshCoreError.timeout
+                }
+
+                defer { group.cancelAll() }
+
+                guard let result = try await group.next() else {
+                    throw MeshCoreError.timeout
+                }
+
+                return result
             }
-
-            group.addTask { [clock = self.clock] in
-                try await clock.sleep(for: .seconds(60))
-                throw MeshCoreError.timeout
-            }
-
-            defer { group.cancelAll() }
-
-            guard let result = try await group.next() else {
-                throw MeshCoreError.timeout
-            }
-
-            return result
         }
 
         // Update contact manager on the actor after the race completes
@@ -839,9 +846,11 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Throws: ``MeshCoreError/timeout`` if no response within the timeout period.
     ///           ``MeshCoreError/invalidResponse`` if an unexpected response is received.
     public func requestStatus(from publicKey: Data) async throws -> StatusResponse {
-        // Serialize binary requests to prevent messageSent race conditions
-        try await binaryRequestSerializer.withSerialization { [self] in
-            try await performStatusRequest(from: publicKey)
+        try await companionCommandSerializer.withSerialization { [self] in
+            // Serialize binary requests to prevent messageSent race conditions
+            try await binaryRequestSerializer.withSerialization { [self] in
+                try await performStatusRequest(from: publicKey)
+            }
         }
     }
 
@@ -1245,9 +1254,21 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Returns: Device telemetry including battery, temperature, and sensor data.
     /// - Throws: ``MeshCoreError/timeout`` if the device doesn't respond.
     public func getSelfTelemetry() async throws -> TelemetryResponse {
-        try await sendAndWait(PacketBuilder.getSelfTelemetry()) { event in
-            if case .telemetryResponse(let response) = event { return response }
-            return nil
+        guard let selfInfo else {
+            throw MeshCoreError.sessionNotStarted
+        }
+        let expectedPrefix = Data(selfInfo.publicKey.prefix(6))
+
+        return try await sendAndWait(PacketBuilder.getSelfTelemetry()) { event in
+            guard case .telemetryResponse(let response) = event else {
+                return nil
+            }
+
+            guard response.publicKeyPrefix == expectedPrefix else {
+                return nil
+            }
+
+            return response
         }
     }
 
@@ -1763,7 +1784,7 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Throws: ``MeshCoreError/timeout`` if the device doesn't respond.
     public func getChannel(index: UInt8) async throws -> ChannelInfo {
         try await sendAndWait(PacketBuilder.getChannel(index: index)) { event in
-            if case .channelInfo(let info) = event { return info }
+            if case .channelInfo(let info) = event, info.index == index { return info }
             return nil
         }
     }
@@ -1802,9 +1823,11 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Throws: ``MeshCoreError/timeout`` if no response within timeout period.
     ///           ``MeshCoreError/invalidResponse`` if unexpected response received.
     public func requestTelemetry(from publicKey: Data) async throws -> TelemetryResponse {
-        // Serialize binary requests to prevent messageSent race conditions
-        try await binaryRequestSerializer.withSerialization { [self] in
-            try await performTelemetryRequest(from: publicKey)
+        try await companionCommandSerializer.withSerialization { [self] in
+            // Serialize binary requests to prevent messageSent race conditions
+            try await binaryRequestSerializer.withSerialization { [self] in
+                try await performTelemetryRequest(from: publicKey)
+            }
         }
     }
 
@@ -1922,8 +1945,10 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Returns: MMA response containing aggregated statistics.
     /// - Throws: ``MeshCoreError/timeout`` if no response within timeout period.
     public func requestMMA(from publicKey: Data, start: Date, end: Date) async throws -> MMAResponse {
-        try await binaryRequestSerializer.withSerialization { [self] in
-            try await performMMARequest(from: publicKey, start: start, end: end)
+        try await companionCommandSerializer.withSerialization { [self] in
+            try await binaryRequestSerializer.withSerialization { [self] in
+                try await performMMARequest(from: publicKey, start: start, end: end)
+            }
         }
     }
 
@@ -2005,8 +2030,10 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
     /// - Returns: ACL response containing authorized public keys.
     /// - Throws: ``MeshCoreError/timeout`` if no response within timeout period.
     public func requestACL(from publicKey: Data) async throws -> ACLResponse {
-        try await binaryRequestSerializer.withSerialization { [self] in
-            try await performACLRequest(from: publicKey)
+        try await companionCommandSerializer.withSerialization { [self] in
+            try await binaryRequestSerializer.withSerialization { [self] in
+                try await performACLRequest(from: publicKey)
+            }
         }
     }
 
@@ -2092,14 +2119,16 @@ public actor MeshCoreSession: MeshCoreSessionProtocol {
         orderBy: UInt8 = 0,
         pubkeyPrefixLength: UInt8 = 4
     ) async throws -> NeighboursResponse {
-        try await binaryRequestSerializer.withSerialization { [self] in
-            try await performNeighboursRequest(
-                from: publicKey,
-                count: count,
-                offset: offset,
-                orderBy: orderBy,
-                pubkeyPrefixLength: pubkeyPrefixLength
-            )
+        try await companionCommandSerializer.withSerialization { [self] in
+            try await binaryRequestSerializer.withSerialization { [self] in
+                try await performNeighboursRequest(
+                    from: publicKey,
+                    count: count,
+                    offset: offset,
+                    orderBy: orderBy,
+                    pubkeyPrefixLength: pubkeyPrefixLength
+                )
+            }
         }
     }
 

--- a/MeshCore/Sources/MeshCore/Session/RequestContext.swift
+++ b/MeshCore/Sources/MeshCore/Session/RequestContext.swift
@@ -244,3 +244,51 @@ public actor BinaryRequestSerializer {
         }
     }
 }
+
+/// Serializes companion-protocol commands that expect a direct firmware response.
+///
+/// The companion protocol expects callers to send one command at a time and wait for the
+/// corresponding response before issuing the next command. Actor isolation alone is not
+/// sufficient because the session actor can re-enter while an async command is awaiting
+/// a response. This serializer enforces the protocol's single in-flight command rule.
+public actor CompanionCommandSerializer {
+    private var isCommandInFlight = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    /// Acquires the serializer, waiting if another command is already in flight.
+    public func acquire() async {
+        if !isCommandInFlight {
+            isCommandInFlight = true
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    /// Releases the serializer so the next queued command can proceed.
+    public func release() {
+        if let next = waiters.first {
+            waiters.removeFirst()
+            next.resume()
+        } else {
+            isCommandInFlight = false
+        }
+    }
+
+    /// Executes an operation while holding the serializer.
+    public func withSerialization<T: Sendable>(
+        _ operation: @Sendable () async throws -> T
+    ) async throws -> T {
+        await acquire()
+        do {
+            let result = try await operation()
+            release()
+            return result
+        } catch {
+            release()
+            throw error
+        }
+    }
+}

--- a/MeshCore/Tests/MeshCoreTests/Session/MeshCoreSessionRequestWaitingTests.swift
+++ b/MeshCore/Tests/MeshCoreTests/Session/MeshCoreSessionRequestWaitingTests.swift
@@ -1,0 +1,993 @@
+import Foundation
+import Testing
+@testable import MeshCore
+
+@Suite("MeshCoreSession request waiting")
+struct MeshCoreSessionRequestWaitingTests {
+    @Test("waitForEvent returns first matching event after ignoring unrelated events")
+    func waitForEventReturnsFirstMatchingEventAfterIgnoringUnrelatedEvents() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(transport: transport)
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let waitTask = Task {
+            await session.waitForEvent(matching: { event in
+                if case .battery = event { return true }
+                return false
+            }, timeout: 0.2)
+        }
+
+        try? await Task.sleep(for: .milliseconds(20))
+        await transport.simulateReceive(makeCurrentTimePacket(timestamp: 1_710_000_000))
+        await transport.simulateReceive(makeBatteryPacket(level: 4021))
+
+        let event = await waitTask.value
+        guard case .battery(let battery)? = event else {
+            Issue.record("Expected battery event, got \(String(describing: event))")
+            return
+        }
+
+        #expect(battery.level == 4021)
+        await session.stop()
+    }
+
+    @Test("waitForEvent filter returns matching ok event")
+    func waitForEventFilterReturnsMatchingOKEvent() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(transport: transport)
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let waitTask = Task {
+            await session.waitForEvent(filter: .ok, timeout: 0.2)
+        }
+
+        try? await Task.sleep(for: .milliseconds(20))
+        await transport.simulateOK(value: 7)
+
+        let event = await waitTask.value
+        guard case .ok(let value)? = event else {
+            Issue.record("Expected ok event, got \(String(describing: event))")
+            await session.stop()
+            return
+        }
+
+        #expect(value == 7)
+        await session.stop()
+    }
+
+    @Test("getBattery returns parsed battery info")
+    func getBatteryReturnsParsedBatteryInfo() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(transport: transport)
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let batteryTask = Task {
+            try await session.getBattery()
+        }
+
+        try await waitUntil("transport should send battery request") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateReceive(makeBatteryPacket(level: 4033, usedStorageKB: 22, totalStorageKB: 100))
+
+        let battery = try await batteryTask.value
+        #expect(battery.level == 4033)
+        #expect(battery.usedStorageKB == 22)
+        #expect(battery.totalStorageKB == 100)
+        await session.stop()
+    }
+
+    @Test("getBattery ignores unrelated error events while waiting for a battery response")
+    func getBatteryIgnoresUnrelatedErrorWhileWaitingForBatteryResponse() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let batteryTask = Task {
+            try await session.getBattery()
+        }
+
+        try await waitUntil("transport should send battery request") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateError(code: 99)
+        await transport.simulateReceive(makeBatteryPacket(level: 4018))
+
+        let battery = try await batteryTask.value
+        #expect(battery.level == 4018)
+        await session.stop()
+    }
+
+    @Test("setAutoAddConfig should not treat unrelated ok as success")
+    func setAutoAddConfigShouldNotTreatUnrelatedOKAsSuccess() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let commandTask = Task {
+            try await session.setAutoAddConfig(AutoAddConfig(bitmask: 0x1E, maxHops: 2))
+        }
+
+        try await waitUntil("transport should send setAutoAddConfig command") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateOK(value: 7)
+
+        await withKnownIssue("setAutoAddConfig currently treats any OK event as success, even when unrelated to the command") {
+            let error = await #expect(throws: MeshCoreError.self) {
+                try await commandTask.value
+            }
+            guard case .timeout? = error else {
+                Issue.record("Expected timeout, got \(String(describing: error))")
+                return
+            }
+        }
+
+        await session.stop()
+    }
+
+    @Test("factoryReset should not treat unrelated ok as success")
+    func factoryResetShouldNotTreatUnrelatedOKAsSuccess() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let commandTask = Task {
+            try await session.factoryReset()
+        }
+
+        try await waitUntil("transport should send factoryReset command") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateOK(value: 99)
+
+        await withKnownIssue("sendSimpleCommand currently treats any OK event as success, even when unrelated to the active command") {
+            let error = await #expect(throws: MeshCoreError.self) {
+                try await commandTask.value
+            }
+            guard case .timeout? = error else {
+                Issue.record("Expected timeout, got \(String(describing: error))")
+                return
+            }
+        }
+
+        await session.stop()
+    }
+
+    @Test("getSelfTelemetry should ignore telemetry from another node")
+    func getSelfTelemetryShouldIgnoreTelemetryFromAnotherNode() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let telemetryTask = Task {
+            try await session.getSelfTelemetry()
+        }
+
+        try await waitUntil("transport should send getSelfTelemetry command") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateReceive(
+            makeTelemetryPacket(
+                publicKeyPrefix: Data([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]),
+                lppPayload: Data([0x01, 0x67, 0x00, 0xFA])
+            )
+        )
+
+        let error = await #expect(throws: MeshCoreError.self) {
+            try await telemetryTask.value
+        }
+        guard case .timeout? = error else {
+            Issue.record("Expected timeout, got \(String(describing: error))")
+            return
+        }
+
+        await session.stop()
+    }
+
+    @Test("getCustomVars should ignore unsolicited customVars event")
+    func getCustomVarsShouldIgnoreUnsolicitedCustomVarsEvent() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let varsTask = Task {
+            try await session.getCustomVars()
+        }
+
+        try await waitUntil("transport should send getCustomVars command") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateReceive(makeCustomVarsPacket("mode:auto"))
+
+        await withKnownIssue("getCustomVars currently accepts any customVars event, even when it may be unsolicited or unrelated to the active command") {
+            let error = await #expect(throws: MeshCoreError.self) {
+                try await varsTask.value
+            }
+            guard case .timeout? = error else {
+                Issue.record("Expected timeout, got \(String(describing: error))")
+                return
+            }
+        }
+
+        await session.stop()
+    }
+
+    @Test("exportPrivateKey should not treat unrelated disabled as export-disabled result")
+    func exportPrivateKeyShouldNotTreatUnrelatedDisabledAsResult() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let exportTask = Task {
+            try await session.exportPrivateKey()
+        }
+
+        try await waitUntil("transport should send exportPrivateKey command") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateReceive(makeDisabledPacket())
+
+        await withKnownIssue("exportPrivateKey currently treats any disabled event as its own export-disabled response") {
+            let error = await #expect(throws: MeshCoreError.self) {
+                _ = try await exportTask.value
+            }
+            guard case .timeout? = error else {
+                Issue.record("Expected timeout, got \(String(describing: error))")
+                return
+            }
+        }
+
+        await session.stop()
+    }
+
+    @Test("getTime should ignore unsolicited currentTime event")
+    func getTimeShouldIgnoreUnsolicitedCurrentTimeEvent() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let timeTask = Task {
+            try await session.getTime()
+        }
+
+        try await waitUntil("transport should send getTime command") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateReceive(makeCurrentTimePacket(timestamp: 1_710_000_123))
+
+        await withKnownIssue("getTime currently accepts any currentTime event, even when it may be unsolicited or unrelated to the active command") {
+            let error = await #expect(throws: MeshCoreError.self) {
+                _ = try await timeTask.value
+            }
+            guard case .timeout? = error else {
+                Issue.record("Expected timeout, got \(String(describing: error))")
+                return
+            }
+        }
+
+        await session.stop()
+    }
+
+    @Test("getAutoAddConfig should ignore unsolicited autoAddConfig event")
+    func getAutoAddConfigShouldIgnoreUnsolicitedEvent() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let configTask = Task {
+            try await session.getAutoAddConfig()
+        }
+
+        try await waitUntil("transport should send getAutoAddConfig command") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateReceive(makeAutoAddConfigPacket(bitmask: 0x1E, maxHops: 3))
+
+        await withKnownIssue("getAutoAddConfig currently accepts any autoAddConfig event, even when it may be unsolicited or unrelated to the active command") {
+            let error = await #expect(throws: MeshCoreError.self) {
+                _ = try await configTask.value
+            }
+            guard case .timeout? = error else {
+                Issue.record("Expected timeout, got \(String(describing: error))")
+                return
+            }
+        }
+
+        await session.stop()
+    }
+
+    @Test("getStatsCore should ignore unsolicited core stats event")
+    func getStatsCoreShouldIgnoreUnsolicitedEvent() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let statsTask = Task {
+            try await session.getStatsCore()
+        }
+
+        try await waitUntil("transport should send getStatsCore command") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateReceive(makeCoreStatsPacket(batteryMV: 3750, uptime: 86_400, errors: 3, queueLength: 5))
+
+        await withKnownIssue("getStatsCore currently accepts any statsCore event, even when it may be unsolicited or unrelated to the active command") {
+            let error = await #expect(throws: MeshCoreError.self) {
+                _ = try await statsTask.value
+            }
+            guard case .timeout? = error else {
+                Issue.record("Expected timeout, got \(String(describing: error))")
+                return
+            }
+        }
+
+        await session.stop()
+    }
+
+    @Test("getStatsRadio should ignore unsolicited radio stats event")
+    func getStatsRadioShouldIgnoreUnsolicitedEvent() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let statsTask = Task {
+            try await session.getStatsRadio()
+        }
+
+        try await waitUntil("transport should send getStatsRadio command") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateReceive(makeRadioStatsPacket(noiseFloor: -115, lastRSSI: -90, lastSNRRaw: 28, txAir: 1_000, rxAir: 2_000))
+
+        await withKnownIssue("getStatsRadio currently accepts any statsRadio event, even when it may be unsolicited or unrelated to the active command") {
+            let error = await #expect(throws: MeshCoreError.self) {
+                _ = try await statsTask.value
+            }
+            guard case .timeout? = error else {
+                Issue.record("Expected timeout, got \(String(describing: error))")
+                return
+            }
+        }
+
+        await session.stop()
+    }
+
+    @Test("exportContact should ignore unsolicited contactURI event")
+    func exportContactShouldIgnoreUnsolicitedURIEvent() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let exportTask = Task {
+            try await session.exportContact()
+        }
+
+        try await waitUntil("transport should send exportContact command") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateReceive(makeContactURIPacket("meshcore://deadbeef"))
+
+        await withKnownIssue("exportContact currently accepts any contactURI event, even when it may be unsolicited or unrelated to the active command") {
+            let error = await #expect(throws: MeshCoreError.self) {
+                _ = try await exportTask.value
+            }
+            guard case .timeout? = error else {
+                Issue.record("Expected timeout, got \(String(describing: error))")
+                return
+            }
+        }
+
+        await session.stop()
+    }
+
+    @Test("getStatsPackets should ignore unsolicited packet stats event")
+    func getStatsPacketsShouldIgnoreUnsolicitedEvent() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let statsTask = Task {
+            try await session.getStatsPackets()
+        }
+
+        try await waitUntil("transport should send getStatsPackets command") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateReceive(makePacketStatsPacket(received: 1000, sent: 500, floodTx: 100, directTx: 400, floodRx: 200, directRx: 800))
+
+        await withKnownIssue("getStatsPackets currently accepts any statsPackets event, even when it may be unsolicited or unrelated to the active command") {
+            let error = await #expect(throws: MeshCoreError.self) {
+                _ = try await statsTask.value
+            }
+            guard case .timeout? = error else {
+                Issue.record("Expected timeout, got \(String(describing: error))")
+                return
+            }
+        }
+
+        await session.stop()
+    }
+
+    @Test("getRepeatFreq should ignore unsolicited allowedRepeatFreq event")
+    func getRepeatFreqShouldIgnoreUnsolicitedEvent() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let repeatTask = Task {
+            try await session.getRepeatFreq()
+        }
+
+        try await waitUntil("transport should send getRepeatFreq command") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateReceive(makeAllowedRepeatFreqPacket([FrequencyRange(lowerKHz: 902_000, upperKHz: 928_000)]))
+
+        await withKnownIssue("getRepeatFreq currently accepts any allowedRepeatFreq event, even when it may be unsolicited or unrelated to the active command") {
+            let error = await #expect(throws: MeshCoreError.self) {
+                _ = try await repeatTask.value
+            }
+            guard case .timeout? = error else {
+                Issue.record("Expected timeout, got \(String(describing: error))")
+                return
+            }
+        }
+
+        await session.stop()
+    }
+
+    @Test("getChannel should ignore unsolicited channelInfo event")
+    func getChannelShouldIgnoreUnsolicitedChannelInfoEvent() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let channelTask = Task {
+            try await session.getChannel(index: 3)
+        }
+
+        try await waitUntil("transport should send getChannel command") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateReceive(makeChannelInfoPacket(index: 9, name: "Unsolicited", secret: Data(repeating: 0xAA, count: 16)))
+
+        let error = await #expect(throws: MeshCoreError.self) {
+            _ = try await channelTask.value
+        }
+        guard case .timeout? = error else {
+            Issue.record("Expected timeout, got \(String(describing: error))")
+            return
+        }
+
+        await session.stop()
+    }
+
+    @Test("companion commands are serialized while a response is pending")
+    func companionCommandsAreSerializedWhileAResponseIsPending() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let timeTask = Task {
+            try await session.getTime()
+        }
+
+        try await waitUntil("transport should send getTime command") {
+            await transport.sentData.count >= 2
+        }
+
+        let batteryTask = Task {
+            try await session.getBattery()
+        }
+
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await transport.sentData.count == 2, "getBattery should wait until getTime completes")
+
+        await transport.simulateReceive(makeCurrentTimePacket(timestamp: 1_710_000_123))
+        _ = try await timeTask.value
+
+        try await waitUntil("transport should send battery request after getTime completes") {
+            await transport.sentData.count >= 3
+        }
+
+        await transport.simulateReceive(makeBatteryPacket(level: 4025))
+        let battery = try await batteryTask.value
+        #expect(battery.level == 4025)
+
+        await session.stop()
+    }
+
+    @Test("signStart should ignore unsolicited signStart event")
+    func signStartShouldIgnoreUnsolicitedEvent() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let signTask = Task {
+            try await session.signStart()
+        }
+
+        try await waitUntil("transport should send signStart command") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateReceive(makeSignStartPacket(maxLength: 4096))
+
+        await withKnownIssue("signStart currently accepts any signStart event, even when it may be unsolicited or unrelated to the active command") {
+            let error = await #expect(throws: MeshCoreError.self) {
+                _ = try await signTask.value
+            }
+            guard case .timeout? = error else {
+                Issue.record("Expected timeout, got \(String(describing: error))")
+                return
+            }
+        }
+
+        await session.stop()
+    }
+
+    @Test("signFinish should ignore unsolicited signature event")
+    func signFinishShouldIgnoreUnsolicitedSignatureEvent() async throws {
+        let transport = MockTransport()
+        let session = MeshCoreSession(
+            transport: transport,
+            configuration: SessionConfiguration(defaultTimeout: 0.2, clientIdentifier: "MeshCore-Tests")
+        )
+
+        let startTask = Task {
+            try await session.start()
+        }
+
+        try await waitUntil("transport should send appStart before session starts") {
+            await transport.sentData.count == 1
+        }
+
+        await transport.simulateReceive(makeSelfInfoPacket())
+        try await startTask.value
+
+        let signTask = Task {
+            try await session.signFinish(timeout: 0.2)
+        }
+
+        try await waitUntil("transport should send signFinish command") {
+            await transport.sentData.count >= 2
+        }
+
+        await transport.simulateReceive(makeSignaturePacket(Data(repeating: 0x55, count: 64)))
+
+        await withKnownIssue("signFinish currently accepts any signature event, even when it may be unsolicited or unrelated to the active command") {
+            let error = await #expect(throws: MeshCoreError.self) {
+                _ = try await signTask.value
+            }
+            guard case .timeout? = error else {
+                Issue.record("Expected timeout, got \(String(describing: error))")
+                return
+            }
+        }
+
+        await session.stop()
+    }
+}
+
+private func makeBatteryPacket(level: UInt16, usedStorageKB: UInt32? = nil, totalStorageKB: UInt32? = nil) -> Data {
+    var packet = Data([ResponseCode.battery.rawValue])
+    packet.append(contentsOf: withUnsafeBytes(of: level.littleEndian) { Array($0) })
+
+    if let usedStorageKB, let totalStorageKB {
+        packet.append(contentsOf: withUnsafeBytes(of: usedStorageKB.littleEndian) { Array($0) })
+        packet.append(contentsOf: withUnsafeBytes(of: totalStorageKB.littleEndian) { Array($0) })
+    }
+
+    return packet
+}
+
+private func makeCurrentTimePacket(timestamp: UInt32) -> Data {
+    var packet = Data([ResponseCode.currentTime.rawValue])
+    packet.append(contentsOf: withUnsafeBytes(of: timestamp.littleEndian) { Array($0) })
+    return packet
+}
+
+private func makeTelemetryPacket(publicKeyPrefix: Data, lppPayload: Data) -> Data {
+    var packet = Data([ResponseCode.telemetryResponse.rawValue])
+    packet.append(0x00)
+    packet.append(publicKeyPrefix)
+    packet.append(lppPayload)
+    return packet
+}
+
+private func makeCustomVarsPacket(_ string: String) -> Data {
+    var packet = Data([ResponseCode.customVars.rawValue])
+    packet.append(contentsOf: string.utf8)
+    return packet
+}
+
+private func makeDisabledPacket() -> Data {
+    Data([ResponseCode.disabled.rawValue])
+}
+
+private func makeAutoAddConfigPacket(bitmask: UInt8, maxHops: UInt8) -> Data {
+    Data([ResponseCode.autoAddConfig.rawValue, bitmask, maxHops])
+}
+
+private func makeCoreStatsPacket(batteryMV: UInt16, uptime: UInt32, errors: UInt16, queueLength: UInt8) -> Data {
+    var packet = Data([ResponseCode.stats.rawValue, StatsType.core.rawValue])
+    packet.append(contentsOf: withUnsafeBytes(of: batteryMV.littleEndian) { Array($0) })
+    packet.append(contentsOf: withUnsafeBytes(of: uptime.littleEndian) { Array($0) })
+    packet.append(contentsOf: withUnsafeBytes(of: errors.littleEndian) { Array($0) })
+    packet.append(queueLength)
+    return packet
+}
+
+private func makeRadioStatsPacket(
+    noiseFloor: Int16,
+    lastRSSI: Int8,
+    lastSNRRaw: Int8,
+    txAir: UInt32,
+    rxAir: UInt32
+) -> Data {
+    var packet = Data([ResponseCode.stats.rawValue, StatsType.radio.rawValue])
+    packet.append(contentsOf: withUnsafeBytes(of: noiseFloor.littleEndian) { Array($0) })
+    packet.append(UInt8(bitPattern: lastRSSI))
+    packet.append(UInt8(bitPattern: lastSNRRaw))
+    packet.append(contentsOf: withUnsafeBytes(of: txAir.littleEndian) { Array($0) })
+    packet.append(contentsOf: withUnsafeBytes(of: rxAir.littleEndian) { Array($0) })
+    return packet
+}
+
+private func makeContactURIPacket(_ uri: String) -> Data {
+    let hex = uri.replacingOccurrences(of: "meshcore://", with: "")
+    var packet = Data([ResponseCode.contactURI.rawValue])
+    packet.append(hexDecodedBytes(hex))
+    return packet
+}
+
+private func makePacketStatsPacket(
+    received: UInt32,
+    sent: UInt32,
+    floodTx: UInt32,
+    directTx: UInt32,
+    floodRx: UInt32,
+    directRx: UInt32
+) -> Data {
+    var packet = Data([ResponseCode.stats.rawValue, StatsType.packets.rawValue])
+    packet.append(contentsOf: withUnsafeBytes(of: received.littleEndian) { Array($0) })
+    packet.append(contentsOf: withUnsafeBytes(of: sent.littleEndian) { Array($0) })
+    packet.append(contentsOf: withUnsafeBytes(of: floodTx.littleEndian) { Array($0) })
+    packet.append(contentsOf: withUnsafeBytes(of: directTx.littleEndian) { Array($0) })
+    packet.append(contentsOf: withUnsafeBytes(of: floodRx.littleEndian) { Array($0) })
+    packet.append(contentsOf: withUnsafeBytes(of: directRx.littleEndian) { Array($0) })
+    return packet
+}
+
+private func makeAllowedRepeatFreqPacket(_ ranges: [FrequencyRange]) -> Data {
+    var packet = Data([ResponseCode.allowedRepeatFreq.rawValue])
+    for range in ranges {
+        packet.append(contentsOf: withUnsafeBytes(of: range.lowerKHz.littleEndian) { Array($0) })
+        packet.append(contentsOf: withUnsafeBytes(of: range.upperKHz.littleEndian) { Array($0) })
+    }
+    return packet
+}
+
+private func makeChannelInfoPacket(index: UInt8, name: String, secret: Data) -> Data {
+    var packet = Data([ResponseCode.channelInfo.rawValue, index])
+    let nameBytes = Data(name.utf8).prefix(32)
+    packet.append(nameBytes)
+    if nameBytes.count < 32 {
+        packet.append(Data(repeating: 0, count: 32 - nameBytes.count))
+    }
+    packet.append(secret.prefix(16))
+    if secret.count < 16 {
+        packet.append(Data(repeating: 0, count: 16 - secret.count))
+    }
+    return packet
+}
+
+private func makeSignStartPacket(maxLength: UInt32) -> Data {
+    var packet = Data([ResponseCode.signStart.rawValue, 0x00])
+    packet.append(contentsOf: withUnsafeBytes(of: maxLength.littleEndian) { Array($0) })
+    return packet
+}
+
+private func makeSignaturePacket(_ signature: Data) -> Data {
+    var packet = Data([ResponseCode.signature.rawValue])
+    packet.append(signature)
+    return packet
+}
+
+private func makeSelfInfoPacket() -> Data {
+    var payload = Data()
+    payload.append(1)
+    payload.append(22)
+    payload.append(22)
+    payload.append(Data(repeating: 0x01, count: 32))
+    payload.append(int32Bytes(0))
+    payload.append(int32Bytes(0))
+    payload.append(0)
+    payload.append(0)
+    payload.append(0)
+    payload.append(0)
+    payload.append(1)
+    payload.append(uint32Bytes(915_000))
+    payload.append(uint32Bytes(125_000))
+    payload.append(7)
+    payload.append(5)
+    payload.append(contentsOf: "Test".utf8)
+
+    var packet = Data([ResponseCode.selfInfo.rawValue])
+    packet.append(payload)
+    return packet
+}
+
+private func int32Bytes(_ value: Int32) -> Data {
+    withUnsafeBytes(of: value.littleEndian) { Data($0) }
+}
+
+private func uint32Bytes(_ value: UInt32) -> Data {
+    withUnsafeBytes(of: value.littleEndian) { Data($0) }
+}
+
+private func hexDecodedBytes(_ hex: String) -> Data {
+    var data = Data()
+    var index = hex.startIndex
+    while index < hex.endIndex {
+        let next = hex.index(index, offsetBy: 2)
+        let byteString = hex[index..<next]
+        data.append(UInt8(byteString, radix: 16) ?? 0)
+        index = next
+    }
+    return data
+}


### PR DESCRIPTION
## Bug
MeshCoreSession was vulnerable to companion-protocol request miscorrelation.

The companion firmware expects one command at a time: send a command, wait for its response, then send the next command. The session actor did not actually enforce that rule. Because actor methods can re-enter while awaiting transport responses, multiple companion commands could overlap in practice, and broad response predicates could let a later command observe an earlier command's response or vice versa.

That showed up as two concrete failure modes:
- overlapping commands could race and complete against the wrong response stream
- commands that only matched on a response type could accept unrelated but valid-looking responses, especially when those responses were unsolicited or stale

The request-waiting test suite already demonstrated this class of issue, including local self-telemetry and channel reads.

## Strategy
Fix the highest-ROI part first at the session boundary instead of patching individual commands one by one.

The strategy in this PR is:
1. Enforce the companion protocol's single in-flight command rule centrally in MeshCoreSession.
2. Route binary request entry points through the same serialization boundary so companion commands and binary requests cannot overlap.
3. Tighten per-command correlation only where the wire format already gives enough identity to do so safely.

This does not fully solve every untagged unsolicited-response case yet. It intentionally addresses the shared overlapping-command bug first so the protocol layer follows the firmware's sequencing contract.

## Implementation
This change introduces a dedicated `CompanionCommandSerializer` and uses it as the outer guard around request/response command flows.

Specifically, it:
- serializes `sendAndWait` and `sendAndWaitWithError` so only one companion command that expects a direct firmware response can be in flight at a time
- serializes `getContacts`, which manages its own multi-event wait loop outside the generic helpers
- serializes binary request entry points (`requestStatus`, `requestTelemetry`, `requestMMA`, `requestACL`, `requestNeighbours`) before they enter the existing binary-request serializer
- tightens two commands with available on-wire identity:
  - `getSelfTelemetry()` now requires the response public-key prefix to match the connected device
  - `getChannel(index:)` now requires the returned channel index to match the requested index
- adds request-waiting coverage proving that:
  - companion commands are serialized while a prior response is still pending
  - local self-telemetry ignores another node's telemetry response
  - channel reads ignore channel info for the wrong index

## Testing
- `swift test --scratch-path /tmp/meshcoreone-meshcore-build --filter MeshCoreSessionRequestWaitingTests`
- `swift test --scratch-path /tmp/meshcoreone-meshcore-build`

## Scope Notes
This PR does not yet fix all remaining request-correlation issues for untagged response types such as generic `OK`, `ERROR`, `DISABLED`, `CURRENT_TIME`, or other same-type unsolicited packets. Those need a follow-up pass with stricter command-specific completion rules.
