### PR TITLE
Feature: Repeater Neighbor Map

### DIFF
--- a/MC1/Resources/Generated/L10n.swift
+++ b/MC1/Resources/Generated/L10n.swift
@@ -2941,7 +2941,7 @@ public enum L10n {
       /// Location: DeviceScanView.swift - Button to retry connection after other-app conflict
       public static let retryConnection = L10n.tr("Onboarding", "deviceScan.retryConnection", fallback: "Retry Connection")
       /// Location: DeviceScanView.swift - Subtitle with pairing instructions
-      public static let subtitle = L10n.tr("Onboarding", "deviceScan.subtitle", fallback: "Power it on, then tap Add Device.")
+      public static let subtitle = L10n.tr("Onboarding", "deviceScan.subtitle", fallback: "Power your radio on, disconnect it from all other apps and devices, then tap Add Device.")
       /// Location: DeviceScanView.swift - Screen title for device pairing
       public static let title = L10n.tr("Onboarding", "deviceScan.title", fallback: "Pair your device")
       public enum DemoModeAlert {
@@ -3727,6 +3727,8 @@ public enum L10n {
         public static func minutesAgo(_ p1: Int) -> String {
           return L10n.tr("RemoteNodes", "remoteNodes.status.minutesAgo", p1, fallback: "%dm ago")
         }
+        /// Location: NeighborMapView.swift - Navigation title
+        public static let neighborMapTitle = L10n.tr("RemoteNodes", "remoteNodes.status.neighborMapTitle", fallback: "Neighbor Map")
         /// Location: RepeaterStatusView.swift - Neighbors section label
         public static let neighbors = L10n.tr("RemoteNodes", "remoteNodes.status.neighbors", fallback: "Neighbors")
         /// Location: RepeaterStatusView.swift - Neighbors section footer
@@ -3771,6 +3773,8 @@ public enum L10n {
         public static func secondsAgo(_ p1: Int) -> String {
           return L10n.tr("RemoteNodes", "remoteNodes.status.secondsAgo", p1, fallback: "%ds ago")
         }
+        /// Location: RepeaterStatusView.swift - Show on map button label
+        public static let showOnMap = L10n.tr("RemoteNodes", "remoteNodes.status.showOnMap", fallback: "Show on Map")
         /// Location: RepeaterStatusView.swift - SNR display format
         public static func snrFormat(_ p1: Any) -> String {
           return L10n.tr("RemoteNodes", "remoteNodes.status.snrFormat", String(describing: p1), fallback: "SNR %@dB")

--- a/MC1/Resources/Localization/de.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/de.lproj/RemoteNodes.strings
@@ -874,3 +874,9 @@
 "remoteNodes.status.sensor.colour" = "Farbe";
 "remoteNodes.status.sensor.gps" = "GPS";
 "remoteNodes.status.sensor.switchValue" = "Schalter";
+
+/* Location: RepeaterStatusView.swift - Show on map button label */
+"remoteNodes.status.showOnMap" = "Auf Karte anzeigen";
+
+/* Location: NeighborMapView.swift - Navigation title */
+"remoteNodes.status.neighborMapTitle" = "Nachbarn-Karte";

--- a/MC1/Resources/Localization/en.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/en.lproj/RemoteNodes.strings
@@ -874,3 +874,9 @@
 
 /* Location: Multiple files - Name label */
 "remoteNodes.name" = "Name";
+
+/* Location: RepeaterStatusView.swift - Show on map button label */
+"remoteNodes.status.showOnMap" = "Show on Map";
+
+/* Location: NeighborMapView.swift - Navigation title */
+"remoteNodes.status.neighborMapTitle" = "Neighbor Map";

--- a/MC1/Resources/Localization/es.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/es.lproj/RemoteNodes.strings
@@ -874,3 +874,9 @@
 "remoteNodes.status.sensor.colour" = "Color";
 "remoteNodes.status.sensor.gps" = "GPS";
 "remoteNodes.status.sensor.switchValue" = "Interruptor";
+
+/* Location: RepeaterStatusView.swift - Show on map button label */
+"remoteNodes.status.showOnMap" = "Mostrar en el mapa";
+
+/* Location: NeighborMapView.swift - Navigation title */
+"remoteNodes.status.neighborMapTitle" = "Mapa de vecinos";

--- a/MC1/Resources/Localization/fr.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/fr.lproj/RemoteNodes.strings
@@ -876,3 +876,9 @@
 "remoteNodes.status.sensor.colour" = "Couleur";
 "remoteNodes.status.sensor.gps" = "GPS";
 "remoteNodes.status.sensor.switchValue" = "Commutateur";
+
+/* Location: RepeaterStatusView.swift - Show on map button label */
+"remoteNodes.status.showOnMap" = "Afficher sur la carte";
+
+/* Location: NeighborMapView.swift - Navigation title */
+"remoteNodes.status.neighborMapTitle" = "Carte des voisins";

--- a/MC1/Resources/Localization/nl.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/nl.lproj/RemoteNodes.strings
@@ -874,3 +874,9 @@
 "remoteNodes.status.sensor.colour" = "Kleur";
 "remoteNodes.status.sensor.gps" = "GPS";
 "remoteNodes.status.sensor.switchValue" = "Schakelaar";
+
+/* Location: RepeaterStatusView.swift - Show on map button label */
+"remoteNodes.status.showOnMap" = "Toon op kaart";
+
+/* Location: NeighborMapView.swift - Navigation title */
+"remoteNodes.status.neighborMapTitle" = "Burenkaart";

--- a/MC1/Resources/Localization/pl.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/pl.lproj/RemoteNodes.strings
@@ -871,3 +871,9 @@
 "remoteNodes.status.sensor.colour" = "Kolor";
 "remoteNodes.status.sensor.gps" = "GPS";
 "remoteNodes.status.sensor.switchValue" = "Przełącznik";
+
+/* Location: RepeaterStatusView.swift - Show on map button label */
+"remoteNodes.status.showOnMap" = "Pokaż na mapie";
+
+/* Location: NeighborMapView.swift - Navigation title */
+"remoteNodes.status.neighborMapTitle" = "Mapa sąsiadów";

--- a/MC1/Resources/Localization/ru.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/ru.lproj/RemoteNodes.strings
@@ -871,3 +871,9 @@
 "remoteNodes.status.sensor.colour" = "Цвет";
 "remoteNodes.status.sensor.gps" = "GPS";
 "remoteNodes.status.sensor.switchValue" = "Переключатель";
+
+/* Location: RepeaterStatusView.swift - Show on map button label */
+"remoteNodes.status.showOnMap" = "Показать на карте";
+
+/* Location: NeighborMapView.swift - Navigation title */
+"remoteNodes.status.neighborMapTitle" = "Карта соседей";

--- a/MC1/Resources/Localization/uk.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/uk.lproj/RemoteNodes.strings
@@ -871,3 +871,9 @@
 "remoteNodes.status.sensor.colour" = "Колір";
 "remoteNodes.status.sensor.gps" = "GPS";
 "remoteNodes.status.sensor.switchValue" = "Перемикач";
+
+/* Location: RepeaterStatusView.swift - Show on map button label */
+"remoteNodes.status.showOnMap" = "Показати на карті";
+
+/* Location: NeighborMapView.swift - Navigation title */
+"remoteNodes.status.neighborMapTitle" = "Карта сусідів";

--- a/MC1/Resources/Localization/zh-Hans.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/zh-Hans.lproj/RemoteNodes.strings
@@ -874,3 +874,9 @@
 "remoteNodes.status.sensor.colour" = "颜色";
 "remoteNodes.status.sensor.gps" = "GPS";
 "remoteNodes.status.sensor.switchValue" = "开关";
+
+/* Location: RepeaterStatusView.swift - Show on map button label */
+"remoteNodes.status.showOnMap" = "在地图上显示";
+
+/* Location: NeighborMapView.swift - Navigation title */
+"remoteNodes.status.neighborMapTitle" = "邻居地图";

--- a/MC1/Views/RemoteNodes/Repeaters/NeighborMapView.swift
+++ b/MC1/Views/RemoteNodes/Repeaters/NeighborMapView.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+import CoreLocation
+import MapKit
+import MC1Services
+
+struct NeighborMapView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.appState) private var appState
+
+    @AppStorage(AppStorageKey.mapStyleSelection.rawValue) private var mapStyleSelection: MapStyleSelection = .standard
+
+    let repeaterSession: RemoteNodeSessionDTO
+    let neighbors: [NeighbourInfo]
+    let contacts: [ContactDTO]
+    let discoveredNodes: [DiscoveredNodeDTO]
+    let userLocation: CLLocation?
+
+    @State private var cameraRegion: MKCoordinateRegion? = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+        span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
+    )
+    @State private var cameraRegionVersion = 0
+    @State private var isStyleLoaded = false
+
+    private var mapData: (points: [MapPoint], lines: [MapLine]) {
+        var points: [MapPoint] = []
+        var lines: [MapLine] = []
+
+        let centerCoord = CLLocationCoordinate2D(latitude: repeaterSession.latitude, longitude: repeaterSession.longitude)
+
+        // Add repeater point
+        points.append(MapPoint(
+            id: repeaterSession.id,
+            coordinate: centerCoord,
+            pinStyle: .repeater,
+            label: repeaterSession.name,
+            isClusterable: false,
+            hopIndex: nil,
+            badgeText: nil
+        ))
+
+        // Add neighbors and lines
+        for neighbor in neighbors {
+            let resolution = NeighborNameResolver.resolve(
+                for: neighbor.publicKeyPrefix,
+                contacts: contacts,
+                discoveredNodes: discoveredNodes,
+                userLocation: userLocation
+            )
+
+            // Try to find the actual node to get location
+            let neighborCoord: CLLocationCoordinate2D? = {
+                if let contact = RepeaterResolver.resolve(for: neighbor.publicKeyPrefix, in: contacts, userLocation: userLocation)?.node {
+                    return CLLocationCoordinate2D(latitude: contact.latitude, longitude: contact.longitude)
+                }
+                if let discovered = RepeaterResolver.resolve(for: neighbor.publicKeyPrefix, in: discoveredNodes, userLocation: userLocation)?.node {
+                    return CLLocationCoordinate2D(latitude: discovered.latitude, longitude: discovered.longitude)
+                }
+                return nil
+            }()
+
+            if let neighborCoord = neighborCoord, neighborCoord.latitude != 0, neighborCoord.longitude != 0 {
+                let neighborId = UUID() // Or a deterministic UUID based on public key
+                let name = resolution?.displayName ?? L10n.RemoteNodes.RemoteNodes.Status.unknown
+
+                points.append(MapPoint(
+                    id: neighborId,
+                    coordinate: neighborCoord,
+                    pinStyle: .contactRepeater,
+                    label: name,
+                    isClusterable: false,
+                    hopIndex: nil,
+                    badgeText: nil
+                ))
+
+                // Midpoint for the SNR label
+                let midLat = (centerCoord.latitude + neighborCoord.latitude) / 2.0
+                let midLon = (centerCoord.longitude + neighborCoord.longitude) / 2.0
+                let midCoord = CLLocationCoordinate2D(latitude: midLat, longitude: midLon)
+                
+                points.append(MapPoint(
+                    id: UUID(),
+                    coordinate: midCoord,
+                    pinStyle: .badge,
+                    label: nil,
+                    isClusterable: false,
+                    hopIndex: nil,
+                    badgeText: String(format: "%.1f dB", neighbor.snr)
+                ))
+
+                let lineStyle: MapLine.LineStyle
+                if neighbor.snr > 10 {
+                    lineStyle = .traceGood
+                } else if neighbor.snr > 0 {
+                    lineStyle = .traceMedium
+                } else {
+                    lineStyle = .traceWeak
+                }
+
+                lines.append(MapLine(
+                    id: neighbor.publicKeyPrefix.hexString,
+                    coordinates: [centerCoord, neighborCoord],
+                    style: lineStyle,
+                    opacity: 1.0,
+                    pathIndex: nil
+                ))
+            }
+        }
+
+        return (points, lines)
+    }
+
+    var body: some View {
+        let data = mapData
+
+        MC1MapView(
+            points: data.points,
+            lines: data.lines,
+            mapStyle: mapStyleSelection,
+            isDarkMode: colorScheme == .dark,
+            isOffline: !appState.offlineMapService.isNetworkAvailable,
+            showLabels: true,
+            showsUserLocation: true,
+            isInteractive: true,
+            showsScale: true,
+            isNorthLocked: false,
+            cameraRegion: $cameraRegion,
+            cameraRegionVersion: cameraRegionVersion,
+            onPointTap: { _, _ in },
+            onMapTap: { _ in },
+            onCameraRegionChange: { _ in },
+            isStyleLoaded: $isStyleLoaded
+        )
+        .overlay {
+            if !isStyleLoaded {
+                ProgressView()
+                    .scaleEffect(1.5)
+            }
+        }
+        .ignoresSafeArea(edges: .bottom)
+        .onAppear {
+            if repeaterSession.latitude != 0 && repeaterSession.longitude != 0 {
+                cameraRegion = MKCoordinateRegion(
+                    center: CLLocationCoordinate2D(latitude: repeaterSession.latitude, longitude: repeaterSession.longitude),
+                    span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
+                )
+                cameraRegionVersion += 1
+            }
+        }
+        .navigationTitle(L10n.RemoteNodes.RemoteNodes.Status.neighborMapTitle)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/MC1/Views/RemoteNodes/Repeaters/RepeaterStatusContent.swift
+++ b/MC1/Views/RemoteNodes/Repeaters/RepeaterStatusContent.swift
@@ -21,6 +21,8 @@ struct RepeaterStatusContent: View {
     /// Contact whose login route is shown at the bottom; nil hides the route section.
     var routePathContact: ContactDTO?
 
+    @State private var showingNeighborMap = false
+
     var body: some View {
         List {
             NodeStatusHeaderSection(session: session)
@@ -34,7 +36,8 @@ struct RepeaterStatusContent: View {
                 contacts: contacts,
                 discoveredNodes: discoveredNodes,
                 userLocation: userLocation,
-                connectionState: connectionState
+                connectionState: connectionState,
+                showingNeighborMap: $showingNeighborMap
             )
             OwnerInfoSection(viewModel: viewModel, session: session, connectionState: connectionState)
             NodeBatteryCurveDisclosureSection(
@@ -56,6 +59,19 @@ struct RepeaterStatusContent: View {
         .themedCanvas(theme)
         .nodeManagementHeaderTopMargin()
         .scrollDismissesKeyboard(.interactively)
+        .sheet(isPresented: $showingNeighborMap) {
+            NavigationStack {
+                NeighborMapView(
+                    repeaterSession: session,
+                    neighbors: viewModel.neighbors,
+                    contacts: contacts,
+                    discoveredNodes: discoveredNodes,
+                    userLocation: userLocation
+                )
+            }
+            .presentationDetents([.large])
+            .presentationDragIndicator(.visible)
+        }
     }
 }
 
@@ -152,6 +168,8 @@ private struct NeighborsSection: View {
     let userLocation: CLLocation?
     let connectionState: DeviceConnectionState
 
+    @Binding var showingNeighborMap: Bool
+
     var body: some View {
         Section {
             DisclosureGroup(isExpanded: $viewModel.neighborsExpanded) {
@@ -207,6 +225,14 @@ private struct NeighborsSection: View {
                                 matchKind: resolution?.matchKind ?? .unresolved
                             )
                         }
+                    }
+                }
+
+                if !viewModel.neighbors.isEmpty {
+                    Button {
+                        showingNeighborMap = true
+                    } label: {
+                        Label(L10n.RemoteNodes.RemoteNodes.Status.showOnMap, systemImage: "map")
                     }
                 }
 


### PR DESCRIPTION
## Description

This PR adds a new Neighbor Map feature accessible from the repeater management page. Users can visualize the selected repeater and its neighbors on a map, with connecting lines displaying the signal strength (SNR).

In addition, it provides full localization for the new UI strings across 7 supported languages and resolves an out-of-sync `L10n.swift` issue from a previous `Onboarding.strings` commit on the `dev` branch.

## Overview of Changes

- **Neighbor Map**: Added `NeighborMapView.swift` containing the map logic and layout for rendering the repeater and neighbor nodes.
- **UI Navigation**: Updated `RepeaterStatusContent.swift` to include a "Auf Karte anzeigen" (Show on map) button.
- **Bug Fix**: Lifted the presentation state for the map out of the `List` section to fix unexpected dismissal issues caused by SwiftUI re-rendering on telemetry updates.
- **UI Polish**: Configured safe areas and label offsets to ensure the UI matches design intent and MapLibre layout behavior.
- **Localization**: Added missing string translations for the new views in English, German, Spanish, French, Polish, Dutch, Russian, Ukrainian, and Simplified Chinese.
- **Housekeeping**: Ran `swiftgen`, which consequently regenerated the missing `deviceScan.subtitle` fallback string that was out of sync on the `dev` branch.

## Testing

1. Open the app on a physical device (iPhone 17 Pro Max).
2. Navigate to a repeater's management view.
3. Verify the "Show on map" button appears and is correctly localized depending on the device's language.
4. Click the button to open the map sheet and verify that the map renders stably without unexpected dismissals.
5. Verify the map fills the bottom safe area correctly.
6. Check that the SNR badge label is centered on the dotted connection line.

## Tested on
- [x] iOS [26.4] (iPhone 17 Pro Max)
- [ ] iPadOS [version]
- [ ] macOS [version]

## Checklist

- [ ] This PR was discussed with the maintainer either via GitHub issue or other means (Also check the box if this PR is small enough not to need discussion e.g. typo fix)
- [x] I have read `CONTRIBUTING.md`
- [x] Testing steps are documented above.
- [x] This change is not low effort and I took the time to test it
