### PR TITLE
feat(radio): add Chile region radio preset

### DIFF
--- a/MC1Services/Sources/MC1Services/Services/RadioPresets.swift
+++ b/MC1Services/Sources/MC1Services/Services/RadioPresets.swift
@@ -166,6 +166,7 @@ public enum RadioPresets {
                     ])),
 
         // South America
+        // Chile: community-standard settings from the MeshChile network (https://meshchile.cl).
         RadioPreset(id: "cl", name: "Chile", region: .southAmerica,
                     frequencyMHz: 927.875, bandwidthKHz: 62.5, spreadingFactor: 8, codingRate: 5,
                     availability: .countries(["CL"])),

--- a/MC1Services/Sources/MC1Services/Services/RadioPresets.swift
+++ b/MC1Services/Sources/MC1Services/Services/RadioPresets.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Geographic regions for radio preset filtering
 public enum RadioRegion: String, CaseIterable, Sendable {
     case northAmerica = "North America"
+    case southAmerica = "South America"
     case europe = "Europe"
     case oceania = "Oceania"
     case asia = "Asia"
@@ -22,6 +23,8 @@ public enum RadioRegion: String, CaseIterable, Sendable {
             return [.europe, .northAmerica, .oceania, .asia]
         case "VN", "TH", "MY", "SG", "PH", "ID":
             return [.asia, .oceania, .europe, .northAmerica]
+        case "CL":
+            return [.southAmerica, .northAmerica, .europe, .oceania, .asia]
         default:
             return RadioRegion.allCases
         }
@@ -31,6 +34,7 @@ public enum RadioRegion: String, CaseIterable, Sendable {
     public var shortCode: String {
         switch self {
         case .northAmerica: return "NA"
+        case .southAmerica: return "SA"
         case .europe: return "EU"
         case .oceania: return "AU"
         case .asia: return "AS"
@@ -160,6 +164,11 @@ public enum RadioPresets {
                         "los angeles", "orange", "san diego", "riverside", "san bernardino",
                         "ventura", "imperial", "kern", "santa barbara", "san luis obispo",
                     ])),
+
+        // South America
+        RadioPreset(id: "cl", name: "Chile", region: .southAmerica,
+                    frequencyMHz: 927.875, bandwidthKHz: 62.5, spreadingFactor: 8, codingRate: 5,
+                    availability: .countries(["CL"])),
 
         // Asia
         RadioPreset(id: "vn-narrow", name: "Vietnam (Narrow)", region: .asia,

--- a/MC1Services/Sources/MC1Services/Services/RegionalAreas.swift
+++ b/MC1Services/Sources/MC1Services/Services/RegionalAreas.swift
@@ -47,12 +47,14 @@ public enum RegionalAreas {
                     nameKey: "region.subdivision.AU-WA"),
     ]
 
-    /// ISO α-2 → `RadioRegion` mapping. Mexico (MX), Africa, and
-    /// South America are intentionally absent — these countries fall through
-    /// `recommended(for:)` to the empty-region fallback.
+    /// ISO α-2 → `RadioRegion` mapping. Mexico (MX) and Africa are intentionally
+    /// absent — those countries fall through `recommended(for:)` to the
+    /// empty-region fallback. South America is currently limited to Chile (CL).
     public static let continents: [String: RadioRegion] = [
         // North America
         "US": .northAmerica, "CA": .northAmerica,
+        // South America
+        "CL": .southAmerica,
         // Europe
         "GB": .europe, "IE": .europe, "DE": .europe, "FR": .europe,
         "IT": .europe, "ES": .europe, "PT": .europe, "NL": .europe,
@@ -76,6 +78,7 @@ public enum RegionalAreas {
     public static let countries: [Country] = [
         Country(id: "US", subdivisions: usSubdivisions),
         Country(id: "CA", subdivisions: nil),
+        Country(id: "CL", subdivisions: nil),
         Country(id: "AU", subdivisions: auSubdivisions),
         Country(id: "NZ", subdivisions: nil),
         Country(id: "GB", subdivisions: nil),

--- a/MC1Services/Tests/MC1ServicesTests/RadioPresetRecommendationTests.swift
+++ b/MC1Services/Tests/MC1ServicesTests/RadioPresetRecommendationTests.swift
@@ -72,6 +72,22 @@ struct RadioPresetRecommendationTests {
         #expect(RadioPresets.recommended(for: region)?.id == "nl")
     }
 
+    @Test("Chile → cl")
+    func chileGetsCL() {
+        let region = RegionSelection(countryCode: "CL", source: .location)
+        #expect(RadioPresets.recommended(for: region)?.id == "cl")
+    }
+
+    @Test("Chile preset carries the expected radio parameters")
+    func chilePresetParameters() throws {
+        let preset = try #require(RadioPresets.all.first(where: { $0.id == "cl" }))
+        #expect(preset.frequencyMHz == 927.875)
+        #expect(preset.bandwidthKHz == 62.5)
+        #expect(preset.spreadingFactor == 8)
+        #expect(preset.codingRate == 5)
+        #expect(preset.region == .southAmerica)
+    }
+
     // MARK: - Tier 3 (continent)
 
     @Test("Berlin (DE) → eu-narrow (priority 110 beats eu-lr)")


### PR DESCRIPTION
## Description

Adds a community radio preset for **Chile (CL)** so users in Chile get a recommended radio configuration out of the box instead of falling through to the empty-region fallback.

These are the settings in active use by the **MeshChile** community — https://meshchile.cl — submitted by a member of that community.

Chile configuration:

| Parameter | Value |
|-----------|-------|
| Frequency | 927.875 MHz |
| Bandwidth | 62.5 kHz |
| Spreading Factor | 8 |
| Coding Rate | 5 |

Chile sits in South America, which the codebase previously left intentionally unmapped. Rather than shoehorn it into an unrelated continent, this adds a proper `southAmerica` region so the preset is grouped under its own "South America" section in the picker.

## Overview of Changes

- **`RadioPresets.swift`**
  - Added `RadioRegion.southAmerica` (`"South America"`, short code `"SA"`).
  - Registered the `cl` preset in `RadioPresets.all` (927.875 MHz / 62.5 kHz / SF 8 / CR 5), available to country `CL`, with a comment citing MeshChile (https://meshchile.cl) as the source.
  - Prefer South America first in `regionsForLocale` for a `CL` locale.
- **`RegionalAreas.swift`**
  - Mapped `CL → .southAmerica` in `continents`.
  - Added Chile to the selectable `countries` catalog (no subdivisions) so it resolves through the country tier of `recommended(for:)`.
  - Updated the stale "South America is intentionally absent" comment.
- **`RadioPresetRecommendationTests.swift`**
  - Added a test asserting `CL → cl` recommendation.
  - Added a test asserting the `cl` preset carries the exact spec parameters and `.southAmerica` region.

The change follows the existing community-preset pattern (e.g. `vn-narrow`, `us-ca`) and touches no UI code — `RadioPresetSection` already iterates `RadioRegion.allCases`, so the new "South America" section renders automatically.

## Testing

- `swiftlint lint` on all changed files → **0 violations**.
- `swift build` of the `MC1Services` package → **build complete**.
- Verified the new behavior against the **real compiled `MC1Services` library** (recommendation + exact protocol-encoding values + regression spot-checks for US/Bermuda). All assertions pass:
  - `recommended(for: CL) == cl`
  - preset params: 927.875 MHz, 62.5 kHz, SF 8, CR 5, region `.southAmerica`
  - `frequencyKHz == 927_875`, `bandwidthHz == 62_500`
  - `CL` present in the countries catalog and mapped to `.southAmerica`
  - existing recommendations unchanged (US → `us-ca`, Bermuda → `nil`)

Note: I could not run the full Xcode app test suite on this machine — the required `iPhone 17e / iOS 26.5` simulator isn't installed, and the host's `AccessorySetupKit` SDK headers differ from CI (unrelated pre-existing build errors in `AccessorySetupKitService.swift`). The change is isolated to `MC1Services` data/logic, which is fully covered by the verification above.

## Tested on
- [ ] iOS [version]
- [ ] iPadOS [version]
- [ ] macOS [version]

## Checklist

- [x] This PR was discussed with the maintainer either via GitHub issue or other means (Also check the box if this PR is small enough not to need discussion e.g. typo fix)
- [x] I have read `CONTRIBUTING.md`
- [x] Testing steps are documented above.
- [x] This change is not low effort and I took the time to test it
