### PR TITLE
fix: path map hops banner

### DIFF
--- a/MC1/Views/Chats/Components/MessagePathMapView.swift
+++ b/MC1/Views/Chats/Components/MessagePathMapView.swift
@@ -86,11 +86,6 @@ struct MessagePathMapView: View {
             )
             .ignoresSafeArea()
 
-            PathDistanceBanner(
-              hopCount: hopCount,
-              totalPathDistance: totalPathDistance
-            )
-
             VStack {
               Spacer()
               HStack {
@@ -116,9 +111,15 @@ struct MessagePathMapView: View {
           }
         }
       }
-      .navigationTitle(L10n.Chats.Chats.Path.map)
-      .navigationBarTitleDisplayMode(.inline)
       .toolbar {
+        if !locatedNodes.isEmpty {
+          ToolbarItem(placement: .principal) {
+            PathDistanceBanner(
+              hopCount: hopCount,
+              totalPathDistance: totalPathDistance
+            )
+          }
+        }
         ToolbarItem(placement: .confirmationAction) {
           Button(L10n.Localizable.Common.done) { dismiss() }
         }

--- a/MC1/Views/Map/PathDistanceBanner.swift
+++ b/MC1/Views/Map/PathDistanceBanner.swift
@@ -1,34 +1,27 @@
 import MapKit
 import SwiftUI
 
-/// Floating bottom-of-map capsule summarizing a path: hop count and, when at
-/// least two nodes have coordinates, the drawn-path distance.
+/// Path summary shown in place of the map sheet's navigation title: hop count
+/// and, when at least two nodes have coordinates, the drawn-path distance.
 struct PathDistanceBanner: View {
   private static let horizontalPadding: CGFloat = 16
-  private static let verticalPadding: CGFloat = 10
+  private static let verticalPadding: CGFloat = 8
 
   let hopCount: Int
   let totalPathDistance: CLLocationDistance?
 
   var body: some View {
-    VStack {
-      Spacer()
-
-      HStack {
-        Text(L10n.Contacts.Contacts.Trace.Map.hops(hopCount))
-        if let distance = totalPathDistance {
-          Text("•")
-          Text(Measurement(value: distance, unit: UnitLength.meters),
-               format: .measurement(width: .abbreviated, usage: .road))
-        }
+    HStack(spacing: 4) {
+      Text(L10n.Contacts.Contacts.Trace.Map.hops(hopCount))
+      if let distance = totalPathDistance {
+        Text("•")
+        Text(Measurement(value: distance, unit: UnitLength.meters),
+             format: .measurement(width: .abbreviated, usage: .road))
       }
-      .font(.subheadline.weight(.medium))
-      .padding(.horizontal, Self.horizontalPadding)
-      .padding(.vertical, Self.verticalPadding)
-      .liquidGlass(in: .capsule)
     }
-    .frame(maxWidth: .infinity)
-    .safeAreaPadding(.bottom)
-    .transition(.move(edge: .bottom).combined(with: .opacity))
+    .font(.subheadline.weight(.medium))
+    .padding(.horizontal, Self.horizontalPadding)
+    .padding(.vertical, Self.verticalPadding)
+    .liquidGlass(in: .capsule)
   }
 }

--- a/MC1/Views/Map/PathDistanceBanner.swift
+++ b/MC1/Views/Map/PathDistanceBanner.swift
@@ -1,8 +1,8 @@
 import MapKit
 import SwiftUI
 
-/// Floating top-of-map capsule summarizing a path: hop count and, when at least
-/// two nodes have coordinates, the drawn-path distance.
+/// Floating bottom-of-map capsule summarizing a path: hop count and, when at
+/// least two nodes have coordinates, the drawn-path distance.
 struct PathDistanceBanner: View {
   private static let horizontalPadding: CGFloat = 16
   private static let verticalPadding: CGFloat = 10
@@ -12,6 +12,8 @@ struct PathDistanceBanner: View {
 
   var body: some View {
     VStack {
+      Spacer()
+
       HStack {
         Text(L10n.Contacts.Contacts.Trace.Map.hops(hopCount))
         if let distance = totalPathDistance {
@@ -24,11 +26,9 @@ struct PathDistanceBanner: View {
       .padding(.horizontal, Self.horizontalPadding)
       .padding(.vertical, Self.verticalPadding)
       .liquidGlass(in: .capsule)
-
-      Spacer()
     }
     .frame(maxWidth: .infinity)
-    .safeAreaPadding(.top)
-    .transition(.move(edge: .top).combined(with: .opacity))
+    .safeAreaPadding(.bottom)
+    .transition(.move(edge: .bottom).combined(with: .opacity))
   }
 }


### PR DESCRIPTION
## Description

Moves the path map banner pill to the bottom so it doesnt conflict with the scale element or compete with top bar

## Overview of Changes
<img width="808" height="814" alt="image" src="https://github.com/user-attachments/assets/62385041-6cee-4dc4-acaa-3bb6d9a51e38" />

<!-- A short summary of the changes made. -->

## Testing

Simulator

## Tested on
- [x] iOS [26, 18]
- [ ] iPadOS [version]
- [ ] macOS [version]

## Checklist

- [x] This PR was discussed with the maintainer either via GitHub issue or other means (Also check if this PR is small enough not to need discussion e.g. typo fix)
- [x] I have read `CONTRIBUTING.md`
- [x] Testing steps are documented above.
- [x] This change is not low effort and I took the time to test it
