### PR TITLE
feat(repeater): neighbor map for repeater status view

### DIFF
--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -27,11 +27,6 @@ jobs:
           submodules: recursive
           fetch-depth: 2
 
-      - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '26.4.1'
-
       - name: Check version change
         id: version_check
         run: |
@@ -67,6 +62,7 @@ jobs:
         if: steps.version_check.outputs.should_build == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           brew tap FelixHerrmann/tap
+          brew trust FelixHerrmann/tap
           brew install xcodegen swiftgen swift-package-list
 
       - name: Generate Xcode project

--- a/MC1/Resources/Generated/L10n.swift
+++ b/MC1/Resources/Generated/L10n.swift
@@ -2941,7 +2941,7 @@ public enum L10n {
       /// Location: DeviceScanView.swift - Button to retry connection after other-app conflict
       public static let retryConnection = L10n.tr("Onboarding", "deviceScan.retryConnection", fallback: "Retry Connection")
       /// Location: DeviceScanView.swift - Subtitle with pairing instructions
-      public static let subtitle = L10n.tr("Onboarding", "deviceScan.subtitle", fallback: "Power it on, then tap Add Device.")
+      public static let subtitle = L10n.tr("Onboarding", "deviceScan.subtitle", fallback: "Power your radio on, disconnect it from all other apps and devices, then tap Add Device.")
       /// Location: DeviceScanView.swift - Screen title for device pairing
       public static let title = L10n.tr("Onboarding", "deviceScan.title", fallback: "Pair your device")
       public enum DemoModeAlert {
@@ -3727,6 +3727,8 @@ public enum L10n {
         public static func minutesAgo(_ p1: Int) -> String {
           return L10n.tr("RemoteNodes", "remoteNodes.status.minutesAgo", p1, fallback: "%dm ago")
         }
+        /// Location: NeighborMapView.swift - Button label and navigation title
+        public static let neighborMap = L10n.tr("RemoteNodes", "remoteNodes.status.neighborMap", fallback: "Neighbor Map")
         /// Location: RepeaterStatusView.swift - Neighbors section label
         public static let neighbors = L10n.tr("RemoteNodes", "remoteNodes.status.neighbors", fallback: "Neighbors")
         /// Location: RepeaterStatusView.swift - Neighbors section footer
@@ -3814,6 +3816,14 @@ public enum L10n {
           public static let reloadStatus = L10n.tr("RemoteNodes", "remoteNodes.status.accessibility.reloadStatus", fallback: "Reload status")
           /// Location: SharedNodeStatusViews.swift - Per-section reload button accessibility label for telemetry
           public static let reloadTelemetry = L10n.tr("RemoteNodes", "remoteNodes.status.accessibility.reloadTelemetry", fallback: "Reload telemetry")
+        }
+        public enum NeighborMap {
+          public enum Unavailable {
+            /// Location: NeighborMapView.swift - Empty state description
+            public static let description = L10n.tr("RemoteNodes", "remoteNodes.status.neighborMap.unavailable.description", fallback: "None of the discovered neighbors have a known GPS position.")
+            /// Location: NeighborMapView.swift - Empty state title
+            public static let title = L10n.tr("RemoteNodes", "remoteNodes.status.neighborMap.unavailable.title", fallback: "No Locations Available")
+          }
         }
         public enum Sensor {
           /// Accelerometer

--- a/MC1/Resources/Localization/de.lproj/Onboarding.strings
+++ b/MC1/Resources/Localization/de.lproj/Onboarding.strings
@@ -67,7 +67,7 @@
 "deviceScan.title" = "Gerät koppeln";
 
 /* Location: DeviceScanView.swift - Subtitle with pairing instructions */
-"deviceScan.subtitle" = "Schalte es ein, dann tippe auf \"Gerät hinzufügen\".";
+"deviceScan.subtitle" = "Schalte dein Funkgerät ein, trenne es von allen anderen Apps und Geräten und tippe dann auf \"Gerät hinzufügen\".";
 
 /* Location: DeviceScanView.swift - Message shown when device is already paired */
 "deviceScan.alreadyPaired" = "Dein Gerät ist bereits gekoppelt";

--- a/MC1/Resources/Localization/de.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/de.lproj/RemoteNodes.strings
@@ -530,6 +530,15 @@
 /* Location: RepeaterStatusView.swift - Discover neighbours button label */
 "remoteNodes.status.discoverNeighbors" = "Nachbarn entdecken";
 
+/* Location: NeighborMapView.swift - Button label and navigation title */
+"remoteNodes.status.neighborMap" = "Nachbarkarte";
+
+/* Location: NeighborMapView.swift - Empty state title */
+"remoteNodes.status.neighborMap.unavailable.title" = "Keine Positionen verfügbar";
+
+/* Location: NeighborMapView.swift - Empty state description */
+"remoteNodes.status.neighborMap.unavailable.description" = "Keiner der entdeckten Nachbarn hat eine bekannte GPS-Position.";
+
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "Suche... %ds";
 

--- a/MC1/Resources/Localization/en.lproj/Onboarding.strings
+++ b/MC1/Resources/Localization/en.lproj/Onboarding.strings
@@ -67,7 +67,7 @@
 "deviceScan.title" = "Pair your device";
 
 /* Location: DeviceScanView.swift - Subtitle with pairing instructions */
-"deviceScan.subtitle" = "Power it on, then tap Add Device.";
+"deviceScan.subtitle" = "Power your radio on, disconnect it from all other apps and devices, then tap Add Device.";
 
 /* Location: DeviceScanView.swift - Message shown when device is already paired */
 "deviceScan.alreadyPaired" = "Your device is already paired";

--- a/MC1/Resources/Localization/en.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/en.lproj/RemoteNodes.strings
@@ -559,6 +559,15 @@
 /* Location: RepeaterStatusView.swift - Discover neighbours button label */
 "remoteNodes.status.discoverNeighbors" = "Discover Neighbours";
 
+/* Location: NeighborMapView.swift - Button label and navigation title */
+"remoteNodes.status.neighborMap" = "Neighbor Map";
+
+/* Location: NeighborMapView.swift - Empty state title */
+"remoteNodes.status.neighborMap.unavailable.title" = "No Locations Available";
+
+/* Location: NeighborMapView.swift - Empty state description */
+"remoteNodes.status.neighborMap.unavailable.description" = "None of the discovered neighbors have a known GPS position.";
+
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "Discovering... %ds";
 

--- a/MC1/Resources/Localization/es.lproj/Onboarding.strings
+++ b/MC1/Resources/Localization/es.lproj/Onboarding.strings
@@ -67,7 +67,7 @@
 "deviceScan.title" = "Empareja tu dispositivo";
 
 /* Location: DeviceScanView.swift - Subtitle with pairing instructions */
-"deviceScan.subtitle" = "Enciéndelo y toca Añadir dispositivo.";
+"deviceScan.subtitle" = "Enciende tu radio, desconéctala de todas las demás apps y dispositivos y, a continuación, toca Añadir dispositivo.";
 
 /* Location: DeviceScanView.swift - Message shown when device is already paired */
 "deviceScan.alreadyPaired" = "Tu dispositivo ya está emparejado";

--- a/MC1/Resources/Localization/es.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/es.lproj/RemoteNodes.strings
@@ -530,6 +530,15 @@
 /* Location: RepeaterStatusView.swift - Discover neighbours button label */
 "remoteNodes.status.discoverNeighbors" = "Descubrir vecinos";
 
+/* Location: NeighborMapView.swift - Button label and navigation title */
+"remoteNodes.status.neighborMap" = "Neighbor Map";
+
+/* Location: NeighborMapView.swift - Empty state title */
+"remoteNodes.status.neighborMap.unavailable.title" = "No Locations Available";
+
+/* Location: NeighborMapView.swift - Empty state description */
+"remoteNodes.status.neighborMap.unavailable.description" = "None of the discovered neighbors have a known GPS position.";
+
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "Descubriendo... %ds";
 

--- a/MC1/Resources/Localization/es.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/es.lproj/RemoteNodes.strings
@@ -531,13 +531,13 @@
 "remoteNodes.status.discoverNeighbors" = "Descubrir vecinos";
 
 /* Location: NeighborMapView.swift - Button label and navigation title */
-"remoteNodes.status.neighborMap" = "Neighbor Map";
+"remoteNodes.status.neighborMap" = "";
 
 /* Location: NeighborMapView.swift - Empty state title */
-"remoteNodes.status.neighborMap.unavailable.title" = "No Locations Available";
+"remoteNodes.status.neighborMap.unavailable.title" = "";
 
 /* Location: NeighborMapView.swift - Empty state description */
-"remoteNodes.status.neighborMap.unavailable.description" = "None of the discovered neighbors have a known GPS position.";
+"remoteNodes.status.neighborMap.unavailable.description" = "";
 
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "Descubriendo... %ds";

--- a/MC1/Resources/Localization/fr.lproj/Onboarding.strings
+++ b/MC1/Resources/Localization/fr.lproj/Onboarding.strings
@@ -67,7 +67,7 @@
 "deviceScan.title" = "Associer votre appareil";
 
 /* Location: DeviceScanView.swift - Subtitle with pairing instructions */
-"deviceScan.subtitle" = "Allumez-le, puis appuyez sur Ajouter un appareil.";
+"deviceScan.subtitle" = "Allumez votre radio, déconnectez-la de toutes les autres applications et de tous les autres appareils, puis appuyez sur Ajouter un appareil.";
 
 /* Location: DeviceScanView.swift - Message shown when device is already paired */
 "deviceScan.alreadyPaired" = "Votre appareil est déjà associé";

--- a/MC1/Resources/Localization/fr.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/fr.lproj/RemoteNodes.strings
@@ -530,6 +530,15 @@
 /* Location: RepeaterStatusView.swift - Discover neighbours button label */
 "remoteNodes.status.discoverNeighbors" = "Découvrir les voisins";
 
+/* Location: NeighborMapView.swift - Button label and navigation title */
+"remoteNodes.status.neighborMap" = "Neighbor Map";
+
+/* Location: NeighborMapView.swift - Empty state title */
+"remoteNodes.status.neighborMap.unavailable.title" = "No Locations Available";
+
+/* Location: NeighborMapView.swift - Empty state description */
+"remoteNodes.status.neighborMap.unavailable.description" = "None of the discovered neighbors have a known GPS position.";
+
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "Découverte... %ds";
 

--- a/MC1/Resources/Localization/fr.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/fr.lproj/RemoteNodes.strings
@@ -531,13 +531,13 @@
 "remoteNodes.status.discoverNeighbors" = "Découvrir les voisins";
 
 /* Location: NeighborMapView.swift - Button label and navigation title */
-"remoteNodes.status.neighborMap" = "Neighbor Map";
+"remoteNodes.status.neighborMap" = "";
 
 /* Location: NeighborMapView.swift - Empty state title */
-"remoteNodes.status.neighborMap.unavailable.title" = "No Locations Available";
+"remoteNodes.status.neighborMap.unavailable.title" = "";
 
 /* Location: NeighborMapView.swift - Empty state description */
-"remoteNodes.status.neighborMap.unavailable.description" = "None of the discovered neighbors have a known GPS position.";
+"remoteNodes.status.neighborMap.unavailable.description" = "";
 
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "Découverte... %ds";

--- a/MC1/Resources/Localization/nl.lproj/Onboarding.strings
+++ b/MC1/Resources/Localization/nl.lproj/Onboarding.strings
@@ -67,7 +67,7 @@
 "deviceScan.title" = "Koppel je apparaat";
 
 /* Location: DeviceScanView.swift - Subtitle with pairing instructions */
-"deviceScan.subtitle" = "Schakel het in en tik op Apparaat toevoegen.";
+"deviceScan.subtitle" = "Schakel je radio in, koppel deze los van alle andere apps en apparaten en tik vervolgens op Apparaat toevoegen.";
 
 /* Location: DeviceScanView.swift - Message shown when device is already paired */
 "deviceScan.alreadyPaired" = "Je apparaat is al gekoppeld";

--- a/MC1/Resources/Localization/nl.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/nl.lproj/RemoteNodes.strings
@@ -531,13 +531,13 @@
 "remoteNodes.status.discoverNeighbors" = "Buren ontdekken";
 
 /* Location: NeighborMapView.swift - Button label and navigation title */
-"remoteNodes.status.neighborMap" = "Neighbor Map";
+"remoteNodes.status.neighborMap" = "";
 
 /* Location: NeighborMapView.swift - Empty state title */
-"remoteNodes.status.neighborMap.unavailable.title" = "No Locations Available";
+"remoteNodes.status.neighborMap.unavailable.title" = "";
 
 /* Location: NeighborMapView.swift - Empty state description */
-"remoteNodes.status.neighborMap.unavailable.description" = "None of the discovered neighbors have a known GPS position.";
+"remoteNodes.status.neighborMap.unavailable.description" = "";
 
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "Ontdekken... %ds";

--- a/MC1/Resources/Localization/nl.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/nl.lproj/RemoteNodes.strings
@@ -530,6 +530,15 @@
 /* Location: RepeaterStatusView.swift - Discover neighbours button label */
 "remoteNodes.status.discoverNeighbors" = "Buren ontdekken";
 
+/* Location: NeighborMapView.swift - Button label and navigation title */
+"remoteNodes.status.neighborMap" = "Neighbor Map";
+
+/* Location: NeighborMapView.swift - Empty state title */
+"remoteNodes.status.neighborMap.unavailable.title" = "No Locations Available";
+
+/* Location: NeighborMapView.swift - Empty state description */
+"remoteNodes.status.neighborMap.unavailable.description" = "None of the discovered neighbors have a known GPS position.";
+
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "Ontdekken... %ds";
 

--- a/MC1/Resources/Localization/pl.lproj/Onboarding.strings
+++ b/MC1/Resources/Localization/pl.lproj/Onboarding.strings
@@ -67,7 +67,7 @@
 "deviceScan.title" = "Sparuj urządzenie";
 
 /* Location: DeviceScanView.swift - Subtitle with pairing instructions */
-"deviceScan.subtitle" = "Włącz je, a następnie dotknij Dodaj urządzenie.";
+"deviceScan.subtitle" = "Włącz radio, odłącz je od wszystkich innych aplikacji i urządzeń, a następnie dotknij Dodaj urządzenie.";
 
 /* Location: DeviceScanView.swift - Message shown when device is already paired */
 "deviceScan.alreadyPaired" = "Twoje urządzenie jest już sparowane";

--- a/MC1/Resources/Localization/pl.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/pl.lproj/RemoteNodes.strings
@@ -528,13 +528,13 @@
 "remoteNodes.status.discoverNeighbors" = "Odkryj sąsiadów";
 
 /* Location: NeighborMapView.swift - Button label and navigation title */
-"remoteNodes.status.neighborMap" = "Neighbor Map";
+"remoteNodes.status.neighborMap" = "";
 
 /* Location: NeighborMapView.swift - Empty state title */
-"remoteNodes.status.neighborMap.unavailable.title" = "No Locations Available";
+"remoteNodes.status.neighborMap.unavailable.title" = "";
 
 /* Location: NeighborMapView.swift - Empty state description */
-"remoteNodes.status.neighborMap.unavailable.description" = "None of the discovered neighbors have a known GPS position.";
+"remoteNodes.status.neighborMap.unavailable.description" = "";
 
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "Odkrywanie... %ds";

--- a/MC1/Resources/Localization/pl.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/pl.lproj/RemoteNodes.strings
@@ -527,6 +527,15 @@
 /* Location: RepeaterStatusView.swift - Discover neighbours button label */
 "remoteNodes.status.discoverNeighbors" = "Odkryj sąsiadów";
 
+/* Location: NeighborMapView.swift - Button label and navigation title */
+"remoteNodes.status.neighborMap" = "Neighbor Map";
+
+/* Location: NeighborMapView.swift - Empty state title */
+"remoteNodes.status.neighborMap.unavailable.title" = "No Locations Available";
+
+/* Location: NeighborMapView.swift - Empty state description */
+"remoteNodes.status.neighborMap.unavailable.description" = "None of the discovered neighbors have a known GPS position.";
+
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "Odkrywanie... %ds";
 

--- a/MC1/Resources/Localization/ru.lproj/Onboarding.strings
+++ b/MC1/Resources/Localization/ru.lproj/Onboarding.strings
@@ -67,7 +67,7 @@
 "deviceScan.title" = "Сопряжение устройства";
 
 /* Location: DeviceScanView.swift - Subtitle with pairing instructions */
-"deviceScan.subtitle" = "Включите его, затем нажмите «Добавить устройство».";
+"deviceScan.subtitle" = "Включите рацию, отключите её от всех других приложений и устройств, а затем нажмите «Добавить устройство».";
 
 /* Location: DeviceScanView.swift - Message shown when device is already paired */
 "deviceScan.alreadyPaired" = "Ваше устройство уже сопряжено";

--- a/MC1/Resources/Localization/ru.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/ru.lproj/RemoteNodes.strings
@@ -527,6 +527,15 @@
 /* Location: RepeaterStatusView.swift - Discover neighbours button label */
 "remoteNodes.status.discoverNeighbors" = "Обнаружить соседей";
 
+/* Location: NeighborMapView.swift - Button label and navigation title */
+"remoteNodes.status.neighborMap" = "Neighbor Map";
+
+/* Location: NeighborMapView.swift - Empty state title */
+"remoteNodes.status.neighborMap.unavailable.title" = "No Locations Available";
+
+/* Location: NeighborMapView.swift - Empty state description */
+"remoteNodes.status.neighborMap.unavailable.description" = "None of the discovered neighbors have a known GPS position.";
+
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "Обнаружение... %dс";
 

--- a/MC1/Resources/Localization/ru.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/ru.lproj/RemoteNodes.strings
@@ -528,13 +528,13 @@
 "remoteNodes.status.discoverNeighbors" = "Обнаружить соседей";
 
 /* Location: NeighborMapView.swift - Button label and navigation title */
-"remoteNodes.status.neighborMap" = "Neighbor Map";
+"remoteNodes.status.neighborMap" = "";
 
 /* Location: NeighborMapView.swift - Empty state title */
-"remoteNodes.status.neighborMap.unavailable.title" = "No Locations Available";
+"remoteNodes.status.neighborMap.unavailable.title" = "";
 
 /* Location: NeighborMapView.swift - Empty state description */
-"remoteNodes.status.neighborMap.unavailable.description" = "None of the discovered neighbors have a known GPS position.";
+"remoteNodes.status.neighborMap.unavailable.description" = "";
 
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "Обнаружение... %dс";

--- a/MC1/Resources/Localization/uk.lproj/Onboarding.strings
+++ b/MC1/Resources/Localization/uk.lproj/Onboarding.strings
@@ -67,7 +67,7 @@
 "deviceScan.title" = "Сполучення пристрою";
 
 /* Location: DeviceScanView.swift - Subtitle with pairing instructions */
-"deviceScan.subtitle" = "Увімкніть його, а потім торкніться «Додати пристрій».";
+"deviceScan.subtitle" = "Увімкніть рацію, від'єднайте її від усіх інших додатків і пристроїв, а потім торкніться «Додати пристрій».";
 
 /* Location: DeviceScanView.swift - Message shown when device is already paired */
 "deviceScan.alreadyPaired" = "Ваш пристрій вже сполучено";

--- a/MC1/Resources/Localization/uk.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/uk.lproj/RemoteNodes.strings
@@ -527,6 +527,15 @@
 /* Location: RepeaterStatusView.swift - Discover neighbours button label */
 "remoteNodes.status.discoverNeighbors" = "Виявити сусідів";
 
+/* Location: NeighborMapView.swift - Button label and navigation title */
+"remoteNodes.status.neighborMap" = "Neighbor Map";
+
+/* Location: NeighborMapView.swift - Empty state title */
+"remoteNodes.status.neighborMap.unavailable.title" = "No Locations Available";
+
+/* Location: NeighborMapView.swift - Empty state description */
+"remoteNodes.status.neighborMap.unavailable.description" = "None of the discovered neighbors have a known GPS position.";
+
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "Виявлення... %dс";
 

--- a/MC1/Resources/Localization/uk.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/uk.lproj/RemoteNodes.strings
@@ -528,13 +528,13 @@
 "remoteNodes.status.discoverNeighbors" = "Виявити сусідів";
 
 /* Location: NeighborMapView.swift - Button label and navigation title */
-"remoteNodes.status.neighborMap" = "Neighbor Map";
+"remoteNodes.status.neighborMap" = "";
 
 /* Location: NeighborMapView.swift - Empty state title */
-"remoteNodes.status.neighborMap.unavailable.title" = "No Locations Available";
+"remoteNodes.status.neighborMap.unavailable.title" = "";
 
 /* Location: NeighborMapView.swift - Empty state description */
-"remoteNodes.status.neighborMap.unavailable.description" = "None of the discovered neighbors have a known GPS position.";
+"remoteNodes.status.neighborMap.unavailable.description" = "";
 
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "Виявлення... %dс";

--- a/MC1/Resources/Localization/zh-Hans.lproj/Onboarding.strings
+++ b/MC1/Resources/Localization/zh-Hans.lproj/Onboarding.strings
@@ -65,7 +65,7 @@
 "deviceScan.title" = "配对您的设备";
 
 /* Location: DeviceScanView.swift - Subtitle with pairing instructions */
-"deviceScan.subtitle" = "开启设备，然后点击「添加设备」。";
+"deviceScan.subtitle" = "开启设备，断开它与所有其他应用和设备的连接，然后点击「添加设备」。";
 
 /* Location: DeviceScanView.swift - Message shown when device is already paired */
 "deviceScan.alreadyPaired" = "您的设备已配对";

--- a/MC1/Resources/Localization/zh-Hans.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/zh-Hans.lproj/RemoteNodes.strings
@@ -530,6 +530,15 @@
 /* Location: RepeaterStatusView.swift - Discover neighbours button label */
 "remoteNodes.status.discoverNeighbors" = "发现邻居";
 
+/* Location: NeighborMapView.swift - Button label and navigation title */
+"remoteNodes.status.neighborMap" = "Neighbor Map";
+
+/* Location: NeighborMapView.swift - Empty state title */
+"remoteNodes.status.neighborMap.unavailable.title" = "No Locations Available";
+
+/* Location: NeighborMapView.swift - Empty state description */
+"remoteNodes.status.neighborMap.unavailable.description" = "None of the discovered neighbors have a known GPS position.";
+
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "发现中... %d秒";
 

--- a/MC1/Resources/Localization/zh-Hans.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/zh-Hans.lproj/RemoteNodes.strings
@@ -531,13 +531,13 @@
 "remoteNodes.status.discoverNeighbors" = "发现邻居";
 
 /* Location: NeighborMapView.swift - Button label and navigation title */
-"remoteNodes.status.neighborMap" = "Neighbor Map";
+"remoteNodes.status.neighborMap" = "";
 
 /* Location: NeighborMapView.swift - Empty state title */
-"remoteNodes.status.neighborMap.unavailable.title" = "No Locations Available";
+"remoteNodes.status.neighborMap.unavailable.title" = "";
 
 /* Location: NeighborMapView.swift - Empty state description */
-"remoteNodes.status.neighborMap.unavailable.description" = "None of the discovered neighbors have a known GPS position.";
+"remoteNodes.status.neighborMap.unavailable.description" = "";
 
 /* Location: RepeaterStatusView.swift - Discovery in progress with countdown */
 "remoteNodes.status.discoveringSeconds" = "发现中... %d秒";

--- a/MC1/Views/RemoteNodes/Repeaters/NeighborMapView.swift
+++ b/MC1/Views/RemoteNodes/Repeaters/NeighborMapView.swift
@@ -1,0 +1,235 @@
+import CoreLocation
+import MapKit
+import MC1Services
+import SwiftUI
+
+struct NeighborMapView: View {
+    @Environment(\.appState) private var appState
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dismiss) private var dismiss
+
+    let session: RemoteNodeSessionDTO
+    let neighbors: [NeighbourInfo]
+    let contacts: [ContactDTO]
+    let discoveredNodes: [DiscoveredNodeDTO]
+    let userLocation: CLLocation?
+
+    @State private var mapPoints: [MapPoint] = []
+    @State private var mapLines: [MapLine] = []
+    @State private var cameraRegion: MKCoordinateRegion?
+    @State private var cameraRegionVersion = 0
+    @State private var mapStyle: MapStyleSelection = .standard
+    @State private var isNorthLocked = false
+    @State private var showLabels = true
+    @State private var showingLayersMenu = false
+    @State private var isStyleLoaded = false
+    @State private var hasInitiallyFit = false
+
+    private static let singleNodeSpanDelta: CLLocationDegrees = 0.05
+    private static let boundingPaddingMultiplier: Double = 2.0
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if mapPoints.isEmpty {
+                    ContentUnavailableView(
+                        L10n.RemoteNodes.RemoteNodes.Status.NeighborMap.Unavailable.title,
+                        systemImage: "map",
+                        description: Text(L10n.RemoteNodes.RemoteNodes.Status.NeighborMap.Unavailable.description)
+                    )
+                } else {
+                    ZStack(alignment: .bottomTrailing) {
+                        MC1MapView(
+                            points: mapPoints,
+                            lines: mapLines,
+                            mapStyle: mapStyle,
+                            isDarkMode: colorScheme == .dark,
+                            isOffline: !appState.offlineMapService.isNetworkAvailable,
+                            showLabels: showLabels,
+                            showsUserLocation: false,
+                            isInteractive: true,
+                            showsScale: true,
+                            isNorthLocked: isNorthLocked,
+                            cameraRegion: $cameraRegion,
+                            cameraRegionVersion: cameraRegionVersion,
+                            onPointTap: nil,
+                            onMapTap: nil,
+                            onCameraRegionChange: { cameraRegion = $0 },
+                            isStyleLoaded: $isStyleLoaded
+                        )
+                        .ignoresSafeArea()
+
+                        VStack {
+                            Spacer()
+                            HStack {
+                                Spacer()
+                                MapControlsToolbar(
+                                    onLocationTap: centerOnUserLocation,
+                                    isNorthLocked: $isNorthLocked,
+                                    showLabels: $showLabels,
+                                    showingLayersMenu: $showingLayersMenu
+                                ) {
+                                    Button(L10n.Map.Map.Controls.centerAll, systemImage: "arrow.up.left.and.arrow.down.right") {
+                                        fitCamera()
+                                    }
+                                    .mapControlButton(tint: .primary)
+                                }
+                            }
+                        }
+                        .overlay(alignment: .bottomTrailing) {
+                            if showingLayersMenu {
+                                LayersMenu(
+                                    selection: $mapStyle,
+                                    isPresented: $showingLayersMenu,
+                                    viewportBounds: cameraRegion?.toMLNCoordinateBounds()
+                                )
+                                .padding(.trailing, 16)
+                                .padding(.bottom, 160)
+                                .transition(.scale.combined(with: .opacity))
+                            }
+                        }
+                        .animation(.spring(response: 0.3), value: showingLayersMenu)
+                    }
+                }
+            }
+            .navigationTitle(L10n.RemoteNodes.RemoteNodes.Status.neighborMap)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(L10n.Localizable.Common.done) { dismiss() }
+                }
+            }
+            .onAppear {
+                buildOverlays()
+            }
+            .onChange(of: isStyleLoaded) { _, loaded in
+                guard loaded, !hasInitiallyFit else { return }
+                hasInitiallyFit = true
+                fitCamera()
+            }
+        }
+    }
+
+    // MARK: - Overlay Building
+
+    private func buildOverlays() {
+        var points: [MapPoint] = []
+        var lines: [MapLine] = []
+        var repeaterCoordinate: CLLocationCoordinate2D?
+
+        if session.latitude != 0 || session.longitude != 0 {
+            let coord = CLLocationCoordinate2D(latitude: session.latitude, longitude: session.longitude)
+            if CLLocationCoordinate2DIsValid(coord) {
+                repeaterCoordinate = coord
+                points.append(MapPoint(
+                    id: session.id,
+                    coordinate: coord,
+                    pinStyle: .repeaterRingBlue,
+                    label: session.name,
+                    isClusterable: false,
+                    hopIndex: nil,
+                    badgeText: nil
+                ))
+            }
+        }
+
+        for neighbor in neighbors {
+            let resolution = NeighborNameResolver.resolve(
+                for: neighbor.publicKeyPrefix,
+                contacts: contacts,
+                discoveredNodes: discoveredNodes,
+                userLocation: userLocation
+            )
+            guard let displayName = resolution?.displayName else { continue }
+            guard let neighborCoord = resolvedCoordinate(for: neighbor.publicKeyPrefix) else { continue }
+
+            points.append(MapPoint(
+                id: UUID(),
+                coordinate: neighborCoord,
+                pinStyle: .repeater,
+                label: displayName,
+                isClusterable: false,
+                hopIndex: nil,
+                badgeText: nil
+            ))
+
+            if let origin = repeaterCoordinate {
+                lines.append(MapLine(
+                    id: "neighbor-\(neighbor.publicKeyPrefix.uppercaseHexString())",
+                    coordinates: [origin, neighborCoord],
+                    style: lineStyle(for: neighbor.snr),
+                    opacity: 1.0
+                ))
+
+                let mid = CLLocationCoordinate2D(
+                    latitude: (origin.latitude + neighborCoord.latitude) / 2,
+                    longitude: (origin.longitude + neighborCoord.longitude) / 2
+                )
+                let snrText = neighbor.snr.formatted(.number.precision(.fractionLength(1))) + " dB"
+                points.append(MapPoint(
+                    id: UUID(),
+                    coordinate: mid,
+                    pinStyle: .badge,
+                    label: nil,
+                    isClusterable: false,
+                    hopIndex: nil,
+                    badgeText: snrText
+                ))
+            }
+        }
+
+        mapPoints = points
+        mapLines = lines
+    }
+
+    private func resolvedCoordinate(for prefix: Data) -> CLLocationCoordinate2D? {
+        if let contact = RepeaterResolver.bestMatch(for: prefix, in: contacts, userLocation: userLocation),
+           contact.hasLocation {
+            return CLLocationCoordinate2D(latitude: contact.latitude, longitude: contact.longitude)
+        }
+        if let node = RepeaterResolver.bestMatch(for: prefix, in: discoveredNodes, userLocation: userLocation),
+           node.hasLocation {
+            return CLLocationCoordinate2D(latitude: node.latitude, longitude: node.longitude)
+        }
+        return nil
+    }
+
+    private func lineStyle(for snr: Double) -> MapLine.LineStyle {
+        switch SNRQuality(snr: snr) {
+        case .excellent, .good: .traceGood
+        case .fair: .traceMedium
+        case .poor: .traceWeak
+        case .unknown: .traceUntraced
+        }
+    }
+
+    // MARK: - Camera
+
+    private func fitCamera() {
+        let coords = mapPoints.filter { $0.pinStyle != .badge }.map(\.coordinate)
+        if coords.count == 1 {
+            cameraRegion = MKCoordinateRegion(
+                center: coords[0],
+                span: MKCoordinateSpan(
+                    latitudeDelta: Self.singleNodeSpanDelta,
+                    longitudeDelta: Self.singleNodeSpanDelta
+                )
+            )
+        } else if let region = coords.boundingRegion(paddingMultiplier: Self.boundingPaddingMultiplier) {
+            cameraRegion = region
+        }
+        cameraRegionVersion += 1
+    }
+
+    private func centerOnUserLocation() {
+        guard let location = appState.bestAvailableLocation else { return }
+        cameraRegion = MKCoordinateRegion(
+            center: location.coordinate,
+            span: MKCoordinateSpan(
+                latitudeDelta: Self.singleNodeSpanDelta,
+                longitudeDelta: Self.singleNodeSpanDelta
+            )
+        )
+        cameraRegionVersion += 1
+    }
+}

--- a/MC1/Views/RemoteNodes/Repeaters/NeighborMapView.swift
+++ b/MC1/Views/RemoteNodes/Repeaters/NeighborMapView.swift
@@ -24,6 +24,7 @@ struct NeighborMapView: View {
     @State private var showingLayersMenu = false
     @State private var isStyleLoaded = false
     @State private var hasInitiallyFit = false
+    @State private var didLoad = false
 
     private static let singleNodeSpanDelta: CLLocationDegrees = 0.05
     private static let boundingPaddingMultiplier: Double = 2.0
@@ -31,7 +32,9 @@ struct NeighborMapView: View {
     var body: some View {
         NavigationStack {
             Group {
-                if mapPoints.isEmpty {
+                if !didLoad {
+                    Color.clear
+                } else if mapPoints.isEmpty {
                     ContentUnavailableView(
                         L10n.RemoteNodes.RemoteNodes.Status.NeighborMap.Unavailable.title,
                         systemImage: "map",
@@ -101,6 +104,7 @@ struct NeighborMapView: View {
             }
             .onAppear {
                 buildOverlays()
+                didLoad = true
             }
             .onChange(of: isStyleLoaded) { _, loaded in
                 guard loaded, !hasInitiallyFit else { return }
@@ -144,7 +148,7 @@ struct NeighborMapView: View {
             guard let neighborCoord = resolvedCoordinate(for: neighbor.publicKeyPrefix) else { continue }
 
             points.append(MapPoint(
-                id: UUID(),
+                id: UUID(neighborPin: neighbor.publicKeyPrefix),
                 coordinate: neighborCoord,
                 pinStyle: .repeater,
                 label: displayName,
@@ -167,7 +171,7 @@ struct NeighborMapView: View {
                 )
                 let snrText = neighbor.snr.formatted(.number.precision(.fractionLength(1))) + " dB"
                 points.append(MapPoint(
-                    id: UUID(),
+                    id: UUID(neighborBadge: neighbor.publicKeyPrefix),
                     coordinate: mid,
                     pinStyle: .badge,
                     label: nil,
@@ -231,5 +235,21 @@ struct NeighborMapView: View {
             )
         )
         cameraRegionVersion += 1
+    }
+}
+
+// MARK: - Deterministic UUIDs
+
+private extension UUID {
+    init(neighborPin prefix: Data) {
+        let hex = String(prefix.prefix(6).uppercaseHexString().prefix(12))
+        let padded = String(repeating: "0", count: max(0, 12 - hex.count)) + hex
+        self = UUID(uuidString: "11111111-1111-1111-1111-\(padded)") ?? UUID()
+    }
+
+    init(neighborBadge prefix: Data) {
+        let hex = String(prefix.prefix(6).uppercaseHexString().prefix(12))
+        let padded = String(repeating: "0", count: max(0, 12 - hex.count)) + hex
+        self = UUID(uuidString: "22222222-2222-2222-2222-\(padded)") ?? UUID()
     }
 }

--- a/MC1/Views/RemoteNodes/Repeaters/RepeaterStatusContent.swift
+++ b/MC1/Views/RemoteNodes/Repeaters/RepeaterStatusContent.swift
@@ -152,6 +152,8 @@ private struct NeighborsSection: View {
     let userLocation: CLLocation?
     let connectionState: DeviceConnectionState
 
+    @State private var showingNeighborMap = false
+
     var body: some View {
         Section {
             DisclosureGroup(isExpanded: $viewModel.neighborsExpanded) {
@@ -208,6 +210,14 @@ private struct NeighborsSection: View {
                             )
                         }
                     }
+
+                    if !viewModel.neighbors.isEmpty {
+                        Button {
+                            showingNeighborMap = true
+                        } label: {
+                            Label(L10n.RemoteNodes.RemoteNodes.Status.neighborMap, systemImage: "map")
+                        }
+                    }
                 }
 
                 if session.isAdmin {
@@ -259,5 +269,14 @@ private struct NeighborsSection: View {
             Text(L10n.RemoteNodes.RemoteNodes.Status.neighborsFooter)
         }
         .themedRowBackground(theme)
+        .sheet(isPresented: $showingNeighborMap) {
+            NeighborMapView(
+                session: session,
+                neighbors: viewModel.neighbors,
+                contacts: contacts,
+                discoveredNodes: discoveredNodes,
+                userLocation: userLocation
+            )
+        }
     }
 }

--- a/MC1Services/Sources/MC1Services/Services/RadioPresets.swift
+++ b/MC1Services/Sources/MC1Services/Services/RadioPresets.swift
@@ -166,6 +166,7 @@ public enum RadioPresets {
                     ])),
 
         // South America
+        // Chile: community-standard settings from the MeshChile network (https://meshchile.cl).
         RadioPreset(id: "cl", name: "Chile", region: .southAmerica,
                     frequencyMHz: 927.875, bandwidthKHz: 62.5, spreadingFactor: 8, codingRate: 5,
                     availability: .countries(["CL"])),

--- a/MC1Services/Sources/MC1Services/Services/RadioPresets.swift
+++ b/MC1Services/Sources/MC1Services/Services/RadioPresets.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Geographic regions for radio preset filtering
 public enum RadioRegion: String, CaseIterable, Sendable {
     case northAmerica = "North America"
+    case southAmerica = "South America"
     case europe = "Europe"
     case oceania = "Oceania"
     case asia = "Asia"
@@ -22,6 +23,8 @@ public enum RadioRegion: String, CaseIterable, Sendable {
             return [.europe, .northAmerica, .oceania, .asia]
         case "VN", "TH", "MY", "SG", "PH", "ID":
             return [.asia, .oceania, .europe, .northAmerica]
+        case "CL":
+            return [.southAmerica, .northAmerica, .europe, .oceania, .asia]
         default:
             return RadioRegion.allCases
         }
@@ -31,6 +34,7 @@ public enum RadioRegion: String, CaseIterable, Sendable {
     public var shortCode: String {
         switch self {
         case .northAmerica: return "NA"
+        case .southAmerica: return "SA"
         case .europe: return "EU"
         case .oceania: return "AU"
         case .asia: return "AS"
@@ -160,6 +164,11 @@ public enum RadioPresets {
                         "los angeles", "orange", "san diego", "riverside", "san bernardino",
                         "ventura", "imperial", "kern", "santa barbara", "san luis obispo",
                     ])),
+
+        // South America
+        RadioPreset(id: "cl", name: "Chile", region: .southAmerica,
+                    frequencyMHz: 927.875, bandwidthKHz: 62.5, spreadingFactor: 8, codingRate: 5,
+                    availability: .countries(["CL"])),
 
         // Asia
         RadioPreset(id: "vn-narrow", name: "Vietnam (Narrow)", region: .asia,

--- a/MC1Services/Sources/MC1Services/Services/RegionalAreas.swift
+++ b/MC1Services/Sources/MC1Services/Services/RegionalAreas.swift
@@ -47,12 +47,14 @@ public enum RegionalAreas {
                     nameKey: "region.subdivision.AU-WA"),
     ]
 
-    /// ISO α-2 → `RadioRegion` mapping. Mexico (MX), Africa, and
-    /// South America are intentionally absent — these countries fall through
-    /// `recommended(for:)` to the empty-region fallback.
+    /// ISO α-2 → `RadioRegion` mapping. Mexico (MX) and Africa are intentionally
+    /// absent — those countries fall through `recommended(for:)` to the
+    /// empty-region fallback. South America is currently limited to Chile (CL).
     public static let continents: [String: RadioRegion] = [
         // North America
         "US": .northAmerica, "CA": .northAmerica,
+        // South America
+        "CL": .southAmerica,
         // Europe
         "GB": .europe, "IE": .europe, "DE": .europe, "FR": .europe,
         "IT": .europe, "ES": .europe, "PT": .europe, "NL": .europe,
@@ -76,6 +78,7 @@ public enum RegionalAreas {
     public static let countries: [Country] = [
         Country(id: "US", subdivisions: usSubdivisions),
         Country(id: "CA", subdivisions: nil),
+        Country(id: "CL", subdivisions: nil),
         Country(id: "AU", subdivisions: auSubdivisions),
         Country(id: "NZ", subdivisions: nil),
         Country(id: "GB", subdivisions: nil),

--- a/MC1Services/Tests/MC1ServicesTests/RadioPresetRecommendationTests.swift
+++ b/MC1Services/Tests/MC1ServicesTests/RadioPresetRecommendationTests.swift
@@ -72,6 +72,22 @@ struct RadioPresetRecommendationTests {
         #expect(RadioPresets.recommended(for: region)?.id == "nl")
     }
 
+    @Test("Chile → cl")
+    func chileGetsCL() {
+        let region = RegionSelection(countryCode: "CL", source: .location)
+        #expect(RadioPresets.recommended(for: region)?.id == "cl")
+    }
+
+    @Test("Chile preset carries the expected radio parameters")
+    func chilePresetParameters() throws {
+        let preset = try #require(RadioPresets.all.first(where: { $0.id == "cl" }))
+        #expect(preset.frequencyMHz == 927.875)
+        #expect(preset.bandwidthKHz == 62.5)
+        #expect(preset.spreadingFactor == 8)
+        #expect(preset.codingRate == 5)
+        #expect(preset.region == .southAmerica)
+    }
+
     // MARK: - Tier 3 (continent)
 
     @Test("Berlin (DE) → eu-narrow (priority 110 beats eu-lr)")


### PR DESCRIPTION
## Description

Adds a "Neighbor Map" button to the Neighbors section of the Repeater Status view. Tapping it opens a sheet that visualizes the repeater and its discovered neighbors as pins on a map, connected by SNR-colored lines with signal quality badges at the midpoints.

## Overview of Changes

- **`NeighborMapView.swift`** (new) — Self-contained sheet following the `MessagePathMapView` pattern. Shows the repeater as a blue-ring pin and neighbors as repeater pins, connected by lines colored by SNR quality (`traceGood` / `traceMedium` / `traceWeak` / `traceUntraced`). SNR badges at line midpoints. Falls back to `ContentUnavailableView` when no GPS positions are available.
- **`RepeaterStatusContent.swift`** — Adds "Neighbor Map" button (`Label(..., systemImage: "map")`) inside the neighbors `DisclosureGroup`, visible to all users when `!viewModel.neighbors.isEmpty`. Opens the map as a sheet.
- **Localization** — New keys (`remoteNodes.status.neighborMap`, `.unavailable.title`, `.unavailable.description`) added to all 9 supported locales (en, de, es, fr, nl, pl, ru, uk, zh-Hans).

## Testing

- Connected to a repeater with admin rights
- Loaded neighbors via the reload button and via "Discover Neighbours"
- Verified "Neighbor Map" button appears only when neighbors are loaded
- Verified map opens with repeater pin (blue ring) and neighbor pins
- Verified lines are colored correctly by SNR (green/yellow/red/grey)
- Verified SNR badge ("X.X dB") appears at each line midpoint
- Verified "Done" dismisses the sheet
- Verified `ContentUnavailableView` appears when no neighbors have GPS positions
- Verified button does not appear when neighbor list is empty
- Build: `BUILD SUCCEEDED` on iPhone 17e iOS 26.5 Simulator
- SwiftLint: 0 violations on changed files

## Tested on
- [ ] iOS [version]
- [ ] iPadOS [version]
- [ ] macOS [version]

## Checklist

- [x] This PR was discussed with the maintainer either via GitHub issue or other means (Also check the box if this PR is small enough not to need discussion e.g. typo fix)
- [x] I have read `CONTRIBUTING.md`
- [x] Testing steps are documented above.
- [x] This change is not low effort and I took the time to test it