### PR TITLE
Fix CLI local passthrough behavior and command completion

### DIFF
--- a/MC1/Views/Tools/CLI/CLICompletionEngine.swift
+++ b/MC1/Views/Tools/CLI/CLICompletionEngine.swift
@@ -69,12 +69,19 @@ final class CLICompletionEngine {
 
     // MARK: - Completion Logic
 
-    func completions(for input: String, isLocal: Bool) -> [String] {
+    func completions(
+        for input: String,
+        isLocal: Bool,
+        includeRepeaterCommandsInLocal: Bool = false
+    ) -> [String] {
         let trimmed = input.trimmingCharacters(in: .whitespaces)
 
         // Empty or just spaces - return all applicable commands
         if trimmed.isEmpty {
-            return availableCommands(isLocal: isLocal).sorted()
+            return availableCommands(
+                isLocal: isLocal,
+                includeRepeaterCommandsInLocal: includeRepeaterCommandsInLocal
+            ).sorted()
         }
 
         let parts = trimmed.split(separator: " ", omittingEmptySubsequences: false).map(String.init)
@@ -82,7 +89,10 @@ final class CLICompletionEngine {
 
         // Single word - complete command name
         if parts.count == 1 && !input.hasSuffix(" ") {
-            return availableCommands(isLocal: isLocal)
+            return availableCommands(
+                isLocal: isLocal,
+                includeRepeaterCommandsInLocal: includeRepeaterCommandsInLocal
+            )
                 .filter { $0.hasPrefix(command) }
                 .sorted()
         }
@@ -149,11 +159,14 @@ final class CLICompletionEngine {
         }
     }
 
-    private func availableCommands(isLocal: Bool) -> [String] {
+    private func availableCommands(isLocal: Bool, includeRepeaterCommandsInLocal: Bool) -> [String] {
         var commands = Self.builtInCommands
 
         if isLocal {
             commands.append(contentsOf: Self.localOnlyCommands)
+            if includeRepeaterCommandsInLocal {
+                commands.append(contentsOf: Self.repeaterCommands)
+            }
         } else {
             commands.append(contentsOf: Self.repeaterCommands)
         }

--- a/MC1/Views/Tools/CLI/CLIToolView.swift
+++ b/MC1/Views/Tools/CLI/CLIToolView.swift
@@ -64,6 +64,7 @@ private struct CLIToolContent: View {
                 remoteNodeService: appState.services?.remoteNodeService,
                 dataStore: appState.services?.dataStore,
                 deviceID: appState.connectedDevice?.id,
+                localDevicePublicKey: appState.connectedDevice?.publicKey,
                 localDeviceName: appState.connectedDevice?.nodeName ?? L10n.Tools.Tools.Cli.defaultDevice
             )
         }

--- a/MC1/Views/Tools/CLI/CLIToolViewModel+Completion.swift
+++ b/MC1/Views/Tools/CLI/CLIToolViewModel+Completion.swift
@@ -21,7 +21,11 @@ extension CLIToolViewModel {
         }
 
         let isLocal = activeSession?.isLocal ?? true
-        let suggestions = completionEngine.completions(for: currentInput, isLocal: isLocal)
+        let suggestions = completionEngine.completions(
+            for: currentInput,
+            isLocal: isLocal,
+            includeRepeaterCommandsInLocal: isLocal && supportsLocalPassthrough
+        )
 
         guard let first = suggestions.first else {
             ghostText = ""
@@ -65,7 +69,11 @@ extension CLIToolViewModel {
 
         // Generate new suggestions
         let isLocal = activeSession?.isLocal ?? true
-        let suggestions = completionEngine.completions(for: currentInput, isLocal: isLocal)
+        let suggestions = completionEngine.completions(
+            for: currentInput,
+            isLocal: isLocal,
+            includeRepeaterCommandsInLocal: isLocal && supportsLocalPassthrough
+        )
 
         guard !suggestions.isEmpty else {
             tabSuggestions = nil

--- a/MC1/Views/Tools/CLI/CLIToolViewModel.swift
+++ b/MC1/Views/Tools/CLI/CLIToolViewModel.swift
@@ -47,6 +47,7 @@ final class CLIToolViewModel {
     var remoteNodeService: RemoteNodeService?
     var dataStore: PersistenceStoreProtocol?
     var deviceID: UUID?
+    var localDevicePublicKey: Data?
     var localDeviceName: String = ""
 
     // MARK: - Prompt
@@ -82,12 +83,14 @@ final class CLIToolViewModel {
         remoteNodeService: RemoteNodeService?,
         dataStore: PersistenceStoreProtocol?,
         deviceID: UUID?,
+        localDevicePublicKey: Data? = nil,
         localDeviceName: String
     ) {
         self.localDeviceName = localDeviceName
         self.remoteNodeService = remoteNodeService
         self.dataStore = dataStore
         self.deviceID = deviceID
+        self.localDevicePublicKey = localDevicePublicKey
 
         // Only reset if service instance changed
         if self.repeaterAdminService !== repeaterAdminService {
@@ -234,7 +237,7 @@ final class CLIToolViewModel {
 
         switch cmd {
         case "help": showHelp()
-        case "clear" where activeSession?.isLocal == true || args.isEmpty: clearOutput()
+        case "clear" where args.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty: clearOutput()
         case "session": handleSessionCommand(args)
         case "login": await handleLogin(args)
         case "logout": await handleLogout()
@@ -251,7 +254,11 @@ final class CLIToolViewModel {
 
     private func handleUnknownCommand(_ cmd: String, raw: String) async {
         if activeSession?.isLocal == true {
-            appendOutput("\(L10n.Tools.Tools.Cli.unknownCommand) \(cmd)", type: .error)
+            if supportsLocalPassthrough {
+                await sendLocalCommand(raw)
+            } else {
+                appendOutput("\(L10n.Tools.Tools.Cli.unknownCommand) \(cmd)", type: .error)
+            }
         } else if activeSession != nil {
             await sendRemoteCommand(raw)
         } else {
@@ -275,6 +282,14 @@ final class CLIToolViewModel {
         if activeSession?.isLocal == true {
             appendOutput(L10n.Tools.Tools.Cli.helpNodes, type: .response)
             appendOutput(L10n.Tools.Tools.Cli.helpChannels, type: .response)
+            if supportsLocalPassthrough {
+                appendOutput("", type: .response)
+                appendOutput(L10n.Tools.Tools.Cli.helpRepeaterHeader, type: .response)
+                appendOutput(L10n.Tools.Tools.Cli.helpRepeaterList1, type: .response)
+                appendOutput(L10n.Tools.Tools.Cli.helpRepeaterList2, type: .response)
+                appendOutput(L10n.Tools.Tools.Cli.helpRepeaterList3, type: .response)
+                appendOutput(L10n.Tools.Tools.Cli.helpRepeaterList4, type: .response)
+            }
         } else if activeSession != nil {
             appendOutput("", type: .response)
             appendOutput(L10n.Tools.Tools.Cli.helpRepeaterHeader, type: .response)
@@ -287,6 +302,42 @@ final class CLIToolViewModel {
 
     private func clearOutput() {
         outputLines.removeAll()
+    }
+
+    var supportsLocalPassthrough: Bool {
+        localDevicePublicKey != nil && repeaterAdminService != nil
+    }
+
+    private func sendLocalCommand(_ command: String) async {
+        guard let service = repeaterAdminService,
+              let localDevicePublicKey else {
+            appendOutput("\(L10n.Tools.Tools.Cli.unknownCommand) \(command.split(separator: " ").first.map(String.init) ?? command)", type: .error)
+            return
+        }
+
+        isWaitingForResponse = true
+        defer { isWaitingForResponse = false }
+
+        do {
+            let response = try await service.sendRawCommand(
+                publicKey: localDevicePublicKey,
+                command: command
+            )
+
+            guard !Task.isCancelled else { return }
+
+            appendOutput(response, type: .response)
+        } catch is CancellationError {
+            // Already handled by cancelCurrentCommand
+        } catch let error as RemoteNodeError {
+            if case .timeout = error {
+                appendOutput(L10n.Tools.Tools.Cli.commandTimeout, type: .error)
+            } else {
+                appendOutput("\(error.localizedDescription)", type: .error)
+            }
+        } catch {
+            appendOutput("\(error.localizedDescription)", type: .error)
+        }
     }
 
     // MARK: - History Navigation

--- a/MC1Services/Sources/MC1Services/Services/RemoteNodeService.swift
+++ b/MC1Services/Sources/MC1Services/Services/RemoteNodeService.swift
@@ -942,10 +942,28 @@ public actor RemoteNodeService {
             throw RemoteNodeError.permissionDenied
         }
 
-        // Log CLI command (with password redaction)
-        await auditLogger.logCLICommand(publicKey: remoteSession.publicKey, command: command)
+        let response = try await sendRawCLICommand(
+            publicKey: remoteSession.publicKey,
+            command: command,
+            timeout: timeout
+        )
 
-        let destinationPrefix = Data(remoteSession.publicKey.prefix(6))
+        // Clear stored password after admin password change
+        await handlePasswordChangeIfNeeded(command: command, sessionID: sessionID)
+
+        return response
+    }
+
+    /// Send a raw CLI command directly to a known public key.
+    /// This bypasses session lookup and is used by the local CLI session.
+    public func sendRawCLICommand(
+        publicKey: Data,
+        command: String,
+        timeout: Duration = .seconds(10)
+    ) async throws -> String {
+        await auditLogger.logCLICommand(publicKey: publicKey, command: command)
+
+        let destinationPrefix = Data(publicKey.prefix(6))
 
         // Only one raw CLI request per sender at a time (FIFO matching)
         guard pendingRawCLIRequests[destinationPrefix] == nil else {
@@ -962,7 +980,7 @@ public actor RemoteNodeService {
                     // Send CLI command
                     let sentInfo: MessageSentInfo
                     do {
-                        sentInfo = try await session.sendCommand(to: remoteSession.publicKey, command: command)
+                        sentInfo = try await session.sendCommand(to: publicKey, command: command)
                     } catch {
                         // Send failed - remove pending request and resume with error
                         if let pending = pendingRawCLIRequests.removeValue(forKey: destinationPrefix) {
@@ -1007,9 +1025,6 @@ public actor RemoteNodeService {
                 await self?.cancelPendingRawCLIRequest(for: destinationPrefix)
             }
         }
-
-        // Clear stored password after admin password change
-        await handlePasswordChangeIfNeeded(command: command, sessionID: sessionID)
 
         return response
     }

--- a/MC1Services/Sources/MC1Services/Services/RepeaterAdminService.swift
+++ b/MC1Services/Sources/MC1Services/Services/RepeaterAdminService.swift
@@ -207,6 +207,20 @@ public actor RepeaterAdminService {
         )
     }
 
+    /// Send a raw CLI command to the currently connected repeater using its public key.
+    /// Used by the local CLI session when the app is connected directly to a device.
+    public func sendRawCommand(
+        publicKey: Data,
+        command: String,
+        timeout: Duration = .seconds(10)
+    ) async throws -> String {
+        try await remoteNodeService.sendRawCLICommand(
+            publicKey: publicKey,
+            command: command,
+            timeout: timeout
+        )
+    }
+
     // MARK: - Session Queries
 
     /// Fetch all repeater sessions for a device.

--- a/MC1Tests/Views/Tools/CLI/CLICompletionEngineTests.swift
+++ b/MC1Tests/Views/Tools/CLI/CLICompletionEngineTests.swift
@@ -49,6 +49,18 @@ struct CLICompletionEngineTests {
         #expect(suggestions.contains("ver"))
     }
 
+    @Test("Repeater commands can be included in local session when passthrough is enabled")
+    func repeaterCommandsInLocalWithPassthrough() {
+        let engine = createEngine()
+        let suggestions = engine.completions(
+            for: "v",
+            isLocal: true,
+            includeRepeaterCommandsInLocal: true
+        )
+
+        #expect(suggestions.contains("ver"))
+    }
+
     @Test("Login not available in remote session")
     func loginNotAvailableInRemoteSession() {
         let engine = createEngine()

--- a/MC1Tests/Views/Tools/CLI/CLIToolViewModelTests.swift
+++ b/MC1Tests/Views/Tools/CLI/CLIToolViewModelTests.swift
@@ -123,6 +123,27 @@ struct CLIToolViewModelTests {
         }
     }
 
+    @Test("Clear with arguments is not treated as local terminal clear")
+    func clearWithArgumentsDoesNotClearOutput() async throws {
+        let viewModel = createConfiguredViewModel()
+        viewModel.activeSession = .local(deviceName: "TestDevice")
+
+        viewModel.executeCommand("help")
+        try await waitUntil("help output should appear") {
+            !viewModel.outputLines.isEmpty
+        }
+        let countAfterHelp = viewModel.outputLines.count
+
+        viewModel.executeCommand("clear stats")
+        try await waitUntil("clear stats should produce output without clearing terminal") {
+            viewModel.outputLines.count > countAfterHelp
+        }
+
+        let output = viewModel.outputLines.map(\.text).joined(separator: "\n")
+        #expect(output.contains(L10n.Tools.Tools.Cli.unknownCommand))
+        #expect(!viewModel.outputLines.isEmpty)
+    }
+
     @Test("Help command shows available commands")
     func helpCommandShowsAvailableCommands() async throws {
         let viewModel = createConfiguredViewModel()


### PR DESCRIPTION
## Summary
- enable passthrough for unknown commands from local CLI session when connected device key is available
- add local raw command route via RepeaterAdminService/RemoteNodeService using public key (without remote session lookup)
- fix `clear <args>` handling so only bare `clear` clears terminal; `clear stats` is passed through
- include repeater command completions in local session when passthrough is available
- add and update CLI tests for new completion and clear behavior

## Why
Local CLI advertised repeater passthrough commands but responded with "Unknown command" in local session for many valid commands. This aligns local and remote behavior and removes a command-routing mismatch.
