### PR TITLE
feat: theme aware QR code

### DIFF
--- a/MC1/Utilities/QRCodeGenerator.swift
+++ b/MC1/Utilities/QRCodeGenerator.swift
@@ -1,0 +1,34 @@
+import CoreImage.CIFilterBuiltins
+import UIKit
+
+/// Generates QR codes whose data modules are opaque and background is transparent, so the image
+/// can be rendered as a `.template` and tinted with the current text color while the cell/canvas
+/// shows through the background. This keeps QR codes legible in both light and dark mode.
+enum QRCodeGenerator {
+  private static let context = CIContext()
+
+  static func generate(from string: String, scale: CGFloat = 10.0, correctionLevel: String = "M")
+    -> UIImage?
+  {
+    let filter = CIFilter.qrCodeGenerator()
+    filter.message = Data(string.utf8)
+    filter.correctionLevel = correctionLevel
+
+    guard let qrImage = filter.outputImage else { return nil }
+
+    let colorFilter = CIFilter.falseColor()
+    colorFilter.inputImage = qrImage
+    colorFilter.color0 = CIColor.black
+    colorFilter.color1 = CIColor(red: 0, green: 0, blue: 0, alpha: 0)
+
+    guard let coloredImage = colorFilter.outputImage else { return nil }
+
+    let scaledImage = coloredImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+
+    guard let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent) else {
+      return nil
+    }
+
+    return UIImage(cgImage: cgImage).withRenderingMode(.alwaysTemplate)
+  }
+}

--- a/MC1/Utilities/QRCodeGenerator.swift
+++ b/MC1/Utilities/QRCodeGenerator.swift
@@ -7,9 +7,7 @@ import UIKit
 enum QRCodeGenerator {
   private static let context = CIContext()
 
-  static func generate(from string: String, scale: CGFloat = 10.0, correctionLevel: String = "M")
-    -> UIImage?
-  {
+  static func generate(from string: String, scale: CGFloat = 10.0, correctionLevel: String = "M") -> UIImage? {
     let filter = CIFilter.qrCodeGenerator()
     filter.message = Data(string.utf8)
     filter.correctionLevel = correctionLevel

--- a/MC1/Views/Chats/CreatePrivateChannelView.swift
+++ b/MC1/Views/Chats/CreatePrivateChannelView.swift
@@ -1,4 +1,3 @@
-import CoreImage.CIFilterBuiltins
 import MC1Services
 import SwiftUI
 
@@ -189,6 +188,7 @@ private struct ShareChannelContent: View {
                 .interpolation(.none)
                 .resizable()
                 .scaledToFit()
+                .foregroundStyle(.primary)
                 .frame(width: 200, height: 200)
             }
 
@@ -241,20 +241,7 @@ private struct ShareChannelContent: View {
     // Format: meshcore://channel/add?name=<name>&secret=<hex>
     let urlString = "meshcore://channel/add?name=\(channelName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")&secret=\(secret.uppercaseHexString())"
 
-    let context = CIContext()
-    let filter = CIFilter.qrCodeGenerator()
-    filter.message = Data(urlString.utf8)
-    filter.correctionLevel = "M"
-
-    guard let outputImage = filter.outputImage else { return nil }
-
-    // Scale up for better quality
-    let scale = 10.0
-    let scaledImage = outputImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
-
-    guard let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent) else { return nil }
-
-    return UIImage(cgImage: cgImage)
+    return QRCodeGenerator.generate(from: urlString)
   }
 }
 

--- a/MC1/Views/Chats/Sheets/ChannelInfoSheet.swift
+++ b/MC1/Views/Chats/Sheets/ChannelInfoSheet.swift
@@ -1,4 +1,3 @@
-import CoreImage.CIFilterBuiltins
 import MC1Services
 import OSLog
 import SwiftUI
@@ -403,6 +402,7 @@ private struct ChannelInfoQRCodeSection: View {
               .interpolation(.none)
               .resizable()
               .scaledToFit()
+              .foregroundStyle(.primary)
               .frame(width: 180, height: 180)
           }
 
@@ -425,20 +425,7 @@ private struct ChannelInfoQRCodeSection: View {
     // Format: meshcore://channel/add?name=<name>&secret=<hex>
     let urlString = "meshcore://channel/add?name=\(channel.name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")&secret=\(channel.secret.uppercaseHexString())"
 
-    let context = CIContext()
-    let filter = CIFilter.qrCodeGenerator()
-    filter.message = Data(urlString.utf8)
-    filter.correctionLevel = "M"
-
-    guard let outputImage = filter.outputImage else { return nil }
-
-    // Scale up for better quality
-    let scale = 10.0
-    let scaledImage = outputImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
-
-    guard let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent) else { return nil }
-
-    return UIImage(cgImage: cgImage)
+    return QRCodeGenerator.generate(from: urlString)
   }
 }
 

--- a/MC1/Views/Contacts/ContactQRShareSheet.swift
+++ b/MC1/Views/Contacts/ContactQRShareSheet.swift
@@ -60,7 +60,8 @@ struct ContactQRShareSheet: View {
 
   private func generateQRCode() -> UIImage? {
     QRCodeGenerator.generate(
-      from: contactURI, scale: Constants.qrScale, correctionLevel: Constants.qrCorrectionLevel)
+      from: contactURI, scale: Constants.qrScale, correctionLevel: Constants.qrCorrectionLevel
+    )
   }
 
   private var shareText: String {

--- a/MC1/Views/Contacts/ContactQRShareSheet.swift
+++ b/MC1/Views/Contacts/ContactQRShareSheet.swift
@@ -1,4 +1,3 @@
-import CoreImage.CIFilterBuiltins
 import MC1Services
 import SwiftUI
 
@@ -60,20 +59,8 @@ struct ContactQRShareSheet: View {
   // MARK: - Private Methods
 
   private func generateQRCode() -> UIImage? {
-    let context = CIContext()
-    let filter = CIFilter.qrCodeGenerator()
-    filter.message = Data(contactURI.utf8)
-    filter.correctionLevel = Constants.qrCorrectionLevel
-
-    guard let outputImage = filter.outputImage else { return nil }
-
-    // Scale up for better quality
-    let transform = CGAffineTransform(scaleX: Constants.qrScale, y: Constants.qrScale)
-    let scaledImage = outputImage.transformed(by: transform)
-
-    guard let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent) else { return nil }
-
-    return UIImage(cgImage: cgImage)
+    QRCodeGenerator.generate(
+      from: contactURI, scale: Constants.qrScale, correctionLevel: Constants.qrCorrectionLevel)
   }
 
   private var shareText: String {
@@ -121,6 +108,7 @@ private struct QRCodeSection: View {
               .interpolation(.none)
               .resizable()
               .scaledToFit()
+              .foregroundStyle(.primary)
               .frame(width: Constants.qrCodeSize, height: Constants.qrCodeSize)
           }
 


### PR DESCRIPTION
## Description

QR Codes now track the system theme

## Overview of Changes

<img width="348" height="266" alt="image" src="https://github.com/user-attachments/assets/101be63a-a3bf-49ce-a2a8-032cbaf46c0a" />
<img width="342" height="260" alt="image" src="https://github.com/user-attachments/assets/8f12d5f8-921b-4cfc-a648-e27ff3b0a09d" />


## Testing

Tested in both themes

## Tested on
- [x] iOS [26]
- [ ] iPadOS [version]
- [ ] macOS [version]

## Checklist

- [x] This PR was discussed with the maintainer either via GitHub issue or other means (Also check if this PR is small enough not to need discussion e.g. typo fix)
- [x] I have read `CONTRIBUTING.md`
- [x] Testing steps are documented above.
- [x] This change is not low effort and I took the time to test it
