### PR TITLE
fix: cli toolbar padding

### DIFF
--- a/MC1/Views/Tools/CLI/CLITerminalView.swift
+++ b/MC1/Views/Tools/CLI/CLITerminalView.swift
@@ -155,6 +155,13 @@ struct CLITerminalView: View {
           onCancel: onCancel,
           onDismiss: onDismiss
         )
+        .padding(.bottom, {
+          if #available(iOS 26.0, *) {
+            8
+          } else {
+            0
+          }
+        }())
       }
     }
     .onKeyPress(.upArrow) {


### PR DESCRIPTION
## Description

Adds padding beneath the toolbar to the cli toolbar on iOS 26

## Overview of Changes

<img width="807" height="365" alt="image" src="https://github.com/user-attachments/assets/d99cb7b8-e351-48d8-8cf4-a90f09f61433" />

## Testing

Tested on simulator 

## Tested on
- [x] iOS [18,26]
- [ ] iPadOS [version]
- [ ] macOS [version]

## Checklist

- [x] This PR was discussed with the maintainer either via GitHub issue or other means (Also check if this PR is small enough not to need discussion e.g. typo fix)
- [x] I have read `CONTRIBUTING.md`
- [x] Testing steps are documented above.
- [x] This change is not low effort and I took the time to test it
