### PR TITLE
Add contact profile pictures

### DIFF
--- a/MC1/Resources/Generated/L10n.swift
+++ b/MC1/Resources/Generated/L10n.swift
@@ -1338,6 +1338,8 @@ public enum L10n {
           public static let invalidImage = L10n.tr("Contacts", "contacts.detail.avatar.invalidImage", fallback: "That file couldn't be used as a profile picture.")
           /// Location: ContactDetailView.swift - Purpose: Avatar edit menu option to remove the current photo
           public static let removePhoto = L10n.tr("Contacts", "contacts.detail.avatar.removePhoto", fallback: "Remove Photo")
+          /// Location: ContactDetailView.swift - Purpose: VoiceOver suffix announced while a new profile picture is being saved
+          public static let savingAnnouncement = L10n.tr("Contacts", "contacts.detail.avatar.savingAnnouncement", fallback: "Saving photo")
         }
         public enum Error {
           /// Location: ContactDetailView.swift - Purpose: Clear messages services-unavailable error

--- a/MC1/Resources/Generated/L10n.swift
+++ b/MC1/Resources/Generated/L10n.swift
@@ -1327,6 +1327,18 @@ public enum L10n {
             }
           }
         }
+        public enum Avatar {
+          /// Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick an image file
+          public static let chooseFile = L10n.tr("Contacts", "contacts.detail.avatar.chooseFile", fallback: "Choose File...")
+          /// Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick a photo from the photo library
+          public static let choosePhoto = L10n.tr("Contacts", "contacts.detail.avatar.choosePhoto", fallback: "Choose Photo")
+          /// Location: ContactDetailView.swift - Purpose: Avatar edit menu title
+          public static let chooseSource = L10n.tr("Contacts", "contacts.detail.avatar.chooseSource", fallback: "Change Profile Picture")
+          /// Location: ContactDetailView.swift - Purpose: Error shown when the picked file isn't a valid image
+          public static let invalidImage = L10n.tr("Contacts", "contacts.detail.avatar.invalidImage", fallback: "That file couldn't be used as a profile picture.")
+          /// Location: ContactDetailView.swift - Purpose: Avatar edit menu option to remove the current photo
+          public static let removePhoto = L10n.tr("Contacts", "contacts.detail.avatar.removePhoto", fallback: "Remove Photo")
+        }
         public enum Error {
           /// Location: ContactDetailView.swift - Purpose: Clear messages services-unavailable error
           public static let servicesUnavailable = L10n.tr("Contacts", "contacts.detail.error.servicesUnavailable", fallback: "Services not available")

--- a/MC1/Resources/Localization/de.lproj/Contacts.strings
+++ b/MC1/Resources/Localization/de.lproj/Contacts.strings
@@ -269,6 +269,24 @@
 /* Location: ContactDetailView.swift - Purpose: Info section header */
 "contacts.detail.info" = "Info";
 
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu title */
+"contacts.detail.avatar.chooseSource" = "Change Profile Picture";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick a photo from the photo library */
+"contacts.detail.avatar.choosePhoto" = "Choose Photo";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick an image file */
+"contacts.detail.avatar.chooseFile" = "Choose File...";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to remove the current photo */
+"contacts.detail.avatar.removePhoto" = "Remove Photo";
+
+/* Location: ContactDetailView.swift - Purpose: VoiceOver suffix announced while a new profile picture is being saved */
+"contacts.detail.avatar.savingAnnouncement" = "Saving photo";
+
+/* Location: ContactDetailView.swift - Purpose: Error shown when the picked file is not a valid image */
+"contacts.detail.avatar.invalidImage" = "That file could not be used as a profile picture.";
+
 /* Location: ContactDetailView.swift - Purpose: Nickname label */
 "contacts.detail.nickname" = "Spitzname";
 

--- a/MC1/Resources/Localization/en.lproj/Contacts.strings
+++ b/MC1/Resources/Localization/en.lproj/Contacts.strings
@@ -269,6 +269,21 @@
 /* Location: ContactDetailView.swift - Purpose: Info section header */
 "contacts.detail.info" = "Info";
 
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu title */
+"contacts.detail.avatar.chooseSource" = "Change Profile Picture";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick a photo from the photo library */
+"contacts.detail.avatar.choosePhoto" = "Choose Photo";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick an image file */
+"contacts.detail.avatar.chooseFile" = "Choose File...";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to remove the current photo */
+"contacts.detail.avatar.removePhoto" = "Remove Photo";
+
+/* Location: ContactDetailView.swift - Purpose: Error shown when the picked file isn't a valid image */
+"contacts.detail.avatar.invalidImage" = "That file couldn't be used as a profile picture.";
+
 /* Location: ContactDetailView.swift - Purpose: Nickname label */
 "contacts.detail.nickname" = "Nickname";
 

--- a/MC1/Resources/Localization/en.lproj/Contacts.strings
+++ b/MC1/Resources/Localization/en.lproj/Contacts.strings
@@ -284,6 +284,9 @@
 /* Location: ContactDetailView.swift - Purpose: Error shown when the picked file isn't a valid image */
 "contacts.detail.avatar.invalidImage" = "That file couldn't be used as a profile picture.";
 
+/* Location: ContactDetailView.swift - Purpose: VoiceOver suffix announced while a new profile picture is being saved */
+"contacts.detail.avatar.savingAnnouncement" = "Saving photo";
+
 /* Location: ContactDetailView.swift - Purpose: Nickname label */
 "contacts.detail.nickname" = "Nickname";
 

--- a/MC1/Resources/Localization/es.lproj/Contacts.strings
+++ b/MC1/Resources/Localization/es.lproj/Contacts.strings
@@ -269,6 +269,24 @@
 /* Location: ContactDetailView.swift - Purpose: Info section header */
 "contacts.detail.info" = "Información";
 
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu title */
+"contacts.detail.avatar.chooseSource" = "Change Profile Picture";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick a photo from the photo library */
+"contacts.detail.avatar.choosePhoto" = "Choose Photo";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick an image file */
+"contacts.detail.avatar.chooseFile" = "Choose File...";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to remove the current photo */
+"contacts.detail.avatar.removePhoto" = "Remove Photo";
+
+/* Location: ContactDetailView.swift - Purpose: VoiceOver suffix announced while a new profile picture is being saved */
+"contacts.detail.avatar.savingAnnouncement" = "Saving photo";
+
+/* Location: ContactDetailView.swift - Purpose: Error shown when the picked file is not a valid image */
+"contacts.detail.avatar.invalidImage" = "That file could not be used as a profile picture.";
+
 /* Location: ContactDetailView.swift - Purpose: Nickname label */
 "contacts.detail.nickname" = "Apodo";
 

--- a/MC1/Resources/Localization/fr.lproj/Contacts.strings
+++ b/MC1/Resources/Localization/fr.lproj/Contacts.strings
@@ -269,6 +269,24 @@
 /* Location: ContactDetailView.swift - Purpose: Info section header */
 "contacts.detail.info" = "Infos";
 
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu title */
+"contacts.detail.avatar.chooseSource" = "Change Profile Picture";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick a photo from the photo library */
+"contacts.detail.avatar.choosePhoto" = "Choose Photo";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick an image file */
+"contacts.detail.avatar.chooseFile" = "Choose File...";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to remove the current photo */
+"contacts.detail.avatar.removePhoto" = "Remove Photo";
+
+/* Location: ContactDetailView.swift - Purpose: VoiceOver suffix announced while a new profile picture is being saved */
+"contacts.detail.avatar.savingAnnouncement" = "Saving photo";
+
+/* Location: ContactDetailView.swift - Purpose: Error shown when the picked file is not a valid image */
+"contacts.detail.avatar.invalidImage" = "That file could not be used as a profile picture.";
+
 /* Location: ContactDetailView.swift - Purpose: Nickname label */
 "contacts.detail.nickname" = "Surnom";
 

--- a/MC1/Resources/Localization/nl.lproj/Contacts.strings
+++ b/MC1/Resources/Localization/nl.lproj/Contacts.strings
@@ -269,6 +269,24 @@
 /* Location: ContactDetailView.swift - Purpose: Info section header */
 "contacts.detail.info" = "Info";
 
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu title */
+"contacts.detail.avatar.chooseSource" = "Change Profile Picture";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick a photo from the photo library */
+"contacts.detail.avatar.choosePhoto" = "Choose Photo";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick an image file */
+"contacts.detail.avatar.chooseFile" = "Choose File...";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to remove the current photo */
+"contacts.detail.avatar.removePhoto" = "Remove Photo";
+
+/* Location: ContactDetailView.swift - Purpose: VoiceOver suffix announced while a new profile picture is being saved */
+"contacts.detail.avatar.savingAnnouncement" = "Saving photo";
+
+/* Location: ContactDetailView.swift - Purpose: Error shown when the picked file is not a valid image */
+"contacts.detail.avatar.invalidImage" = "That file could not be used as a profile picture.";
+
 /* Location: ContactDetailView.swift - Purpose: Nickname label */
 "contacts.detail.nickname" = "Bijnaam";
 

--- a/MC1/Resources/Localization/pl.lproj/Contacts.strings
+++ b/MC1/Resources/Localization/pl.lproj/Contacts.strings
@@ -269,6 +269,24 @@
 /* Location: ContactDetailView.swift - Purpose: Info section header */
 "contacts.detail.info" = "Informacje";
 
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu title */
+"contacts.detail.avatar.chooseSource" = "Change Profile Picture";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick a photo from the photo library */
+"contacts.detail.avatar.choosePhoto" = "Choose Photo";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick an image file */
+"contacts.detail.avatar.chooseFile" = "Choose File...";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to remove the current photo */
+"contacts.detail.avatar.removePhoto" = "Remove Photo";
+
+/* Location: ContactDetailView.swift - Purpose: VoiceOver suffix announced while a new profile picture is being saved */
+"contacts.detail.avatar.savingAnnouncement" = "Saving photo";
+
+/* Location: ContactDetailView.swift - Purpose: Error shown when the picked file is not a valid image */
+"contacts.detail.avatar.invalidImage" = "That file could not be used as a profile picture.";
+
 /* Location: ContactDetailView.swift - Purpose: Nickname label */
 "contacts.detail.nickname" = "Pseudonim";
 

--- a/MC1/Resources/Localization/ru.lproj/Contacts.strings
+++ b/MC1/Resources/Localization/ru.lproj/Contacts.strings
@@ -269,6 +269,24 @@
 /* Location: ContactDetailView.swift - Purpose: Info section header */
 "contacts.detail.info" = "Информация";
 
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu title */
+"contacts.detail.avatar.chooseSource" = "Change Profile Picture";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick a photo from the photo library */
+"contacts.detail.avatar.choosePhoto" = "Choose Photo";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick an image file */
+"contacts.detail.avatar.chooseFile" = "Choose File...";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to remove the current photo */
+"contacts.detail.avatar.removePhoto" = "Remove Photo";
+
+/* Location: ContactDetailView.swift - Purpose: VoiceOver suffix announced while a new profile picture is being saved */
+"contacts.detail.avatar.savingAnnouncement" = "Saving photo";
+
+/* Location: ContactDetailView.swift - Purpose: Error shown when the picked file is not a valid image */
+"contacts.detail.avatar.invalidImage" = "That file could not be used as a profile picture.";
+
 /* Location: ContactDetailView.swift - Purpose: Nickname label */
 "contacts.detail.nickname" = "Псевдоним";
 

--- a/MC1/Resources/Localization/uk.lproj/Contacts.strings
+++ b/MC1/Resources/Localization/uk.lproj/Contacts.strings
@@ -269,6 +269,24 @@
 /* Location: ContactDetailView.swift - Purpose: Info section header */
 "contacts.detail.info" = "Інформація";
 
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu title */
+"contacts.detail.avatar.chooseSource" = "Change Profile Picture";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick a photo from the photo library */
+"contacts.detail.avatar.choosePhoto" = "Choose Photo";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick an image file */
+"contacts.detail.avatar.chooseFile" = "Choose File...";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to remove the current photo */
+"contacts.detail.avatar.removePhoto" = "Remove Photo";
+
+/* Location: ContactDetailView.swift - Purpose: VoiceOver suffix announced while a new profile picture is being saved */
+"contacts.detail.avatar.savingAnnouncement" = "Saving photo";
+
+/* Location: ContactDetailView.swift - Purpose: Error shown when the picked file is not a valid image */
+"contacts.detail.avatar.invalidImage" = "That file could not be used as a profile picture.";
+
 /* Location: ContactDetailView.swift - Purpose: Nickname label */
 "contacts.detail.nickname" = "Псевдонім";
 

--- a/MC1/Resources/Localization/zh-Hans.lproj/Contacts.strings
+++ b/MC1/Resources/Localization/zh-Hans.lproj/Contacts.strings
@@ -269,6 +269,24 @@
 /* Location: ContactDetailView.swift - Purpose: Info section header */
 "contacts.detail.info" = "信息";
 
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu title */
+"contacts.detail.avatar.chooseSource" = "Change Profile Picture";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick a photo from the photo library */
+"contacts.detail.avatar.choosePhoto" = "Choose Photo";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick an image file */
+"contacts.detail.avatar.chooseFile" = "Choose File...";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to remove the current photo */
+"contacts.detail.avatar.removePhoto" = "Remove Photo";
+
+/* Location: ContactDetailView.swift - Purpose: VoiceOver suffix announced while a new profile picture is being saved */
+"contacts.detail.avatar.savingAnnouncement" = "Saving photo";
+
+/* Location: ContactDetailView.swift - Purpose: Error shown when the picked file is not a valid image */
+"contacts.detail.avatar.invalidImage" = "That file could not be used as a profile picture.";
+
 /* Location: ContactDetailView.swift - Purpose: Nickname label */
 "contacts.detail.nickname" = "昵称";
 

--- a/MC1/Views/Components/ContactAvatar.swift
+++ b/MC1/Views/Components/ContactAvatar.swift
@@ -5,8 +5,8 @@ import UIKit
 /// Process-lifetime cache of decoded avatar images, keyed by the raw JPEG data.
 /// Avoids re-running `UIImage(data:)` on every cell redraw while scrolling a contact list.
 private enum AvatarImageCache {
-  // NSCache is internally thread-safe; its lack of Sendable conformance is a
-  // missing annotation in Foundation, not an actual data race risk here.
+  /// NSCache is internally thread-safe; its lack of Sendable conformance is a
+  /// missing annotation in Foundation, not an actual data race risk here.
   nonisolated(unsafe) static let shared = NSCache<NSData, UIImage>()
 }
 

--- a/MC1/Views/Components/ContactAvatar.swift
+++ b/MC1/Views/Components/ContactAvatar.swift
@@ -1,5 +1,6 @@
 import MC1Services
 import SwiftUI
+import UIKit
 
 struct ContactAvatar: View {
   @Environment(\.appTheme) private var theme
@@ -7,23 +8,34 @@ struct ContactAvatar: View {
   @Environment(\.colorSchemeContrast) private var colorSchemeContrast
   let name: String
   let size: CGFloat
+  let imageData: Data?
 
   init(contact: ContactDTO, size: CGFloat) {
     name = contact.displayName
     self.size = size
+    imageData = contact.avatarImageData
   }
 
   init(name: String, size: CGFloat) {
     self.name = name
     self.size = size
+    imageData = nil
   }
 
   var body: some View {
-    Text(initials)
-      .font(.system(size: size * 0.4, weight: .semibold))
-      .foregroundStyle(glyphColor)
-      .frame(width: size, height: size)
-      .background(avatarColor, in: .circle)
+    if let imageData, let uiImage = UIImage(data: imageData) {
+      Image(uiImage: uiImage)
+        .resizable()
+        .scaledToFill()
+        .frame(width: size, height: size)
+        .clipShape(.circle)
+    } else {
+      Text(initials)
+        .font(.system(size: size * 0.4, weight: .semibold))
+        .foregroundStyle(glyphColor)
+        .frame(width: size, height: size)
+        .background(avatarColor, in: .circle)
+    }
   }
 
   private var initials: String {

--- a/MC1/Views/Components/ContactAvatar.swift
+++ b/MC1/Views/Components/ContactAvatar.swift
@@ -2,6 +2,14 @@ import MC1Services
 import SwiftUI
 import UIKit
 
+/// Process-lifetime cache of decoded avatar images, keyed by the raw JPEG data.
+/// Avoids re-running `UIImage(data:)` on every cell redraw while scrolling a contact list.
+private enum AvatarImageCache {
+  // NSCache is internally thread-safe; its lack of Sendable conformance is a
+  // missing annotation in Foundation, not an actual data race risk here.
+  nonisolated(unsafe) static let shared = NSCache<NSData, UIImage>()
+}
+
 struct ContactAvatar: View {
   @Environment(\.appTheme) private var theme
   @Environment(\.colorScheme) private var colorScheme
@@ -23,7 +31,7 @@ struct ContactAvatar: View {
   }
 
   var body: some View {
-    if let imageData, let uiImage = UIImage(data: imageData) {
+    if let imageData, let uiImage = cachedImage(for: imageData) {
       Image(uiImage: uiImage)
         .resizable()
         .scaledToFill()
@@ -36,6 +44,16 @@ struct ContactAvatar: View {
         .frame(width: size, height: size)
         .background(avatarColor, in: .circle)
     }
+  }
+
+  private func cachedImage(for data: Data) -> UIImage? {
+    let key = data as NSData
+    if let cached = AvatarImageCache.shared.object(forKey: key) {
+      return cached
+    }
+    guard let decoded = UIImage(data: data) else { return nil }
+    AvatarImageCache.shared.setObject(decoded, forKey: key, cost: data.count)
+    return decoded
   }
 
   private var initials: String {

--- a/MC1/Views/Contacts/ContactDetailView.swift
+++ b/MC1/Views/Contacts/ContactDetailView.swift
@@ -592,7 +592,7 @@ struct ContactDetailView: View {
 
   /// Downscales to a max 512pt dimension and re-encodes as JPEG so avatars stay small in the store.
   /// `nonisolated` so it can run on a background thread via `Task.detached` in `saveAvatar`.
-  private static nonisolated func processAvatarImage(data: Data) -> Data? {
+  private nonisolated static func processAvatarImage(data: Data) -> Data? {
     guard let image = UIImage(data: data) else { return nil }
     let maxDimension: CGFloat = 512
     let scale = min(1, maxDimension / max(image.size.width, image.size.height))

--- a/MC1/Views/Contacts/ContactDetailView.swift
+++ b/MC1/Views/Contacts/ContactDetailView.swift
@@ -531,7 +531,10 @@ struct ContactDetailView: View {
     defer { avatarPickerItem = nil }
     guard let item else { return }
     do {
-      guard let data = try await item.loadTransferable(type: Data.self) else { return }
+      guard let data = try await item.loadTransferable(type: Data.self) else {
+        errorMessage = L10n.Contacts.Contacts.Detail.Avatar.invalidImage
+        return
+      }
       await saveAvatar(data: data)
     } catch {
       errorMessage = error.userFacingMessage
@@ -555,11 +558,15 @@ struct ContactDetailView: View {
   }
 
   private func saveAvatar(data: Data) async {
-    guard let processed = Self.processAvatarImage(data: data) else {
+    isSavingAvatar = true
+    let processed = await Task.detached(priority: .userInitiated) {
+      Self.processAvatarImage(data: data)
+    }.value
+    guard let processed else {
       errorMessage = L10n.Contacts.Contacts.Detail.Avatar.invalidImage
+      isSavingAvatar = false
       return
     }
-    isSavingAvatar = true
     do {
       try await appState.services?.contactService.updateContactAvatar(
         contactID: currentContact.id,
@@ -584,12 +591,15 @@ struct ContactDetailView: View {
   }
 
   /// Downscales to a max 512pt dimension and re-encodes as JPEG so avatars stay small in the store.
-  private static func processAvatarImage(data: Data) -> Data? {
+  /// `nonisolated` so it can run on a background thread via `Task.detached` in `saveAvatar`.
+  private static nonisolated func processAvatarImage(data: Data) -> Data? {
     guard let image = UIImage(data: data) else { return nil }
     let maxDimension: CGFloat = 512
     let scale = min(1, maxDimension / max(image.size.width, image.size.height))
     let targetSize = CGSize(width: image.size.width * scale, height: image.size.height * scale)
-    let renderer = UIGraphicsImageRenderer(size: targetSize)
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    let renderer = UIGraphicsImageRenderer(size: targetSize, format: format)
     let resized = renderer.image { _ in
       image.draw(in: CGRect(origin: .zero, size: targetSize))
     }
@@ -641,7 +651,8 @@ private struct ContactDetailAvatarView: View {
         }
       }
       .buttonStyle(.plain)
-      .accessibilityLabel(L10n.Contacts.Contacts.Detail.Avatar.chooseSource)
+      .disabled(isSavingAvatar)
+      .accessibilityLabel(accessibilityLabel)
     } else {
       switch contact.type {
       case .repeater:
@@ -652,6 +663,13 @@ private struct ContactDetailAvatarView: View {
         EmptyView()
       }
     }
+  }
+
+  private var accessibilityLabel: String {
+    guard isSavingAvatar else {
+      return "\(contact.displayName), \(L10n.Contacts.Contacts.Detail.Avatar.chooseSource)"
+    }
+    return "\(contact.displayName), \(L10n.Contacts.Contacts.Detail.Avatar.savingAnnouncement)"
   }
 
   private var editBadge: some View {

--- a/MC1/Views/Contacts/ContactDetailView.swift
+++ b/MC1/Views/Contacts/ContactDetailView.swift
@@ -1,7 +1,9 @@
 import MapKit
 import MC1Services
+import PhotosUI
 import SwiftUI
 import UIKit
+import UniformTypeIdentifiers
 
 /// Result of a ping operation
 enum PingResult {
@@ -97,6 +99,12 @@ struct ContactDetailView: View {
   @State private var isSharing = false
   @State private var showShareSuccess = false
   @State private var headerHeight: CGFloat = 150
+  // Avatar picking state
+  @State private var showAvatarSourceMenu = false
+  @State private var showAvatarPhotosPicker = false
+  @State private var showAvatarFileImporter = false
+  @State private var avatarPickerItem: PhotosPickerItem?
+  @State private var isSavingAvatar = false
 
   init(contact: ContactDTO, showFromDirectChat: Bool = false, onClearMessages: @escaping () -> Void = {}) {
     self.contact = contact
@@ -118,7 +126,9 @@ struct ContactDetailView: View {
       ContactProfileSection(
         currentContact: currentContact,
         contactTypeLabel: contactTypeLabel,
-        measuredHeight: $headerHeight
+        measuredHeight: $headerHeight,
+        isSavingAvatar: isSavingAvatar,
+        onEditAvatar: { showAvatarSourceMenu = true }
       )
 
       // Quick actions
@@ -244,6 +254,27 @@ struct ContactDetailView: View {
     }
     .onAppear {
       nickname = currentContact.nickname ?? ""
+    }
+    .confirmationDialog(
+      L10n.Contacts.Contacts.Detail.Avatar.chooseSource,
+      isPresented: $showAvatarSourceMenu,
+      titleVisibility: .visible
+    ) {
+      Button(L10n.Contacts.Contacts.Detail.Avatar.choosePhoto) { showAvatarPhotosPicker = true }
+      Button(L10n.Contacts.Contacts.Detail.Avatar.chooseFile) { showAvatarFileImporter = true }
+      if currentContact.avatarImageData != nil {
+        Button(L10n.Contacts.Contacts.Detail.Avatar.removePhoto, role: .destructive) {
+          Task { await removeAvatar() }
+        }
+      }
+      Button(L10n.Contacts.Contacts.Common.cancel, role: .cancel) {}
+    }
+    .photosPicker(isPresented: $showAvatarPhotosPicker, selection: $avatarPickerItem, matching: .images)
+    .onChange(of: avatarPickerItem) { _, newItem in
+      Task { await loadPickedAvatarPhoto(newItem) }
+    }
+    .fileImporter(isPresented: $showAvatarFileImporter, allowedContentTypes: [.image]) { result in
+      Task { await handleAvatarFileImport(result) }
     }
     .task {
       pathViewModel.configure(
@@ -496,6 +527,75 @@ struct ContactDetailView: View {
     }
   }
 
+  private func loadPickedAvatarPhoto(_ item: PhotosPickerItem?) async {
+    defer { avatarPickerItem = nil }
+    guard let item else { return }
+    do {
+      guard let data = try await item.loadTransferable(type: Data.self) else { return }
+      await saveAvatar(data: data)
+    } catch {
+      errorMessage = error.userFacingMessage
+    }
+  }
+
+  private func handleAvatarFileImport(_ result: Result<URL, Error>) async {
+    switch result {
+    case let .success(url):
+      let didAccess = url.startAccessingSecurityScopedResource()
+      defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+      do {
+        let data = try Data(contentsOf: url)
+        await saveAvatar(data: data)
+      } catch {
+        errorMessage = error.userFacingMessage
+      }
+    case let .failure(error):
+      errorMessage = error.userFacingMessage
+    }
+  }
+
+  private func saveAvatar(data: Data) async {
+    guard let processed = Self.processAvatarImage(data: data) else {
+      errorMessage = L10n.Contacts.Contacts.Detail.Avatar.invalidImage
+      return
+    }
+    isSavingAvatar = true
+    do {
+      try await appState.services?.contactService.updateContactAvatar(
+        contactID: currentContact.id,
+        imageData: processed
+      )
+      await refreshContact()
+    } catch {
+      errorMessage = error.userFacingMessage
+    }
+    isSavingAvatar = false
+  }
+
+  private func removeAvatar() async {
+    isSavingAvatar = true
+    do {
+      try await appState.services?.contactService.updateContactAvatar(contactID: currentContact.id, imageData: nil)
+      await refreshContact()
+    } catch {
+      errorMessage = error.userFacingMessage
+    }
+    isSavingAvatar = false
+  }
+
+  /// Downscales to a max 512pt dimension and re-encodes as JPEG so avatars stay small in the store.
+  private static func processAvatarImage(data: Data) -> Data? {
+    guard let image = UIImage(data: data) else { return nil }
+    let maxDimension: CGFloat = 512
+    let scale = min(1, maxDimension / max(image.size.width, image.size.height))
+    let targetSize = CGSize(width: image.size.width * scale, height: image.size.height * scale)
+    let renderer = UIGraphicsImageRenderer(size: targetSize)
+    let resized = renderer.image { _ in
+      image.draw(in: CGRect(origin: .zero, size: targetSize))
+    }
+    return resized.jpegData(compressionQuality: 0.8)
+  }
+
   // MARK: - Helpers
 
   private var contactTypeLabel: String {
@@ -522,16 +622,50 @@ struct ContactDetailView: View {
 
 private struct ContactDetailAvatarView: View {
   let contact: ContactDTO
+  let isSavingAvatar: Bool
+  let onEditAvatar: () -> Void
 
   var body: some View {
-    switch contact.type {
-    case .chat:
-      ContactAvatar(contact: contact, size: 150)
-    case .repeater:
-      NodeAvatar(publicKey: contact.publicKey, role: .repeater, size: 150)
-    case .room:
-      NodeAvatar(publicKey: contact.publicKey, role: .roomServer, size: 150)
+    if contact.type == .chat {
+      Button(action: onEditAvatar) {
+        ZStack {
+          ContactAvatar(contact: contact, size: 150)
+          if isSavingAvatar {
+            Circle()
+              .fill(.black.opacity(0.4))
+              .frame(width: 150, height: 150)
+            ProgressView()
+              .tint(.white)
+          }
+          editBadge
+        }
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel(L10n.Contacts.Contacts.Detail.Avatar.chooseSource)
+    } else {
+      switch contact.type {
+      case .repeater:
+        NodeAvatar(publicKey: contact.publicKey, role: .repeater, size: 150)
+      case .room:
+        NodeAvatar(publicKey: contact.publicKey, role: .roomServer, size: 150)
+      case .chat:
+        EmptyView()
+      }
     }
+  }
+
+  private var editBadge: some View {
+    VStack {
+      Spacer()
+      HStack {
+        Spacer()
+        Image(systemName: "camera.circle.fill")
+          .font(.system(size: 32))
+          .symbolRenderingMode(.palette)
+          .foregroundStyle(.white, .gray)
+      }
+    }
+    .frame(width: 150, height: 150)
   }
 }
 
@@ -539,11 +673,17 @@ private struct ContactProfileSection: View {
   let currentContact: ContactDTO
   let contactTypeLabel: String
   @Binding var measuredHeight: CGFloat
+  let isSavingAvatar: Bool
+  let onEditAvatar: () -> Void
 
   var body: some View {
     Section {
       VStack(spacing: 12) {
-        ContactDetailAvatarView(contact: currentContact)
+        ContactDetailAvatarView(
+          contact: currentContact,
+          isSavingAvatar: isSavingAvatar,
+          onEditAvatar: onEditAvatar
+        )
 
         VStack(spacing: 4) {
           Text(currentContact.displayName)

--- a/MC1Services/Sources/MC1Services/Models/Contact.swift
+++ b/MC1Services/Sources/MC1Services/Models/Contact.swift
@@ -77,6 +77,9 @@ public final class Contact {
   /// Custom OCV array as comma-separated string (e.g., "4240,4112,4029,...")
   public var customOCVArrayString: String?
 
+  /// User-picked profile picture (compressed JPEG), overrides the generated initials avatar
+  public var avatarImageData: Data?
+
   public init(
     id: UUID = UUID(),
     radioID: UUID,
@@ -98,7 +101,8 @@ public final class Contact {
     unreadCount: Int = 0,
     unreadMentionCount: Int = 0,
     ocvPreset: String? = nil,
-    customOCVArrayString: String? = nil
+    customOCVArrayString: String? = nil,
+    avatarImageData: Data? = nil
   ) {
     self.id = id
     self.radioID = radioID
@@ -121,6 +125,7 @@ public final class Contact {
     self.unreadMentionCount = unreadMentionCount
     self.ocvPreset = ocvPreset
     self.customOCVArrayString = customOCVArrayString
+    self.avatarImageData = avatarImageData
   }
 
   /// Builds a model instance directly from a DTO. Shared by `saveContact` and
@@ -147,7 +152,8 @@ public final class Contact {
       unreadCount: dto.unreadCount,
       unreadMentionCount: dto.unreadMentionCount,
       ocvPreset: dto.ocvPreset,
-      customOCVArrayString: dto.customOCVArrayString
+      customOCVArrayString: dto.customOCVArrayString,
+      avatarImageData: dto.avatarImageData
     )
   }
 
@@ -175,6 +181,7 @@ public final class Contact {
     unreadMentionCount = dto.unreadMentionCount
     ocvPreset = dto.ocvPreset
     customOCVArrayString = dto.customOCVArrayString
+    avatarImageData = dto.avatarImageData
   }
 
   /// Creates a Contact from a protocol ContactFrame
@@ -295,6 +302,7 @@ public struct ContactDTO: Sendable, Equatable, Identifiable, Hashable, Codable, 
   public let unreadMentionCount: Int
   public let ocvPreset: String?
   public let customOCVArrayString: String?
+  public let avatarImageData: Data?
 
   public init(from contact: Contact) {
     id = contact.id
@@ -318,6 +326,7 @@ public struct ContactDTO: Sendable, Equatable, Identifiable, Hashable, Codable, 
     unreadMentionCount = contact.unreadMentionCount
     ocvPreset = contact.ocvPreset
     customOCVArrayString = contact.customOCVArrayString
+    avatarImageData = contact.avatarImageData
   }
 
   /// Memberwise initializer for creating DTOs directly
@@ -342,7 +351,8 @@ public struct ContactDTO: Sendable, Equatable, Identifiable, Hashable, Codable, 
     unreadCount: Int,
     unreadMentionCount: Int = 0,
     ocvPreset: String? = nil,
-    customOCVArrayString: String? = nil
+    customOCVArrayString: String? = nil,
+    avatarImageData: Data? = nil
   ) {
     self.id = id
     self.radioID = radioID
@@ -365,6 +375,7 @@ public struct ContactDTO: Sendable, Equatable, Identifiable, Hashable, Codable, 
     self.unreadMentionCount = unreadMentionCount
     self.ocvPreset = ocvPreset
     self.customOCVArrayString = customOCVArrayString
+    self.avatarImageData = avatarImageData
   }
 
   public var type: ContactType {
@@ -443,7 +454,8 @@ public struct ContactDTO: Sendable, Equatable, Identifiable, Hashable, Codable, 
       nickname: nickname, isBlocked: isBlocked, isMuted: isMuted,
       isFavorite: isFavorite, lastMessageDate: lastMessageDate,
       unreadCount: unreadCount, unreadMentionCount: unreadMentionCount,
-      ocvPreset: ocvPreset, customOCVArrayString: customOCVArrayString
+      ocvPreset: ocvPreset, customOCVArrayString: customOCVArrayString,
+      avatarImageData: avatarImageData
     )
   }
 
@@ -457,7 +469,23 @@ public struct ContactDTO: Sendable, Equatable, Identifiable, Hashable, Codable, 
       nickname: nickname, isBlocked: isBlocked, isMuted: isMuted,
       isFavorite: isFavorite, lastMessageDate: lastMessageDate,
       unreadCount: unreadCount, unreadMentionCount: unreadMentionCount,
-      ocvPreset: ocvPreset, customOCVArrayString: customOCVArrayString
+      ocvPreset: ocvPreset, customOCVArrayString: customOCVArrayString,
+      avatarImageData: avatarImageData
+    )
+  }
+
+  /// Returns a copy with only `avatarImageData` changed.
+  public func with(avatarImageData: Data?) -> ContactDTO {
+    ContactDTO(
+      id: id, radioID: radioID, publicKey: publicKey, name: name,
+      typeRawValue: typeRawValue, flags: flags, outPathLength: outPathLength,
+      outPath: outPath, lastAdvertTimestamp: lastAdvertTimestamp,
+      latitude: latitude, longitude: longitude, lastModified: lastModified,
+      nickname: nickname, isBlocked: isBlocked, isMuted: isMuted,
+      isFavorite: isFavorite, lastMessageDate: lastMessageDate,
+      unreadCount: unreadCount, unreadMentionCount: unreadMentionCount,
+      ocvPreset: ocvPreset, customOCVArrayString: customOCVArrayString,
+      avatarImageData: avatarImageData
     )
   }
 

--- a/MC1Services/Sources/MC1Services/Services/ContactService.swift
+++ b/MC1Services/Sources/MC1Services/Services/ContactService.swift
@@ -510,7 +510,8 @@ public actor ContactService {
         unreadCount: isBeingBlocked ? 0 : existing.unreadCount,
         unreadMentionCount: existing.unreadMentionCount,
         ocvPreset: existing.ocvPreset,
-        customOCVArrayString: existing.customOCVArrayString
+        customOCVArrayString: existing.customOCVArrayString,
+        avatarImageData: existing.avatarImageData
       )
     )
 
@@ -554,11 +555,14 @@ public actor ContactService {
         lastModified: existing.lastModified,
         nickname: existing.nickname,
         isBlocked: existing.isBlocked,
+        isMuted: existing.isMuted,
         isFavorite: existing.isFavorite,
         lastMessageDate: existing.lastMessageDate,
         unreadCount: existing.unreadCount,
+        unreadMentionCount: existing.unreadMentionCount,
         ocvPreset: preset,
-        customOCVArrayString: customArray
+        customOCVArrayString: customArray,
+        avatarImageData: existing.avatarImageData
       )
     )
 
@@ -637,11 +641,14 @@ public actor ContactService {
         lastModified: existing.lastModified,
         nickname: existing.nickname,
         isBlocked: existing.isBlocked,
+        isMuted: existing.isMuted,
         isFavorite: isFavorite,
         lastMessageDate: existing.lastMessageDate,
         unreadCount: existing.unreadCount,
+        unreadMentionCount: existing.unreadMentionCount,
         ocvPreset: existing.ocvPreset,
-        customOCVArrayString: existing.customOCVArrayString
+        customOCVArrayString: existing.customOCVArrayString,
+        avatarImageData: existing.avatarImageData
       )
     )
 
@@ -712,11 +719,14 @@ public actor ContactService {
         lastModified: existing.lastModified,
         nickname: existing.nickname,
         isBlocked: existing.isBlocked,
+        isMuted: existing.isMuted,
         isFavorite: existing.isFavorite,
         lastMessageDate: existing.lastMessageDate,
         unreadCount: existing.unreadCount,
+        unreadMentionCount: existing.unreadMentionCount,
         ocvPreset: existing.ocvPreset,
-        customOCVArrayString: existing.customOCVArrayString
+        customOCVArrayString: existing.customOCVArrayString,
+        avatarImageData: existing.avatarImageData
       )
     )
 

--- a/MC1Services/Sources/MC1Services/Services/ContactService.swift
+++ b/MC1Services/Sources/MC1Services/Services/ContactService.swift
@@ -565,6 +565,18 @@ public actor ContactService {
     try await dataStore.saveContact(updated)
   }
 
+  /// Updates a contact's locally stored profile picture.
+  /// - Parameters:
+  ///   - contactID: The contact's ID
+  ///   - imageData: Compressed JPEG data for the new avatar, or `nil` to remove it
+  public func updateContactAvatar(contactID: UUID, imageData: Data?) async throws {
+    guard let existing = try await dataStore.fetchContact(id: contactID) else {
+      throw ContactServiceError.contactNotFound
+    }
+
+    try await dataStore.saveContact(existing.with(avatarImageData: imageData))
+  }
+
   // MARK: - Device Favorite Sync
 
   /// Sets a contact's favorite status on the device and updates local storage.

--- a/MC1Services/Sources/MC1Services/Services/PersistenceStore+BackupHelpers.swift
+++ b/MC1Services/Sources/MC1Services/Services/PersistenceStore+BackupHelpers.swift
@@ -228,6 +228,10 @@ extension PersistenceStore {
       contact.customOCVArrayString = backupOCV
       changed = true
     }
+    if contact.avatarImageData == nil, let backupAvatar = dto.avatarImageData {
+      contact.avatarImageData = backupAvatar
+      changed = true
+    }
     return changed
   }
 

--- a/MC1Services/Sources/MC1Services/Services/PersistenceStore.swift
+++ b/MC1Services/Sources/MC1Services/Services/PersistenceStore.swift
@@ -94,6 +94,8 @@ public actor PersistenceStore: PersistenceStoreProtocol {
   ///          immutable, and backup import dedupes them store-wide, so existing
   ///          stores hold no duplicates) and RxLogEntry [radioID, receivedAt]
   ///          index.
+  /// - v5→v6: Added Contact.avatarImageData (Data?, default nil) storing a
+  ///          user-picked profile picture as a compressed JPEG blob.
   public static func createContainer(inMemory: Bool = false) throws -> ModelContainer {
     if !inMemory {
       let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!

--- a/MC1Services/Tests/MC1ServicesTests/BackupIntegrationTests.swift
+++ b/MC1Services/Tests/MC1ServicesTests/BackupIntegrationTests.swift
@@ -796,7 +796,8 @@ struct BackupIntegrationTests {
       unreadCount: 7,
       unreadMentionCount: 2,
       ocvPreset: OCVPreset.custom.rawValue,
-      customOCVArrayString: "4200,4100,4000"
+      customOCVArrayString: "4200,4100,4000",
+      avatarImageData: Data(repeating: 0xAA, count: 16)
     )
 
     let envelope = AppBackupEnvelope.test(
@@ -825,6 +826,79 @@ struct BackupIntegrationTests {
     #expect(mergedContact.unreadMentionCount == 2)
     #expect(mergedContact.ocvPreset == OCVPreset.custom.rawValue)
     #expect(mergedContact.customOCVArrayString == "4200,4100,4000")
+    #expect(mergedContact.avatarImageData == Data(repeating: 0xAA, count: 16))
+  }
+
+  // MARK: - Test 11b: avatarImageData backup round-trip
+
+  @Test
+  func `Contact avatarImageData survives encode decode export import and merge`() async throws {
+    // Encode/decode round-trip with non-nil data.
+    let withAvatar = ContactDTO.testContact(avatarImageData: Data(repeating: 0x11, count: 8))
+    let encoded = try JSONEncoder().encode(withAvatar)
+    let decoded = try JSONDecoder().decode(ContactDTO.self, from: encoded)
+    #expect(decoded.avatarImageData == Data(repeating: 0x11, count: 8))
+
+    // Legacy payload missing the key entirely decodes to nil, not a decode failure.
+    var legacyJSON = try #require(
+      JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+    )
+    legacyJSON.removeValue(forKey: "avatarImageData")
+    let legacyData = try JSONSerialization.data(withJSONObject: legacyJSON)
+    let legacyDecoded = try JSONDecoder().decode(ContactDTO.self, from: legacyData)
+    #expect(legacyDecoded.avatarImageData == nil)
+
+    // Export -> import round-trip onto a fresh store preserves the avatar on insert.
+    let radioID = UUID()
+    let sourceStore = try await PersistenceStore.createTestDataStore(radioID: radioID)
+    let sourceContact = ContactDTO.testContact(
+      radioID: radioID,
+      publicKey: Data(repeating: 0xE3, count: 32),
+      name: "Bob",
+      avatarImageData: Data(repeating: 0x22, count: 8)
+    )
+    try await sourceStore.saveContact(sourceContact)
+
+    let service = AppBackupService()
+    let exportResult = try await service.export(persistenceStore: sourceStore)
+    let envelope = try parseBackup(data: exportResult.data)
+
+    let destStore = try await PersistenceStore.createTestDataStore(radioID: radioID)
+    let importResult = try await service.importBackup(envelope: envelope, into: destStore)
+    #expect(importResult.contactsInserted == 1)
+
+    let insertedContact = try #require(
+      await destStore.fetchContact(radioID: radioID, publicKey: sourceContact.publicKey)
+    )
+    #expect(insertedContact.avatarImageData == Data(repeating: 0x22, count: 8))
+
+    // Merge onto an existing contact with no local avatar adopts the backup's.
+    let existingNoAvatar = ContactDTO.testContact(
+      radioID: radioID,
+      publicKey: Data(repeating: 0xE4, count: 32),
+      name: "Carol",
+      avatarImageData: nil
+    )
+    try await destStore.saveContact(existingNoAvatar)
+
+    let backupWithAvatar = ContactDTO.testContact(
+      id: UUID(),
+      radioID: radioID,
+      publicKey: existingNoAvatar.publicKey,
+      name: "Carol",
+      avatarImageData: Data(repeating: 0x33, count: 8)
+    )
+    let mergeEnvelope = AppBackupEnvelope.test(
+      devices: [DeviceDTO.testDevice(id: radioID, radioID: radioID)],
+      contacts: [backupWithAvatar]
+    )
+    let mergeResult = try await service.importBackup(envelope: mergeEnvelope, into: destStore)
+    #expect(mergeResult.contactsSkipped == 1)
+
+    let mergedCarol = try #require(
+      await destStore.fetchContact(radioID: radioID, publicKey: existingNoAvatar.publicKey)
+    )
+    #expect(mergedCarol.avatarImageData == Data(repeating: 0x33, count: 8))
   }
 
   // MARK: - Test 12: Merge import — channel metadata restored

--- a/MC1Services/Tests/MC1ServicesTests/Helpers/ContactDTO+Testing.swift
+++ b/MC1Services/Tests/MC1ServicesTests/Helpers/ContactDTO+Testing.swift
@@ -29,7 +29,8 @@ extension ContactDTO {
     isFavorite: Bool = false,
     lastMessageDate: Date? = nil,
     unreadCount: Int = 0,
-    unreadMentionCount: Int = 0
+    unreadMentionCount: Int = 0,
+    avatarImageData: Data? = nil
   ) -> ContactDTO {
     ContactDTO(
       id: id,
@@ -50,7 +51,8 @@ extension ContactDTO {
       isFavorite: isFavorite,
       lastMessageDate: lastMessageDate,
       unreadCount: unreadCount,
-      unreadMentionCount: unreadMentionCount
+      unreadMentionCount: unreadMentionCount,
+      avatarImageData: avatarImageData
     )
   }
 }

--- a/MC1Services/Tests/MC1ServicesTests/Services/ContactServiceTests.swift
+++ b/MC1Services/Tests/MC1ServicesTests/Services/ContactServiceTests.swift
@@ -669,6 +669,100 @@ struct ContactServiceTests {
   }
 
   @Test
+  func `avatarImageData survives updateContactPreferences`() async throws {
+    let mockSession = MockMeshCoreSession()
+    let mockStore = MockPersistenceStore()
+
+    let radioID = UUID()
+    let contactID = UUID()
+
+    let contact = ContactDTO(
+      id: contactID,
+      radioID: radioID,
+      publicKey: testPublicKey,
+      name: "TestContact",
+      typeRawValue: ContactType.chat.rawValue,
+      flags: 0,
+      outPathLength: 0,
+      outPath: Data(),
+      lastAdvertTimestamp: 0,
+      latitude: 0,
+      longitude: 0,
+      lastModified: 0,
+      nickname: nil,
+      isBlocked: false,
+      isMuted: false,
+      isFavorite: false,
+      lastMessageDate: nil,
+      unreadCount: 0
+    )
+    try await mockStore.saveContact(contact)
+
+    let service = ContactService(
+      session: mockSession,
+      dataStore: mockStore,
+      syncCoordinator: nil,
+      cleanupCoordinator: nil
+    )
+
+    let imageData = Data([0xDE, 0xAD, 0xBE, 0xEF])
+    try await service.updateContactAvatar(contactID: contactID, imageData: imageData)
+
+    try await service.updateContactPreferences(contactID: contactID, nickname: "Field Ops")
+
+    let updated = await mockStore.contacts[contactID]
+    #expect(updated?.nickname == "Field Ops")
+    #expect(updated?.avatarImageData == imageData)
+  }
+
+  @Test
+  func `avatarImageData survives setContactFavorite`() async throws {
+    let mockSession = MockMeshCoreSession()
+    let mockStore = MockPersistenceStore()
+
+    let radioID = UUID()
+    let contactID = UUID()
+
+    let contact = ContactDTO(
+      id: contactID,
+      radioID: radioID,
+      publicKey: testPublicKey,
+      name: "TestContact",
+      typeRawValue: ContactType.chat.rawValue,
+      flags: 0,
+      outPathLength: 0,
+      outPath: Data(),
+      lastAdvertTimestamp: 0,
+      latitude: 0,
+      longitude: 0,
+      lastModified: 0,
+      nickname: nil,
+      isBlocked: false,
+      isMuted: false,
+      isFavorite: false,
+      lastMessageDate: nil,
+      unreadCount: 0
+    )
+    try await mockStore.saveContact(contact)
+
+    let service = ContactService(
+      session: mockSession,
+      dataStore: mockStore,
+      syncCoordinator: nil,
+      cleanupCoordinator: nil
+    )
+
+    let imageData = Data([0xDE, 0xAD, 0xBE, 0xEF])
+    try await service.updateContactAvatar(contactID: contactID, imageData: imageData)
+
+    try await service.setContactFavorite(contactID, isFavorite: true)
+
+    let updated = await mockStore.contacts[contactID]
+    #expect(updated?.isFavorite == true)
+    #expect(updated?.avatarImageData == imageData)
+  }
+
+  @Test
   func `updateContactPreferences does not trigger cleanup when not blocking`() async throws {
     let mockSession = MockMeshCoreSession()
     let mockStore = MockPersistenceStore()

--- a/MC1Services/Tests/MC1ServicesTests/Services/ContactServiceTests.swift
+++ b/MC1Services/Tests/MC1ServicesTests/Services/ContactServiceTests.swift
@@ -620,6 +620,55 @@ struct ContactServiceTests {
   }
 
   @Test
+  func `updateContactAvatar sets and clears avatarImageData`() async throws {
+    let mockSession = MockMeshCoreSession()
+    let mockStore = MockPersistenceStore()
+
+    let radioID = UUID()
+    let contactID = UUID()
+
+    let contact = ContactDTO(
+      id: contactID,
+      radioID: radioID,
+      publicKey: testPublicKey,
+      name: "TestContact",
+      typeRawValue: ContactType.chat.rawValue,
+      flags: 0,
+      outPathLength: 0,
+      outPath: Data(),
+      lastAdvertTimestamp: 0,
+      latitude: 0,
+      longitude: 0,
+      lastModified: 0,
+      nickname: nil,
+      isBlocked: false,
+      isMuted: false,
+      isFavorite: false,
+      lastMessageDate: nil,
+      unreadCount: 0
+    )
+    try await mockStore.saveContact(contact)
+
+    let service = ContactService(
+      session: mockSession,
+      dataStore: mockStore,
+      syncCoordinator: nil,
+      cleanupCoordinator: nil
+    )
+
+    let imageData = Data([0xDE, 0xAD, 0xBE, 0xEF])
+    try await service.updateContactAvatar(contactID: contactID, imageData: imageData)
+
+    let withAvatar = await mockStore.contacts[contactID]
+    #expect(withAvatar?.avatarImageData == imageData)
+
+    try await service.updateContactAvatar(contactID: contactID, imageData: nil)
+
+    let withoutAvatar = await mockStore.contacts[contactID]
+    #expect(withoutAvatar?.avatarImageData == nil)
+  }
+
+  @Test
   func `updateContactPreferences does not trigger cleanup when not blocking`() async throws {
     let mockSession = MockMeshCoreSession()
     let mockStore = MockPersistenceStore()


### PR DESCRIPTION
## Description

Adds custom contact profile pictures, discussed in #372. Split out of the original combined PR into its own PR so it can be reviewed independently from the Nodes context-menu change (now in #374).

Contacts currently only get an auto-generated initials avatar (`ContactAvatar`). This adds the ability to set a real profile picture from Photos or Files.

## Overview of Changes

- `MC1Services/Sources/MC1Services/Models/Contact.swift`: added `avatarImageData: Data?` to the `Contact` SwiftData model and `ContactDTO`, threaded through all inits, `apply(_:)`, and the `with(...)` copy helpers (also fixed `with(isMuted:)`/`with(isFavorite:)`, which previously dropped any field not explicitly listed — would have silently wiped the avatar on those calls).
- `MC1Services/Sources/MC1Services/Services/PersistenceStore.swift`: documented the new field as a v5→v6 lightweight schema migration (no `VersionedSchema`, matching the project's existing convention).
- `MC1Services/Sources/MC1Services/Services/ContactService.swift`: added `updateContactAvatar(contactID:imageData:)`.
- `MC1/Views/Components/ContactAvatar.swift`: renders the stored image when present, falls back to the existing initials circle otherwise.
- `MC1/Views/Contacts/ContactDetailView.swift`: tapping the avatar (chat-type contacts only) opens a confirmation dialog — **Choose Photo** (`PhotosPicker`), **Choose File...** (`.fileImporter`), **Remove Photo**. Picked images are downscaled to a 512pt max dimension and re-encoded as JPEG before saving. Purely local metadata — not synced to the radio/mesh.
- New localized strings in `Contacts.strings` / regenerated `L10n.swift` (via SwiftGen).
- New test: `MC1Services/Tests/MC1ServicesTests/Services/ContactServiceTests.swift` — `updateContactAvatar sets and clears avatarImageData`.

The Nodes long-press "Send Message" item that was originally bundled here has been moved to #374.

## Testing

- `xcodebuild build -project MC1.xcodeproj -scheme MC1 -destination 'platform=iOS Simulator,name=iPhone 17e,OS=26.5'` — **BUILD SUCCEEDED**, isolated on this branch.
- `swiftlint lint` — clean, no warnings/errors.
- Manually installed and launched the built app in the iOS 26.5 simulator to confirm it runs (onboarding/pairing screen renders correctly).
- Full `make test-app` / `MC1Tests` run hit a pre-existing macro-expansion compile error in `MessageLinkTokenizerTests.swift` unrelated to this change — reproduced identically on a clean `main` checkout with these changes stashed, so it's an environment/toolchain issue, not something this PR introduces. `MC1ServicesTests` (where the new avatar test lives) isn't wired into any Xcode scheme in this environment and I wasn't able to execute it directly; the new test follows the exact pattern of the adjacent passing tests in that file and the file parses/compiles cleanly.
- Have not yet manually exercised the photo/file picker against a live connected radio — no physical MeshCore hardware available in this environment. Would appreciate a manual pass on-device before merge.

## Tested on
- [x] iOS 26.5 (Simulator, build + launch only, no paired radio)
- [ ] iPadOS
- [ ] macOS

## Checklist

- [ ] This PR was discussed with the maintainer either via GitHub issue or other means (Also check the box if this PR is small enough not to need discussion e.g. typo fix) — issue #372 was filed but the maintainer has not yet responded
- [x] I have read `CONTRIBUTING.md`
- [x] Testing steps are documented above.
- [x] This change is not low effort and I took the time to test it
