### PR TITLE
fix: new chat padding

### DIFF
--- a/MC1/Views/Chats/NewChatView.swift
+++ b/MC1/Views/Chats/NewChatView.swift
@@ -55,6 +55,8 @@ struct NewChatView: View {
             }
             .buttonStyle(.plain)
           }
+          .listStyle(.insetGrouped)
+          .contentMargins(.top, 0, for: .scrollContent)
           .themedCanvas(theme)
         }
       }


### PR DESCRIPTION
## Description

Removed large gap above contacts in new chat window

## Overview of Changes

<img width="779" height="815" alt="image" src="https://github.com/user-attachments/assets/d56ca4b2-0ddb-4f89-9936-85e59ce2546b" />

## Testing

Tested on ios 18 and 26

## Tested on
- [x] iOS [18, 26]
- [ ] iPadOS [version]
- [ ] macOS [version]

## Checklist

- [x] This PR was discussed with the maintainer either via GitHub issue or other means (Also check if this PR is small enough not to need discussion e.g. typo fix)
- [x] I have read `CONTRIBUTING.md`
- [x] Testing steps are documented above.
- [x] This change is not low effort and I took the time to test it
