### PR TITLE
fix(l10n): add missing contact avatar strings to Italian locale

### DIFF
--- a/MC1/Resources/Localization/it.lproj/Contacts.strings
+++ b/MC1/Resources/Localization/it.lproj/Contacts.strings
@@ -269,6 +269,24 @@
 /* Location: ContactDetailView.swift - Purpose: Info section header */
 "contacts.detail.info" = "Info";
 
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu title */
+"contacts.detail.avatar.chooseSource" = "Change Profile Picture";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick a photo from the photo library */
+"contacts.detail.avatar.choosePhoto" = "Choose Photo";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to pick an image file */
+"contacts.detail.avatar.chooseFile" = "Choose File...";
+
+/* Location: ContactDetailView.swift - Purpose: Avatar edit menu option to remove the current photo */
+"contacts.detail.avatar.removePhoto" = "Remove Photo";
+
+/* Location: ContactDetailView.swift - Purpose: VoiceOver suffix announced while a new profile picture is being saved */
+"contacts.detail.avatar.savingAnnouncement" = "Saving photo";
+
+/* Location: ContactDetailView.swift - Purpose: Error shown when the picked file is not a valid image */
+"contacts.detail.avatar.invalidImage" = "That file could not be used as a profile picture.";
+
 /* Location: ContactDetailView.swift - Purpose: Nickname label */
 "contacts.detail.nickname" = "Soprannome";
 


### PR DESCRIPTION
## Description

Adds the five `contacts.detail.avatar.*` localization keys (from #373) to the Italian (`it.lproj`) locale.

## Overview of Changes

`it.lproj/Contacts.strings` was added in a separate commit around the same time #373 was in review. When #373 backfilled the avatar strings to every non-English locale per review feedback, `it` didn't exist yet in the branch it was based on, so it was missed. This adds the same English-placeholder keys already present in `de`, `es`, `fr`, `nl`, `pl`, `ru`, `uk`, and `zh-Hans`.

- `MC1/Resources/Localization/it.lproj/Contacts.strings`: added `contacts.detail.avatar.chooseSource`, `.choosePhoto`, `.chooseFile`, `.removePhoto`, `.savingAnnouncement`, `.invalidImage`, matching the placement and English-placeholder pattern used in the other locale files.

## Testing

- `xcodebuild build -project MC1.xcodeproj -scheme MC1 -destination 'platform=iOS Simulator,name=iPhone 17e,OS=26.5'` — **BUILD SUCCEEDED**
- `swiftlint lint` — 0 violations
- `swiftformat --lint --strict .` — clean

## Tested on
- [x] iOS 26.5 (Simulator, build only — this is a strings-only change)
- [ ] iPadOS
- [ ] macOS

## Checklist

- [x] This PR is small enough not to need prior discussion (missing-locale-keys fix, same pattern already approved in #373)
- [x] I have read `CONTRIBUTING.md`
- [x] Testing steps are documented above.
- [x] This change is not low effort and I took the time to test it
